### PR TITLE
fix: add server-side Supabase access for core users and members

### DIFF
--- a/database/migrations/202605200001_core_integrity_constraints.sql
+++ b/database/migrations/202605200001_core_integrity_constraints.sql
@@ -1,0 +1,42 @@
+-- Gym Master - Core integrity constraints
+-- Objetivo: reforzar integridad mínima usuario/socio y consultas core.
+-- Recomendación: ejecutar primero database/scripts/preflight_core_integrity.sql.
+
+BEGIN;
+
+-- Un usuario con rol socio debe mapear, como máximo, a un único perfil socio.
+-- Si existen duplicados, este índice fallará: resolverlos antes con el preflight.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_socio_usuario_id_unique
+ON public.socio (usuario_id)
+WHERE usuario_id IS NOT NULL;
+
+-- Índices de soporte para rutas y RPC frecuentes.
+CREATE INDEX IF NOT EXISTS idx_socio_activo_creado_en
+ON public.socio (activo, creado_en DESC);
+
+CREATE INDEX IF NOT EXISTS idx_rutina_id_socio_creado_en
+ON public.rutina (id_socio, creado_en DESC);
+
+CREATE INDEX IF NOT EXISTS idx_asistencia_socio_fecha
+ON public.asistencia (socio_id, fecha DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pago_socio_fecha_pago
+ON public.pago (socio_id, fecha_pago DESC);
+
+-- Reglas de consistencia para preferencias de entrenamiento del socio.
+ALTER TABLE public.socio
+DROP CONSTRAINT IF EXISTS socio_dias_por_semana_check;
+
+ALTER TABLE public.socio
+ADD CONSTRAINT socio_dias_por_semana_check
+CHECK (dias_por_semana IS NULL OR dias_por_semana BETWEEN 1 AND 6)
+NOT VALID;
+
+-- Comentarios operativos para continuidad técnica.
+COMMENT ON INDEX public.idx_socio_usuario_id_unique IS
+'Garantiza relación 1 a 1 entre usuario con rol socio y perfil socio. Requerido para login socio y rutinas.';
+
+COMMENT ON CONSTRAINT socio_dias_por_semana_check ON public.socio IS
+'Valida que la cantidad de días de entrenamiento del socio esté entre 1 y 6 cuando se informe.';
+
+COMMIT;

--- a/database/scripts/preflight_core_integrity.sql
+++ b/database/scripts/preflight_core_integrity.sql
@@ -1,0 +1,74 @@
+-- Gym Master - Preflight de integridad core
+-- Ejecutar antes de aplicar migraciones de integridad/RLS.
+-- Este script NO modifica datos.
+
+-- 1) Usuarios socio sin perfil asociado en tabla socio.
+SELECT
+  u.id AS usuario_id,
+  u.email,
+  u.nombre,
+  u.rol
+FROM public.usuario u
+LEFT JOIN public.socio s ON s.usuario_id = u.id
+WHERE u.rol = 'socio'
+  AND s.id_socio IS NULL
+ORDER BY u.creado_en DESC;
+
+-- 2) Perfiles socio duplicados por usuario_id.
+SELECT
+  usuario_id,
+  COUNT(*) AS cantidad_perfiles
+FROM public.socio
+WHERE usuario_id IS NOT NULL
+GROUP BY usuario_id
+HAVING COUNT(*) > 1
+ORDER BY cantidad_perfiles DESC;
+
+-- 3) Socios sin usuario asociado.
+SELECT
+  s.id_socio,
+  s.nombre_completo,
+  s.email,
+  s.dni,
+  s.activo
+FROM public.socio s
+WHERE s.usuario_id IS NULL
+ORDER BY s.creado_en DESC;
+
+-- 4) Socios con usuario_id inválido.
+SELECT
+  s.id_socio,
+  s.usuario_id,
+  s.nombre_completo,
+  s.email
+FROM public.socio s
+LEFT JOIN public.usuario u ON u.id = s.usuario_id
+WHERE s.usuario_id IS NOT NULL
+  AND u.id IS NULL;
+
+-- 5) Policies dev abiertas que deben retirarse cuando el frontend deje de consultar Supabase directo.
+SELECT
+  schemaname,
+  tablename,
+  policyname,
+  cmd,
+  roles,
+  qual,
+  with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND (
+    policyname ILIKE 'dev_%'
+    OR qual = 'true'
+    OR with_check = 'true'
+  )
+ORDER BY tablename, policyname;
+
+-- 6) Tablas públicas con RLS activo.
+SELECT
+  schemaname,
+  tablename,
+  rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public'
+ORDER BY tablename;

--- a/database/scripts/rls_hardening_plan.sql
+++ b/database/scripts/rls_hardening_plan.sql
@@ -1,0 +1,39 @@
+-- Gym Master - Plan controlado de hardening RLS
+-- NO ejecutar completo sin validar que todos los módulos críticos consumen API Routes.
+-- Contexto: Gym Master usa JWT propio, no Supabase Auth para autorización de negocio.
+-- Por eso, la estrategia recomendada es:
+-- 1) Frontend -> API Routes con Authorization Bearer propio.
+-- 2) API Routes -> Supabase server client con SUPABASE_SERVICE_ROLE_KEY.
+-- 3) Retirar progresivamente policies dev_all_* abiertas cuando ya no haya acceso directo desde cliente.
+
+-- Inventario de policies abiertas:
+SELECT
+  schemaname,
+  tablename,
+  policyname,
+  cmd,
+  roles,
+  qual,
+  with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND (
+    policyname ILIKE 'dev_%'
+    OR qual = 'true'
+    OR with_check = 'true'
+  )
+ORDER BY tablename, policyname;
+
+-- Ejemplo de retiro controlado para una tabla, aplicar solo después de validar módulo:
+-- DROP POLICY IF EXISTS dev_all_usuario ON public.usuario;
+-- DROP POLICY IF EXISTS "Permitir lectura de usuarios" ON public.usuario;
+
+-- Ejemplo de bloqueo explícito para anon/authenticated si el acceso queda solo por service_role:
+-- CREATE POLICY usuario_no_direct_client_access
+-- ON public.usuario
+-- FOR ALL
+-- TO anon, authenticated
+-- USING (false)
+-- WITH CHECK (false);
+
+-- El service_role seguirá operando desde API Routes del backend.

--- a/docs/database/rls-and-core-integrity.md
+++ b/docs/database/rls-and-core-integrity.md
@@ -1,0 +1,184 @@
+# Gym Master — RLS e integridad core
+
+## 1. Contexto
+
+Gym Master ya quedó migrado a una arquitectura **single-tenant por instancia**: una aplicación/deploy y una base Supabase por gimnasio. Con esto se eliminó `dbName` como mecanismo de selección dinámica de base.
+
+Después del checkpoint, quedaron funcionando:
+
+- Login administrador.
+- Creación/login de administrador.
+- Creación/login de socio.
+- Relación `usuario` → `socio` para usuarios con rol socio.
+- Generación de rutinas mediante el procedimiento almacenado `generar_rutina_socio`.
+
+Esta rama inicia la etapa de desarrollo/corrección real sobre seguridad e integridad base.
+
+## 2. Problema detectado
+
+El proyecto venía utilizando Supabase desde servicios compartidos que podían ser importados tanto por API Routes como por componentes `use client`.
+
+Esto genera dos problemas:
+
+1. Para que el frontend pudiera leer datos directamente desde Supabase, se mantuvieron policies RLS abiertas de desarrollo (`dev_all_*`, `USING (true)`, `WITH CHECK (true)`).
+2. La autorización real del sistema está en el JWT propio de Gym Master, no en Supabase Auth. Por lo tanto, Supabase no puede inferir correctamente el rol de negocio (`admin`, `usuario`, `socio`) desde las policies si el cliente consulta directo con la anon key.
+
+## 3. Decisión técnica
+
+La estrategia segura será:
+
+```txt
+Frontend / use client
+  ↓ Authorization Bearer JWT propio
+API Routes Next.js
+  ↓ validación authMiddleware + rol
+Servicios server-only
+  ↓ Supabase service role
+PostgreSQL/Supabase
+```
+
+Con este enfoque:
+
+- La service role key no viaja al navegador.
+- La autorización de negocio queda en API Routes.
+- RLS puede endurecerse progresivamente.
+- Se evita depender de policies abiertas para operar el sistema.
+
+## 4. Cambios aplicados en esta rama
+
+### 4.1 Cliente Supabase server-only
+
+Se agrega:
+
+```txt
+src/services/supabaseServerClient.ts
+```
+
+Este cliente usa:
+
+```txt
+SUPABASE_SERVICE_ROLE_KEY
+```
+
+y está protegido con `server-only`, por lo que no debe importarse desde componentes cliente.
+
+### 4.2 Servicios server-only para core
+
+Se agregan servicios específicos para backend:
+
+```txt
+src/services/server/usuarioServerService.ts
+src/services/server/socioServerService.ts
+```
+
+Estos servicios concentran operaciones sensibles de:
+
+- usuarios,
+- socios,
+- creación de usuario socio + perfil asociado,
+- activación/desactivación,
+- validación básica de roles.
+
+### 4.3 API Routes migradas a servicios server-only
+
+Se actualizan:
+
+```txt
+src/app/api/usuarios/route.ts
+src/app/api/socios/route.ts
+```
+
+Ahora validan JWT con `authMiddleware` y delegan operaciones a servicios server-only.
+
+### 4.4 Frontend migrado a API Routes en módulos core
+
+Se agregan clientes browser:
+
+```txt
+src/services/browser/usuarioApiClient.ts
+src/services/browser/socioApiClient.ts
+```
+
+Y se actualizan:
+
+```txt
+src/app/dashboard/usuarios/page.tsx
+src/app/dashboard/socios/page.tsx
+src/components/forms/UserForm.tsx
+src/components/forms/SocioForm.tsx
+```
+
+El frontend deja de importar directamente servicios con lógica Supabase para estos dos módulos core.
+
+## 5. Integridad de base de datos
+
+Se agrega un preflight:
+
+```txt
+database/scripts/preflight_core_integrity.sql
+```
+
+Sirve para detectar:
+
+- usuarios con rol socio sin perfil socio,
+- perfiles socio duplicados por `usuario_id`,
+- socios sin usuario asociado,
+- socios con `usuario_id` inválido,
+- policies abiertas de desarrollo,
+- estado RLS de tablas públicas.
+
+Se agrega migración:
+
+```txt
+database/migrations/202605200001_core_integrity_constraints.sql
+```
+
+Incluye:
+
+- índice único parcial `idx_socio_usuario_id_unique`,
+- índices de soporte para consultas frecuentes,
+- constraint `socio_dias_por_semana_check` como `NOT VALID`.
+
+## 6. RLS: criterio de avance
+
+No se eliminan todavía todas las policies abiertas, porque aún pueden existir pantallas o módulos que consulten Supabase de manera directa.
+
+Se agrega:
+
+```txt
+database/scripts/rls_hardening_plan.sql
+```
+
+Este script documenta el camino de retiro gradual:
+
+1. migrar módulo a API Routes,
+2. validar funcionalmente,
+3. retirar policy `dev_all_*` de esa tabla,
+4. bloquear acceso directo desde anon/authenticated si corresponde.
+
+## 7. Validaciones sugeridas
+
+```bash
+npm run build
+```
+
+Flujos funcionales a probar:
+
+- Login admin.
+- Listar usuarios.
+- Crear usuario admin.
+- Crear usuario socio con DNI.
+- Login socio.
+- Listar socios.
+- Crear socio manual.
+- Activar/desactivar usuario.
+- Activar/desactivar socio.
+- Generar rutina con socio logueado.
+
+## 8. Pendientes
+
+- Migrar el resto de módulos que todavía importan servicios Supabase desde componentes cliente.
+- Endurecer policies RLS por tabla una vez migrados sus accesos.
+- Revisar relación circular `venta` ↔ `venta_detalle`.
+- Consolidar `entrenador_horarios` vs `horario_entrenador`.
+- Validar datos existentes antes de aplicar índices únicos en producción.

--- a/docs/informes/informe-ejecutivo-rls-integrity.md
+++ b/docs/informes/informe-ejecutivo-rls-integrity.md
@@ -1,0 +1,52 @@
+# Informe ejecutivo — RLS e integridad core Gym Master
+
+## Resumen
+
+Se inició la primera etapa de desarrollo/corrección real posterior a la migración single-tenant de Gym Master. El objetivo fue preparar una base más segura para usuarios y socios, evitando que el frontend dependa directamente de consultas Supabase en módulos core.
+
+## Decisión técnica
+
+Se adoptó una estrategia de acceso controlado:
+
+```txt
+Frontend → API Routes → servicios server-only → Supabase service role
+```
+
+Esto permite mantener el JWT propio de Gym Master como fuente de autorización de negocio y prepara el camino para cerrar policies RLS abiertas.
+
+## Avances
+
+- Nuevo cliente Supabase server-only.
+- Servicios backend para usuarios y socios.
+- API Routes de usuarios y socios actualizadas.
+- Frontend de usuarios/socios migrado a clientes API browser.
+- Script de preflight de integridad usuario/socio.
+- Migración de integridad mínima con índices y constraint.
+- Plan de hardening progresivo de RLS.
+
+## Beneficio
+
+El sistema empieza a separar correctamente:
+
+- código cliente,
+- lógica backend,
+- acceso privilegiado a base de datos,
+- autorización por rol.
+
+Esto reduce riesgo de exponer datos sensibles y permite avanzar hacia una arquitectura más mantenible.
+
+## Riesgos controlados
+
+No se eliminaron todavía todas las policies abiertas porque hay módulos pendientes de revisar. El retiro se hará por módulo, después de validar que cada pantalla consuma API Routes y no Supabase directo.
+
+## Próximo paso recomendado
+
+Continuar migrando módulos críticos a API Routes server-only, priorizando:
+
+1. pagos/cuotas,
+2. rutinas,
+3. asistencia/QR,
+4. dietas/evolución,
+5. ficha médica.
+
+Luego se podrá endurecer RLS tabla por tabla.

--- a/docs/pr/pr-database-rls-and-core-integrity.md
+++ b/docs/pr/pr-database-rls-and-core-integrity.md
@@ -1,0 +1,51 @@
+## Descripción
+
+Este PR inicia la etapa de desarrollo/corrección real posterior a la auditoría documental de Gym Master. El foco está en reforzar la integridad core y preparar el sistema para endurecer RLS sin romper los módulos principales.
+
+El cambio mantiene la arquitectura single-tenant ya definida: una instancia/deploy y una base Supabase por gimnasio.
+
+## Cambios principales
+
+- Se agrega un cliente Supabase server-only basado en `SUPABASE_SERVICE_ROLE_KEY`.
+- Se agregan servicios backend específicos para usuarios y socios.
+- Se actualizan las API Routes de usuarios y socios para operar mediante servicios server-only.
+- Se agregan clientes browser para que el frontend consuma `/api/usuarios` y `/api/socios` en lugar de importar servicios Supabase directos.
+- Se actualizan pantallas y formularios de usuarios/socios para usar API Routes.
+- Se agrega script de preflight para detectar inconsistencias usuario/socio y policies abiertas.
+- Se agrega migración de integridad core con índices y constraint de días por semana.
+- Se agrega plan controlado para hardening progresivo de RLS.
+
+## Archivos relevantes
+
+- `src/services/supabaseServerClient.ts`
+- `src/services/server/usuarioServerService.ts`
+- `src/services/server/socioServerService.ts`
+- `src/services/browser/usuarioApiClient.ts`
+- `src/services/browser/socioApiClient.ts`
+- `src/app/api/usuarios/route.ts`
+- `src/app/api/socios/route.ts`
+- `src/app/dashboard/usuarios/page.tsx`
+- `src/app/dashboard/socios/page.tsx`
+- `src/components/forms/UserForm.tsx`
+- `src/components/forms/SocioForm.tsx`
+- `database/scripts/preflight_core_integrity.sql`
+- `database/migrations/202605200001_core_integrity_constraints.sql`
+- `database/scripts/rls_hardening_plan.sql`
+- `docs/database/rls-and-core-integrity.md`
+
+## Validaciones sugeridas
+
+- `npm run build`
+- Login admin.
+- Listado de usuarios.
+- Crear usuario socio con DNI.
+- Login socio.
+- Listado de socios.
+- Crear socio manual.
+- Activar/desactivar usuario.
+- Activar/desactivar socio.
+- Generación de rutina para socio.
+
+## Nota sobre RLS
+
+Este PR no elimina masivamente las policies abiertas de desarrollo. Primero se empieza a mover el acceso de módulos core hacia API Routes y service role server-side. El endurecimiento RLS debe hacerse progresivamente por módulo para evitar romper pantallas que todavía consulten Supabase desde cliente.

--- a/src/app/api/socios/route.ts
+++ b/src/app/api/socios/route.ts
@@ -1,101 +1,97 @@
-import { supabase } from '@/services/supabaseClient' // asegurate de tener esta importación
-import { NextResponse } from 'next/server'
+import { NextResponse } from 'next/server';
 import {
-  fetchSocios,
-  createSocio,
-  updateSocio,
-  deleteSocio
-} from '@/services/socioService'
+  createSocioServer,
+  deactivateSocioServer,
+  fetchSociosServer,
+  updateSocioServer,
+} from '@/services/server/socioServerService';
 import { authMiddleware } from '@/middlewares/auth.middleware';
 
 export async function GET(req: Request) {
   try {
-    const {user} = await authMiddleware(req);
-        if(!user){
-          return NextResponse.json({error: "No autorizado"}, {status: 401});
-        }
-    const socios = await fetchSocios(user)
-    return NextResponse.json(socios, { status: 200 })
+    const { user } = await authMiddleware(req);
+    const socios = await fetchSociosServer(user);
+    return NextResponse.json(socios, { status: 200 });
   } catch (error: any) {
-    console.error('ERROR al obtener socios:', error.message || error)
-    return NextResponse.json({ error: 'Error al obtener socios' }, { status: 500 })
+    console.error('ERROR al obtener socios:', error.message || error);
+    return NextResponse.json(
+      { error: error.message || 'Error al obtener socios' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
-
 export async function POST(req: Request) {
-
-  console.log(req);
   try {
-    const {user} = await authMiddleware(req);
-    if(!user){
-      return NextResponse.json({error: "No autorizado"}, {status: 401});
-    }
-    const body = await req.json()
-    
-    // ✅ Validar si usuario_id existe (si se envía)
-    if (body.usuario_id) {
-      const { data, error } = await supabase
-        .from('usuario')
-        .select('id')
-        .eq('id', body.usuario_id)
+    const { user } = await authMiddleware(req);
+    const body = await req.json();
+    const creado = await createSocioServer(user, body);
 
-      if (error || !data || data.length === 0) {
-        return NextResponse.json({ error: 'usuario_id no existe en la base de datos' }, { status: 400 })
-      }
-    }
-
-    const creado = await createSocio(user,body)
-
-    return NextResponse.json({
-      message: 'Socio creado con éxito',
-      data: creado
-    }, { status: 201 })
+    return NextResponse.json(
+      {
+        message: 'Socio creado con éxito',
+        data: creado,
+      },
+      { status: 201 }
+    );
   } catch (error: any) {
-    console.error('❌ ERROR al crear socio:', error.message || error)
-    return NextResponse.json({ error: 'Error al crear socio' }, { status: 500 })
+    console.error('ERROR al crear socio:', error.message || error);
+    return NextResponse.json(
+      { error: error.message || 'Error al crear socio' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function PUT(req: Request) {
   try {
-    const {user} = await authMiddleware(req);
-    if(!user){
-      return NextResponse.json({error: "No autorizado"}, {status: 401});
-    }
-    const { id, ...updateData } = await req.json()
+    const { user } = await authMiddleware(req);
+    const { id, ...updateData } = await req.json();
 
     if (!id || typeof id !== 'string') {
-      return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 })
+      return NextResponse.json(
+        { error: 'ID inválido para actualizar' },
+        { status: 400 }
+      );
     }
 
-    const actualizado = await updateSocio(user,id, updateData)
-    return NextResponse.json({
-      message: 'Socio actualizado con éxito',
-      data: actualizado
-    }, { status: 200 })
+    const actualizado = await updateSocioServer(user, id, updateData);
+    return NextResponse.json(
+      {
+        message: 'Socio actualizado con éxito',
+        data: actualizado,
+      },
+      { status: 200 }
+    );
   } catch (error: any) {
-    const msg = error.message || 'Error al actualizar socio'
-    return NextResponse.json({ error: msg }, { status: 500 })
+    return NextResponse.json(
+      { error: error.message || 'Error al actualizar socio' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function DELETE(req: Request) {
   try {
-    const {user} = await authMiddleware(req);
-    if(!user){
-      return NextResponse.json({error: "No autorizado"}, {status: 401});
-    }
-    const { id } = await req.json()
+    const { user } = await authMiddleware(req);
+    const { id } = await req.json();
 
     if (!id || typeof id !== 'string') {
-      return NextResponse.json({ error: 'ID requerido para eliminar' }, { status: 400 })
+      return NextResponse.json(
+        { error: 'ID requerido para eliminar' },
+        { status: 400 }
+      );
     }
 
-    await deleteSocio(user,id)
-    return NextResponse.json({ message: 'Socio desactivado con éxito' }, { status: 200 })
+    const desactivado = await deactivateSocioServer(user, id);
+    return NextResponse.json(
+      { message: 'Socio desactivado con éxito', data: desactivado },
+      { status: 200 }
+    );
   } catch (error: any) {
-    const msg = error.message || 'Error al desactivar socio'
-    return NextResponse.json({ error: msg }, { status: 500 })
+    return NextResponse.json(
+      { error: error.message || 'Error al desactivar socio' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }

--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -1,105 +1,103 @@
 import { NextResponse } from 'next/server';
 import {
-  fetchUsuarios,
-  createUsuarios,
-  updateUsuarios,
-  deleteUsuarios
-} from '@/services/usuarioService';
+  createUsuarioServer,
+  deactivateUsuarioServer,
+  fetchUsuariosServer,
+  updateUsuarioServer,
+} from '@/services/server/usuarioServerService';
 import { authMiddleware } from '@/middlewares/auth.middleware';
 
-export async function GET(req : Request) {
-
+export async function GET(req: Request) {
   try {
-    //MIDDLEWARE PARA VERIFICAR QUE VENGA EL TOKEN Y ESTE FIRMADO CON LA CLAVESECRETA
-  const {user} = await authMiddleware(req);
-  console.log(user);
-  
-  //PASO EL PAYLOAD DEL USUARIO LOGUEADO AL SERVICIO  
-    const usuarios = await fetchUsuarios(user);
-    return NextResponse.json({data:usuarios}, { status: 200 });
-  } catch {
-    return NextResponse.json({ error: 'Error al obtener usuarios' }, { status: 500 });
+    const { user } = await authMiddleware(req);
+    const usuarios = await fetchUsuariosServer(user);
+    return NextResponse.json({ data: usuarios }, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || 'Error al obtener usuarios' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
-
-//TODO: Implementar dto para que al enviar el response, no se envie el password_hash
 export async function POST(req: Request) {
   try {
+    const { user } = await authMiddleware(req);
+    const { nombre, email, password, rol, dni, foto } = await req.json();
 
-    const {user} = await authMiddleware(req);
-    if(!user){
-      return NextResponse.json({error: "No autorizado"}, {status: 401});
-    }
-
-    const { nombre, email, password, rol, dni } = await req.json();
-
-    if (!nombre || !email || !password) {
-      return NextResponse.json({ error: 'Todos los campos son obligatorios' }, { status: 400 });
-    }
-
-    const rolFinal = rol?.trim() || 'socio';
-
-    if (rolFinal === 'socio' && !dni?.trim()) {
-      return NextResponse.json({ error: 'El DNI es obligatorio para crear un usuario socio' }, { status: 400 });
-    }
-
-    const creado = await createUsuarios(user, {
-      nombre: nombre.trim(),
-      email: email.trim(),
-      password: password.trim(),
-      rol: rolFinal,
-      dni: dni?.trim(),
+    const creado = await createUsuarioServer(user, {
+      nombre,
+      email,
+      password,
+      rol,
+      dni,
+      foto,
     });
 
-    return NextResponse.json({
-      message: 'Usuario creado con éxito',
-      data: creado
-    }, { status: 201 });
+    return NextResponse.json(
+      {
+        message: 'Usuario creado con éxito',
+        data: creado,
+      },
+      { status: 201 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || 'Error al crear usuario' }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al crear usuario' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function PUT(req: Request) {
   try {
-
-    const {user} = await authMiddleware(req);
-    if(!user){
-      return NextResponse.json({error: "No autorizado"}, {status: 401});
-    }
-
+    const { user } = await authMiddleware(req);
     const { id, updateData } = await req.json();
 
     if (!id || typeof id !== 'string') {
-      return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'ID inválido para actualizar' },
+        { status: 400 }
+      );
     }
-    
-    const actualizado = await updateUsuarios(user,id, updateData);
-    return NextResponse.json({
-      message: 'Usuario actualizado con éxito',
-      data: actualizado
-    }, { status: 200 });
+
+    const actualizado = await updateUsuarioServer(user, id, updateData);
+    return NextResponse.json(
+      {
+        message: 'Usuario actualizado con éxito',
+        data: actualizado,
+      },
+      { status: 200 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || 'Error al actualizar usuario' }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al actualizar usuario' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function DELETE(req: Request) {
   try {
-    const {user} = await authMiddleware(req);
-    if(!user){
-      return NextResponse.json({error: "No autorizado"}, {status: 401});
-    }
+    const { user } = await authMiddleware(req);
     const { id } = await req.json();
 
     if (!id || typeof id !== 'string') {
-      return NextResponse.json({ error: 'ID requerido para eliminar' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'ID requerido para eliminar' },
+        { status: 400 }
+      );
     }
 
-    await deleteUsuarios(user,id);
-    return NextResponse.json({ message: 'Usuario desactivado con éxito' }, { status: 200 });
+    const desactivado = await deactivateUsuarioServer(user, id);
+    return NextResponse.json(
+      { message: 'Usuario desactivado con éxito', data: desactivado },
+      { status: 200 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || 'Error al desactivar usuario' }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al desactivar usuario' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }

--- a/src/app/dashboard/socios/page.tsx
+++ b/src/app/dashboard/socios/page.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Search, Printer, FileSpreadsheet } from 'lucide-react';
-import { fetchSocios, toggleSocioActivo } from '@/services/socioService';
+import { fetchSociosApi, setSocioActivoApi } from '@/services/browser/socioApiClient';
 import SocioModal from '@/components/modal/SocioModal';
 import SocioViewModal from '@/components/modal/SocioViewModal';
 import SociosTable from '@/components/tables/SociosTable';
@@ -18,7 +18,6 @@ import { AppSidebar } from '@/components/sidebar/AppSidebar';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { toast } from 'sonner';
 import ExcelJS from 'exceljs';
-import { JwtUser } from '@/interfaces/jwtUser.interface';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -27,7 +26,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export default function SociosPage() {
-  const { user, isAuthenticated, initializeAuth, isInitialized } =
+  const { isAuthenticated, initializeAuth, isInitialized } =
     useAuthStore();
   const router = useRouter();
   const [socios, setSocios] = useState<Socio[]>([]);
@@ -52,7 +51,7 @@ export default function SociosPage() {
 
   const loadSocios = async () => {
     setLoading(true);
-    const data = await fetchSocios(user as JwtUser);
+    const data = await fetchSociosApi();
     setSocios(data ?? []);
     setFilteredSocios(data ?? []);
     setLoading(false);
@@ -246,7 +245,7 @@ export default function SociosPage() {
                       if (!confirmar) return;
 
                       try {
-                        await toggleSocioActivo(user as JwtUser, socio);
+                        await setSocioActivoApi(socio.id_socio, !socio.activo);
                         toast.success(
                           `Socio ${
                             socio.activo ? 'desactivado' : 'activado'

--- a/src/app/dashboard/usuarios/page.tsx
+++ b/src/app/dashboard/usuarios/page.tsx
@@ -10,15 +10,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, Printer, FileSpreadsheet } from "lucide-react";
 import {
-  fetchUsuarios,
-  deleteUsuarios,
-  updateUsuarios,
-} from "@/services/usuarioService";
+  deactivateUsuarioApi,
+  fetchUsuariosApi,
+  updateUsuarioApi,
+} from "@/services/browser/usuarioApiClient";
 import UserModal from "@/components/modal/UserModal";
 import UserViewModal from "@/components/modal/UserViewModal";
 import UsersTable from "@/components/tables/UserTable";
 import { Usuario } from "@/interfaces/usuario.interface";
-import { JwtUser } from "@/interfaces/jwtUser.interface";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
@@ -31,7 +30,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 export default function UsuariosPage() {
-  const { user, isAuthenticated, initializeAuth, isInitialized } =
+  const { isAuthenticated, initializeAuth, isInitialized } =
     useAuthStore();
   const router = useRouter();
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
@@ -56,11 +55,11 @@ export default function UsuariosPage() {
 
   const loadUsuarios = useCallback(async () => {
     setLoading(true);
-    const data = await fetchUsuarios(user as JwtUser);
+    const data = await fetchUsuariosApi();
     setUsuarios(data as Usuario[] ?? []);
     setFilteredUsuarios(data as Usuario[] ?? []);
     setLoading(false);
-  }, [user]);
+  }, []);
 
   const handlePrint = () => {
     window.print();
@@ -110,10 +109,10 @@ export default function UsuariosPage() {
 
     try {
       if (usuario.activo) {
-        await deleteUsuarios(user as JwtUser, usuario.id);
+        await deactivateUsuarioApi(usuario.id);
         toast.success("Usuario desactivado correctamente");
       } else {
-        await updateUsuarios(user as JwtUser, usuario.id, { activo: true });
+        await updateUsuarioApi(usuario.id, { activo: true });
         toast.success("Usuario activado correctamente");
       }
       await loadUsuarios();

--- a/src/components/forms/SocioForm.tsx
+++ b/src/components/forms/SocioForm.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { createSocio, updateSocio } from "@/services/socioService";
+import { createSocioApi, updateSocioApi } from "@/services/browser/socioApiClient";
 import { toast } from "sonner";
 
 export interface SocioFormProps {
@@ -59,7 +59,7 @@ export default function SocioForm({ socio, onCreated }: SocioFormProps) {
     setLoading(true);
     try {
       if (socio && socio.id_socio) {
-        await updateSocio(undefined as any, socio.id_socio, form);
+        await updateSocioApi(socio.id_socio, form);
         toast.success("Socio actualizado");
       } else {
         const createData = {
@@ -70,7 +70,7 @@ export default function SocioForm({ socio, onCreated }: SocioFormProps) {
           telefono: form.telefono,
           email: form.email,
         };
-        await createSocio(undefined as any, createData);
+        await createSocioApi(createData);
         toast.success("Socio creado");
       }
       setForm(emptyForm);

--- a/src/components/forms/UserForm.tsx
+++ b/src/components/forms/UserForm.tsx
@@ -9,7 +9,7 @@ import {
   CreateUsuarioDto,
   UpdateUsuarioDto,
 } from '@/interfaces/usuario.interface';
-import { createUsuarios, updateUsuarios } from '@/services/usuarioService';
+import { createUsuarioApi, updateUsuarioApi } from '@/services/browser/usuarioApiClient';
 import { toast } from 'sonner';
 
 export interface UserFormProps {
@@ -66,7 +66,7 @@ export default function UserForm({
           ...(form.password && { password: form.password }),
         };
 
-        await updateUsuarios(undefined as any, usuario.id, updateData);
+        await updateUsuarioApi(usuario.id, updateData);
         toast.success('Usuario actualizado exitosamente.');
       } else {
         const rol = form.rol || 'socio';
@@ -92,7 +92,7 @@ export default function UserForm({
           return;
         }
 
-        await createUsuarios(undefined as any, createData);
+        await createUsuarioApi(createData);
         toast.success('Usuario creado exitosamente.');
       }
       setForm(emptyForm);

--- a/src/services/browser/socioApiClient.ts
+++ b/src/services/browser/socioApiClient.ts
@@ -1,0 +1,69 @@
+import { CreateSocioDto, Socio, UpdateSocioDto } from '@/interfaces/socio.interface';
+import { authHeader } from '@/services/storageService';
+
+async function parseResponse<T>(res: Response): Promise<T> {
+  const payload = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    throw new Error(payload.error || payload.message || 'Error en la operación de socios');
+  }
+
+  return payload as T;
+}
+
+export async function fetchSociosApi(): Promise<Socio[]> {
+  const res = await fetch('/api/socios', {
+    method: 'GET',
+    headers: authHeader(),
+  });
+  return parseResponse<Socio[]>(res);
+}
+
+export async function createSocioApi(payload: CreateSocioDto): Promise<Socio> {
+  const res = await fetch('/api/socios', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify(payload),
+  });
+  const response = await parseResponse<{ data: Socio }>(res);
+  return response.data;
+}
+
+export async function updateSocioApi(
+  id: string,
+  updateData: UpdateSocioDto
+): Promise<Socio> {
+  const res = await fetch('/api/socios', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify({ id, ...updateData }),
+  });
+  const response = await parseResponse<{ data: Socio }>(res);
+  return response.data;
+}
+
+export async function setSocioActivoApi(
+  id: string,
+  activo: boolean
+): Promise<Socio> {
+  return updateSocioApi(id, { activo });
+}
+
+export async function deactivateSocioApi(id: string): Promise<Socio> {
+  const res = await fetch('/api/socios', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify({ id }),
+  });
+  const response = await parseResponse<{ data: Socio }>(res);
+  return response.data;
+}

--- a/src/services/browser/usuarioApiClient.ts
+++ b/src/services/browser/usuarioApiClient.ts
@@ -1,0 +1,65 @@
+import { CreateUsuarioDto, ResponseUsuario, UpdateUsuarioDto } from '@/interfaces/usuario.interface';
+import { authHeader } from '@/services/storageService';
+
+async function parseResponse<T>(res: Response): Promise<T> {
+  const payload = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    throw new Error(payload.error || payload.message || 'Error en la operación de usuarios');
+  }
+
+  return payload as T;
+}
+
+export async function fetchUsuariosApi(): Promise<ResponseUsuario[]> {
+  const res = await fetch('/api/usuarios', {
+    method: 'GET',
+    headers: authHeader(),
+  });
+  const payload = await parseResponse<{ data: ResponseUsuario[] }>(res);
+  return payload.data ?? [];
+}
+
+export async function createUsuarioApi(
+  payload: CreateUsuarioDto
+): Promise<ResponseUsuario> {
+  const res = await fetch('/api/usuarios', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify(payload),
+  });
+  const response = await parseResponse<{ data: ResponseUsuario }>(res);
+  return response.data;
+}
+
+export async function updateUsuarioApi(
+  id: string,
+  updateData: UpdateUsuarioDto
+): Promise<ResponseUsuario> {
+  const res = await fetch('/api/usuarios', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify({ id, updateData }),
+  });
+  const response = await parseResponse<{ data: ResponseUsuario }>(res);
+  return response.data;
+}
+
+export async function deactivateUsuarioApi(id: string): Promise<ResponseUsuario> {
+  const res = await fetch('/api/usuarios', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify({ id }),
+  });
+  const response = await parseResponse<{ data: ResponseUsuario }>(res);
+  return response.data;
+}

--- a/src/services/server/socioServerService.ts
+++ b/src/services/server/socioServerService.ts
@@ -1,0 +1,141 @@
+import { CreateSocioDto, Socio, UpdateSocioDto } from '@/interfaces/socio.interface';
+import { JwtUser } from '@/interfaces/jwtUser.interface';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+
+const allowedManagerRoles = new Set(['admin', 'usuario']);
+
+function assertCanManageSocios(user: JwtUser) {
+  if (!allowedManagerRoles.has(user.rol)) {
+    throw new Error('No autorizado para administrar socios');
+  }
+}
+
+function normalizeSocioPayload<T extends Record<string, unknown>>(payload: T): T {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== '')
+  ) as T;
+}
+
+export const fetchSociosServer = async (user: JwtUser): Promise<Socio[]> => {
+  assertCanManageSocios(user);
+  const supabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from('socio')
+    .select('*')
+    .order('creado_en', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as Socio[];
+};
+
+export const createSocioServer = async (
+  user: JwtUser,
+  payload: CreateSocioDto
+): Promise<Socio> => {
+  assertCanManageSocios(user);
+  const supabase = getSupabaseServerClient();
+  const sanitizedPayload = normalizeSocioPayload({ ...payload });
+
+  if (!sanitizedPayload.nombre_completo || !sanitizedPayload.dni) {
+    throw new Error('Nombre completo y DNI son obligatorios');
+  }
+
+  if (sanitizedPayload.usuario_id) {
+    const { data: usuario, error: usuarioError } = await supabase
+      .from('usuario')
+      .select('id')
+      .eq('id', sanitizedPayload.usuario_id)
+      .single();
+
+    if (usuarioError || !usuario) {
+      throw new Error('usuario_id no existe en la base de datos');
+    }
+  }
+
+  const { data, error } = await supabase
+    .from('socio')
+    .insert(sanitizedPayload)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data as Socio;
+};
+
+export const updateSocioServer = async (
+  user: JwtUser,
+  id_socio: string,
+  updateData: UpdateSocioDto
+): Promise<Socio> => {
+  assertCanManageSocios(user);
+  const supabase = getSupabaseServerClient();
+  const sanitizedPayload = normalizeSocioPayload({ ...updateData });
+
+  const { data, error } = await supabase
+    .from('socio')
+    .update(sanitizedPayload)
+    .eq('id_socio', id_socio)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el socio con ese ID');
+
+  return data as Socio;
+};
+
+export const setSocioActivoServer = async (
+  user: JwtUser,
+  id_socio: string,
+  activo: boolean
+): Promise<Socio> => {
+  assertCanManageSocios(user);
+  const supabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from('socio')
+    .update({ activo })
+    .eq('id_socio', id_socio)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el socio con ese ID');
+
+  return data as Socio;
+};
+
+export const deactivateSocioServer = async (
+  user: JwtUser,
+  id_socio: string
+): Promise<Socio> => setSocioActivoServer(user, id_socio, false);
+
+export const getSocioByIdServer = async (
+  user: JwtUser,
+  id_socio: string
+): Promise<Socio> => {
+  if (user.rol === 'socio' && user.id_socio !== id_socio) {
+    throw new Error('No autorizado para consultar este socio');
+  }
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('socio')
+    .select(
+      `
+      *,
+      usuario_id (
+        foto,
+        nombre
+      )
+    `
+    )
+    .eq('id_socio', id_socio)
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el socio con ese ID');
+
+  return data as Socio;
+};

--- a/src/services/server/usuarioServerService.ts
+++ b/src/services/server/usuarioServerService.ts
@@ -1,0 +1,198 @@
+import bcrypt from 'bcryptjs';
+
+import {
+  CreateUsuarioDto,
+  ResponseUsuario,
+  UpdateUsuarioDto,
+  Usuario,
+} from '@/interfaces/usuario.interface';
+import { JwtUser } from '@/interfaces/jwtUser.interface';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+
+const allowedManagerRoles = new Set(['admin', 'usuario']);
+const allowedRoles = new Set(['admin', 'usuario', 'socio']);
+
+function assertCanManageUsers(user: JwtUser) {
+  if (!allowedManagerRoles.has(user.rol)) {
+    throw new Error('No autorizado para administrar usuarios');
+  }
+}
+
+function toResponseUsuario(usuario: Usuario): ResponseUsuario {
+  return {
+    id: usuario.id,
+    nombre: usuario.nombre,
+    email: usuario.email,
+    rol: usuario.rol,
+    activo: usuario.activo,
+    foto: usuario.foto,
+  };
+}
+
+function sanitizeRole(rol?: string) {
+  const normalized = (rol || 'socio').trim().toLowerCase();
+  if (!allowedRoles.has(normalized)) {
+    throw new Error('Rol inválido');
+  }
+  return normalized;
+}
+
+export const fetchUsuariosServer = async (
+  user: JwtUser
+): Promise<ResponseUsuario[]> => {
+  assertCanManageUsers(user);
+  const supabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from('usuario')
+    .select('id,nombre,email,rol,activo,foto')
+    .order('creado_en', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((usuario) => toResponseUsuario(usuario as Usuario));
+};
+
+export const createUsuarioServer = async (
+  user: JwtUser,
+  payload: CreateUsuarioDto
+): Promise<ResponseUsuario> => {
+  assertCanManageUsers(user);
+  const supabase = getSupabaseServerClient();
+
+  const rol = sanitizeRole(payload.rol);
+  const email = payload.email?.trim().toLowerCase();
+  const nombre = payload.nombre?.trim();
+
+  if (!nombre || !email || !payload.password?.trim()) {
+    throw new Error('Nombre, email y contraseña son obligatorios');
+  }
+
+  if (rol === 'socio' && !payload.dni?.trim()) {
+    throw new Error('El DNI es obligatorio para crear un usuario socio');
+  }
+
+  const password_hash = await bcrypt.hash(payload.password.trim(), 10);
+
+  const { data: usuarioCreado, error: usuarioError } = await supabase
+    .from('usuario')
+    .insert([
+      {
+        nombre,
+        email,
+        password_hash,
+        rol,
+        activo: true,
+        foto: payload.foto ?? null,
+      },
+    ])
+    .select('id,nombre,email,rol,activo,foto')
+    .single();
+
+  if (usuarioError) throw new Error(usuarioError.message);
+
+  if (rol === 'socio') {
+    const { error: socioError } = await supabase.from('socio').insert([
+      {
+        usuario_id: usuarioCreado.id,
+        nombre_completo: nombre,
+        dni: payload.dni?.trim(),
+        email,
+        activo: true,
+        foto: payload.foto ?? null,
+      },
+    ]);
+
+    if (socioError) {
+      await supabase.from('usuario').delete().eq('id', usuarioCreado.id);
+      throw new Error(
+        `Usuario creado, pero no se pudo crear el perfil de socio: ${socioError.message}`
+      );
+    }
+  }
+
+  return toResponseUsuario(usuarioCreado as Usuario);
+};
+
+export const updateUsuarioServer = async (
+  user: JwtUser,
+  id: string,
+  updateData: UpdateUsuarioDto
+): Promise<ResponseUsuario> => {
+  assertCanManageUsers(user);
+  const supabase = getSupabaseServerClient();
+
+  if (!id) throw new Error('ID de usuario requerido');
+
+  const payload: Record<string, unknown> = { ...updateData };
+  delete payload.password_hash;
+
+  if (typeof updateData.email === 'string') {
+    payload.email = updateData.email.trim().toLowerCase();
+  }
+
+  if (typeof updateData.nombre === 'string') {
+    payload.nombre = updateData.nombre.trim();
+  }
+
+  if (typeof updateData.rol === 'string') {
+    payload.rol = sanitizeRole(updateData.rol);
+  }
+
+  if (updateData.password) {
+    payload.password_hash = await bcrypt.hash(updateData.password.trim(), 10);
+    delete payload.password;
+  }
+
+  const { data, error } = await supabase
+    .from('usuario')
+    .update(payload)
+    .eq('id', id)
+    .select('id,nombre,email,rol,activo,foto')
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el usuario con ese ID');
+
+  return toResponseUsuario(data as Usuario);
+};
+
+export const deactivateUsuarioServer = async (
+  user: JwtUser,
+  id: string
+): Promise<ResponseUsuario> => {
+  assertCanManageUsers(user);
+  const supabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from('usuario')
+    .update({ activo: false })
+    .eq('id', id)
+    .select('id,nombre,email,rol,activo,foto')
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el usuario con ese ID');
+
+  return toResponseUsuario(data as Usuario);
+};
+
+export const getUsuarioByIdServer = async (
+  user: JwtUser,
+  id: string
+): Promise<ResponseUsuario> => {
+  if (user.rol === 'socio' && user.id !== id) {
+    throw new Error('No autorizado para consultar este usuario');
+  }
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('usuario')
+    .select('id,nombre,email,rol,activo,foto')
+    .eq('id', id)
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el usuario con ese ID');
+
+  return toResponseUsuario(data as Usuario);
+};

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -40,7 +40,14 @@ export function getToken() {
   return Cookies.get(TOKEN_KEY) || null;
 }
 
-export function authHeader() {
+export function authHeader(): Record<string, string> {
   const token = getToken();
-  return token ? { Authorization: `Bearer ${token}` } : {};
+
+  if (!token) {
+    return {};
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  };
 }

--- a/src/services/supabaseServerClient.ts
+++ b/src/services/supabaseServerClient.ts
@@ -1,0 +1,27 @@
+import 'server-only';
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseServiceRoleKey) {
+  throw new Error(
+    'Faltan variables de entorno NEXT_PUBLIC_SUPABASE_URL o SUPABASE_SERVICE_ROLE_KEY'
+  );
+}
+
+/**
+ * Cliente Supabase exclusivo para Server Components, API Routes y servicios backend.
+ *
+ * No importar este archivo desde componentes con `use client`.
+ * La service role key nunca debe llegar al bundle del navegador.
+ */
+export const supabaseServer = createClient(supabaseUrl, supabaseServiceRoleKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+  },
+});
+
+export const getSupabaseServerClient = (): SupabaseClient => supabaseServer;


### PR DESCRIPTION
# PR: fix: add server-side Supabase access for core users and members

## Descripción

Este PR forma parte de la etapa de corrección técnica posterior al checkpoint single-tenant de Gym Master. Luego de eliminar la lógica multi-tenant basada en `dbName`, este bloque empieza a ordenar el acceso a datos del core del sistema, especialmente en los módulos de **usuarios** y **socios**.

El objetivo principal es reducir el uso directo de Supabase desde componentes/pantallas del frontend y comenzar a centralizar las operaciones sensibles en **API Routes server-side**, preparando el camino para endurecer RLS, mejorar seguridad, ordenar la integridad de datos y mantener una arquitectura más estable para producción.

> Importante: en este bloque se versionan scripts SQL y documentación técnica, pero las migraciones productivas no deben ejecutarse todavía en Supabase remoto. Primero se deberán validar con Supabase CLI y una base local.

---

## Contexto técnico

Gym Master ya fue migrado a una arquitectura **single-tenant por instancia**, donde cada gimnasio tendrá su propio deploy/app y su propia base Supabase/PostgreSQL. Esto simplifica el sistema porque ya no se necesita resolver dinámicamente un tenant mediante `dbName`.

Después de ese cambio, se detectó que todavía era necesario mejorar la capa de acceso a datos y empezar a separar con más claridad:

- código que corre en cliente/browser,
- código que debe correr exclusivamente del lado servidor,
- operaciones seguras usando service role cuando corresponda,
- endpoints internos que protejan operaciones de usuarios/socios,
- scripts SQL de diagnóstico, integridad y hardening.

---

## Cambios principales

### 1. Nuevo cliente Supabase server-only

Se incorpora un cliente Supabase pensado para ejecutarse exclusivamente en servidor:

```txt
src/services/supabaseServerClient.ts
```

Este cliente permite preparar operaciones internas sin exponer credenciales sensibles al frontend.

---

### 2. Nuevos servicios backend para usuarios y socios

Se agregan servicios server-side para encapsular lógica sensible del core:

```txt
src/services/server/usuarioServerService.ts
src/services/server/socioServerService.ts
```

Estos servicios permiten comenzar a mover operaciones críticas fuera del frontend y hacia API Routes controladas.

---

### 3. Nuevos clientes browser para consumir API Routes

Se incorporan clientes livianos para que el frontend consuma endpoints internos, en lugar de acceder directamente a Supabase:

```txt
src/services/browser/usuarioApiClient.ts
src/services/browser/socioApiClient.ts
```

Esto mejora la separación de responsabilidades:

```txt
Frontend → API Route → Servicio server-side → Supabase
```

---

### 4. Refactor de API Routes core

Se ajustan rutas internas asociadas a usuarios y socios:

```txt
src/app/api/usuarios/route.ts
src/app/api/socios/route.ts
```

Estas rutas actúan como capa intermedia para las operaciones del core y dejan mejor preparado el sistema para aplicar reglas de seguridad y permisos.

---

### 5. Refactor de pantallas y formularios

Se actualizan pantallas/formularios relacionados con usuarios y socios para trabajar con la nueva capa API:

```txt
src/app/dashboard/usuarios/page.tsx
src/app/dashboard/socios/page.tsx
src/components/forms/UserForm.tsx
src/components/forms/SocioForm.tsx
```

---

### 6. Scripts SQL de diagnóstico, integridad y hardening

Se agregan scripts SQL versionables para avanzar de manera controlada en la revisión de base de datos:

```txt
database/scripts/preflight_core_integrity.sql
database/migrations/202605200001_core_integrity_constraints.sql
database/scripts/rls_hardening_plan.sql
```

Aclaración importante:

- Los scripts quedan versionados.
- No se deben ejecutar todavía en Supabase remoto.
- Primero deben validarse con Supabase CLI y una base local.

---

### 7. Documentación técnica agregada

Se agregan documentos para dejar trazabilidad del bloque:

```txt
docs/database/rls-and-core-integrity.md
docs/pr/pr-database-rls-and-core-integrity.md
docs/informes/informe-ejecutivo-rls-integrity.md
```

---

## Validaciones realizadas

Durante las pruebas funcionales se verificó:

- Login de administrador.
- Listado de usuarios.
- Creación de usuario con rol socio.
- Creación automática/asociada de perfil socio.
- Login de socio.
- Listado de socios.
- Creación de socio manual.
- Activación/desactivación de usuario.
- Activación/desactivación de socio.
- Carga del dashboard y consumo de métricas existentes.
- Acceso a pantalla de rutinas.
- Carga de objetivos y niveles.
- Historial de rutinas.
- Generación de rutina exitosa para nivel avanzado.

---

## Corrección de build detectada

Durante `npm run build` se detectó un error de TypeScript asociado al tipado de `authHeader()`:

```txt
Type '{ Authorization: string; } | { Authorization?: undefined; }' is not assignable to type 'HeadersInit'
```

La solución fue tipar explícitamente la función para que nunca retorne headers con valores `undefined`:

```ts
export function authHeader(): Record<string, string> {
  const token = getToken();

  if (!token) {
    return {};
  }

  return {
    Authorization: `Bearer ${token}`,
  };
}
```

---

## Hallazgos detectados durante pruebas

Estos puntos no se corrigen en este PR para evitar mezclar objetivos, pero quedan identificados para próximas ramas:

### 1. Rutinas para niveles inicial e intermedio

La generación de rutina funciona para nivel avanzado, pero falla para nivel inicial e intermedio con mensajes del procedimiento almacenado:

```txt
No hay ejercicios definidos para objetivo 1 y nivel 1
No hay ejercicios definidos para objetivo 1 y nivel 2
```

Diagnóstico preliminar:

- El flujo API/RPC funciona.
- El procedimiento responde correctamente.
- El problema parece estar en datos faltantes/seed incompleto para ejercicios de niveles inicial e intermedio.

Rama futura sugerida:

```txt
feature/rutinas-exercise-seed-levels
```

---

### 2. Endpoint `/api/cuota-estado` devuelve 404

Se detectaron llamadas a:

```txt
GET /api/cuota-estado 404
```

Rama futura sugerida:

```txt
feature/cuota-estado-api
```

---

### 3. Imagen por defecto inexistente

Se detectó:

```txt
GET /default-user.png 404
```

Rama futura sugerida:

```txt
feature/default-user-avatar
```

---

### 4. Primer intento de creación de usuario con 500

Durante pruebas apareció un primer:

```txt
POST /api/usuarios 500
```

Luego la creación respondió correctamente con:

```txt
POST /api/usuarios 201
```

Este comportamiento debe investigarse si vuelve a reproducirse.

Rama futura sugerida:

```txt
feature/usuarios-create-first-attempt
```

---

## Consideraciones sobre Supabase local

A partir de este bloque se establece una regla operativa:

> Antes de ejecutar migraciones productivas en Supabase remoto, se deben validar con Supabase CLI y una base local.

Flujo recomendado:

```txt
1. Levantar Supabase local.
2. Restaurar o reconstruir la estructura base.
3. Ejecutar scripts preflight.
4. Probar migraciones localmente.
5. Validar constraints, RLS, RPC, triggers y seeds.
6. Recién después aplicar cambios en Supabase remoto.
```

---

## Riesgo controlado

Este PR empieza el hardening del core, pero **no elimina masivamente policies abiertas de RLS** todavía. La razón es evitar romper pantallas o módulos que aún puedan estar consultando Supabase directo.

El endurecimiento de RLS debe hacerse progresivamente, módulo por módulo.

---

## Alcance fuera de este PR

No se incluye en este PR:

- Seed de ejercicios para niveles inicial/intermedio.
- Corrección de `/api/cuota-estado`.
- Corrección de `/default-user.png`.
- Implementación de Supabase CLI/local workflow.
- Hardening completo de RLS.
- Cambios de Business Intelligence visual.
- Cambios de RAG o mobile.

---

## Próximos pasos recomendados

1. Mergear este PR si las validaciones pasan.
2. No borrar la rama, conservarla como trazabilidad.
3. Adoptar convención de ramas `feature/*` desde el próximo bloque.
4. Crear rama:

```txt
feature/rutinas-exercise-seed-levels
```

5. Investigar estructura real de tablas de ejercicios, objetivos, niveles y grupos musculares.
6. Crear seed/migración para completar ejercicios de nivel inicial e intermedio.
7. Validar primero en Supabase local antes de tocar remoto.

---

## Checklist

- [x] Se agrega cliente Supabase server-only.
- [x] Se agregan servicios server-side para usuarios y socios.
- [x] Se agregan clientes browser para API Routes.
- [x] Se refactorizan rutas API de usuarios/socios.
- [x] Se refactorizan pantallas/formularios core.
- [x] Se agregan scripts SQL de diagnóstico/integridad/hardening.
- [x] Se agrega documentación técnica del bloque.
- [x] Se valida funcionalmente usuarios y socios.
- [x] Se detectan pendientes reales sin mezclarlos en este PR.
- [ ] Migraciones validadas con Supabase local.
- [ ] Migraciones aplicadas en Supabase remoto.

