### PR TITLE
fix: refresh and delete workout routines

### DIFF
--- a/docs/informes/informe-ejecutivo-rutinas-refresh-delete.md
+++ b/docs/informes/informe-ejecutivo-rutinas-refresh-delete.md
@@ -1,0 +1,52 @@
+# Informe ejecutivo — Corrección de refresco y eliminación de rutinas
+
+## Proyecto
+
+Gym Master
+
+## Rama sugerida
+
+`feature/rutinas-refresh-delete-fix`
+
+## Resumen ejecutivo
+
+Se corrigió el flujo funcional del módulo Rutinas para mejorar la experiencia del socio y asegurar consistencia entre las operaciones realizadas y la información mostrada en pantalla.
+
+Durante pruebas funcionales se detectó que, al crear una rutina, el sistema informaba éxito pero no actualizaba el listado automáticamente. También se detectó que la acción de eliminar mostraba confirmación, pero no ejecutaba una eliminación real ni actualizaba el estado visual.
+
+Esta mejora incorpora un flujo completo de creación/refresco y eliminación real de rutinas.
+
+## Problemas detectados
+
+1. Rutina creada sin refresco automático del historial.
+2. Eliminación de rutina sin operación real en backend.
+3. Falta de feedback visual durante la eliminación.
+4. Separación incompleta entre confirmación UI y persistencia real en base.
+
+## Solución implementada
+
+- Se agregó refresco automático del listado luego de crear una rutina.
+- Se agregó endpoint `DELETE` para eliminar rutinas.
+- Se agregó un servicio server-side para validar permisos y ejecutar la eliminación.
+- Se actualizó el componente de visualización para recargar datos y mostrar estado de eliminación.
+- Se incorporó documentación técnica del flujo corregido.
+
+## Impacto funcional
+
+- El socio puede generar una rutina y verla inmediatamente sin presionar F5.
+- El socio puede eliminar una rutina propia y verla desaparecer del listado.
+- El sistema valida permisos antes de eliminar.
+- El flujo queda más alineado con un comportamiento esperado de aplicación SaaS moderna.
+
+## Riesgos y consideraciones
+
+- La ruta dinámica existente `api/rutina/[idSocio]` se reutiliza para `DELETE`, interpretando el parámetro como `idRutina`. A futuro puede evaluarse crear una ruta más explícita, por ejemplo `api/rutina/by-id/[idRutina]`, para mayor claridad semántica.
+- La eliminación actual es física. Si el negocio requiere auditoría/historial completo, se recomienda evaluar borrado lógico mediante campos como `eliminado_en` o `activo`.
+
+## Próximos pasos recomendados
+
+1. Validar con `npm run build`.
+2. Probar generación y eliminación con usuario socio.
+3. Probar permisos entre socios.
+4. Evaluar a futuro si conviene implementar borrado lógico.
+5. Continuar con la rama pendiente de imágenes/gifs para ejercicios iniciales e intermedios.

--- a/docs/pr/pr-rutinas-refresh-delete-fix.md
+++ b/docs/pr/pr-rutinas-refresh-delete-fix.md
@@ -1,0 +1,59 @@
+# PR: Corrección de refresco y eliminación de rutinas
+
+## Descripción
+
+Este PR corrige dos problemas funcionales detectados durante las pruebas del módulo Rutinas de Gym Master:
+
+1. Al generar una rutina, el sistema mostraba el mensaje de éxito, pero el listado no se actualizaba automáticamente. La rutina recién aparecía al recargar manualmente la pantalla con F5.
+2. Al eliminar una rutina, aparecía el mensaje de confirmación, pero la operación no eliminaba realmente la rutina ni actualizaba el listado.
+
+Con este cambio, el flujo de rutinas queda más consistente para el socio y más preparado para uso real en producción.
+
+## Cambios principales
+
+### Frontend
+
+- Se agrega un mecanismo de refresco controlado mediante `refreshKey` en la página de rutinas.
+- El componente `RutinaDisplay` ahora recarga el historial cuando se crea o elimina una rutina.
+- Se agrega feedback visual durante la eliminación con el estado `ELIMINANDO...`.
+- Se mantiene el modal de confirmación antes de eliminar.
+- Se muestran mensajes de éxito/error con `toast`.
+
+### API Client
+
+- Se agrega la función `eliminarRutina(idRutina)` en `src/services/apiClient.ts`.
+- La función consume `DELETE /api/rutina/:idRutina` enviando el JWT del usuario autenticado.
+
+### Backend
+
+- Se agrega soporte para `DELETE` en la ruta `src/app/api/rutina/[idSocio]/route.ts`.
+- Se agrega el servicio server-side `src/services/server/rutinaServerService.ts`.
+- La eliminación se ejecuta desde backend usando Supabase server-side/service role.
+- Se valida que:
+  - la rutina exista,
+  - el id sea válido,
+  - el socio solo elimine sus propias rutinas,
+  - el administrador pueda eliminar rutinas si corresponde.
+
+## Archivos modificados
+
+- `src/app/dashboard/rutinas/page.tsx`
+- `src/components/dashboard/rutinas/RutinaDisplay.tsx`
+- `src/services/apiClient.ts`
+- `src/app/api/rutina/[idSocio]/route.ts`
+- `src/services/server/rutinaServerService.ts`
+- `docs/rutinas/refresh-delete-flow.md`
+
+## Validaciones sugeridas
+
+- `npm run build`
+- Login como socio.
+- Generar rutina y verificar refresco automático del listado.
+- Eliminar rutina y verificar que desaparezca sin recargar manualmente.
+- Recargar la pantalla y verificar que la rutina eliminada no reaparezca.
+- Probar autorización: un socio no debe poder eliminar rutinas de otro socio.
+- Probar rol administrador si la vista lo permite.
+
+## Notas
+
+Este PR no agrega migraciones de base de datos. La corrección trabaja sobre la tabla `rutina` existente y sobre el flujo API/UI.

--- a/docs/rutinas/refresh-delete-flow.md
+++ b/docs/rutinas/refresh-delete-flow.md
@@ -1,0 +1,70 @@
+# Gym Master — Corrección de flujo de rutinas: refresco y eliminación
+
+## Contexto
+
+Durante las pruebas funcionales del módulo Rutinas se detectaron dos problemas:
+
+1. Al generar una rutina, el sistema mostraba el mensaje de éxito, pero el listado no se actualizaba automáticamente. La rutina recién aparecía al recargar manualmente la pantalla con F5.
+2. Al eliminar una rutina, aparecía el diálogo de confirmación, pero luego de aceptar la rutina permanecía visible y no se eliminaba de la base.
+
+## Objetivo de la rama
+
+Corregir el flujo operativo de rutinas para que:
+
+- Después de generar una rutina, el historial/listado se refresque automáticamente.
+- La eliminación de una rutina ejecute una operación real contra el backend.
+- El socio solo pueda eliminar sus propias rutinas.
+- Un administrador pueda eliminar rutinas desde una vista global si corresponde.
+- La UI muestre feedback correcto durante la eliminación.
+
+## Cambios técnicos
+
+### Frontend
+
+- Se agregó un `refreshKey` en `src/app/dashboard/rutinas/page.tsx` para forzar la recarga del componente `RutinaDisplay` después de crear o eliminar una rutina.
+- Se agregó un handler dedicado `handleDeleteRutina` para:
+  - confirmar eliminación,
+  - llamar a la API,
+  - mostrar toast de éxito/error,
+  - refrescar el historial.
+- Se actualizó `src/components/dashboard/rutinas/RutinaDisplay.tsx` para:
+  - aceptar `refreshKey`,
+  - recargar el historial cuando cambia ese valor,
+  - ejecutar correctamente `onDelete`,
+  - mostrar estado `ELIMINANDO...` durante la operación.
+
+### API Client
+
+- Se agregó `eliminarRutina(idRutina)` en `src/services/apiClient.ts`.
+- La función llama a `DELETE /api/rutina/:idRutina` con token JWT.
+
+### Backend / API Route
+
+- Se agregó soporte para `DELETE` en `src/app/api/rutina/[idSocio]/route.ts`.
+- Aunque el segmento existente se llama `[idSocio]`, para `DELETE` se interpreta como `idRutina` por compatibilidad con la estructura de rutas actual.
+
+### Servicio server-side
+
+- Se agregó `src/services/server/rutinaServerService.ts`.
+- Usa `getSupabaseServerClient()` para operar con service role desde backend.
+- Valida:
+  - que el id de rutina sea válido,
+  - que la rutina exista,
+  - que el socio logueado sea dueño de la rutina,
+  - que un admin pueda eliminar si corresponde.
+
+## Validaciones sugeridas
+
+1. Iniciar sesión como socio.
+2. Entrar a `Dashboard > Rutinas`.
+3. Generar una rutina nueva.
+4. Confirmar que aparece automáticamente sin presionar F5.
+5. Eliminar una rutina.
+6. Confirmar que desaparece automáticamente del listado.
+7. Recargar la página y confirmar que la rutina eliminada no vuelve a aparecer.
+8. Probar con rol administrador si corresponde.
+
+## Notas
+
+Esta rama no requiere migraciones de base de datos. Es una corrección de flujo frontend/backend sobre la tabla `rutina` existente.
+

--- a/src/app/api/rutina/[idSocio]/route.ts
+++ b/src/app/api/rutina/[idSocio]/route.ts
@@ -1,6 +1,7 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { historialRutinaSocio } from "@/services/rutinaService";
-import { NextResponse } from "next/server";
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { historialRutinaSocio } from '@/services/rutinaService';
+import { deleteRutinaById } from '@/services/server/rutinaServerService';
+import { NextResponse } from 'next/server';
 
 export async function GET(
   req: Request,
@@ -9,13 +10,13 @@ export async function GET(
   try {
     const { user } = await authMiddleware(req);
     if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { idSocio } = await params;
     if (!idSocio) {
       return NextResponse.json(
-        { error: "ID del socio es requerido" },
+        { error: 'ID del socio es requerido' },
         { status: 400 }
       );
     }
@@ -24,14 +25,55 @@ export async function GET(
 
     if (!rutinas) {
       return NextResponse.json(
-        { error: "Rutinas no encontradas para el socio" },
+        { error: 'Rutinas no encontradas para el socio' },
         { status: 404 }
       );
     }
 
     return NextResponse.json(rutinas, { status: 200 });
   } catch (error: any) {
-    console.error("Error al obtener las rutinas del socio:", error);
+    console.error('Error al obtener las rutinas del socio:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ idSocio: string }> }
+) {
+  try {
+    const { user } = await authMiddleware(req);
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { idSocio: idRutina } = await params;
+    const deletedRutina = await deleteRutinaById(user, idRutina);
+
+    return NextResponse.json(
+      {
+        message: 'Rutina eliminada correctamente',
+        data: deletedRutina,
+      },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    console.error('Error al eliminar rutina:', error);
+
+    const message = error?.message ?? 'Error al eliminar rutina';
+
+    if (message.includes('no es válido')) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    if (message.includes('No autorizado')) {
+      return NextResponse.json({ error: message }, { status: 403 });
+    }
+
+    if (message.includes('no encontrada') || message.includes('no encontrado')) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/dashboard/rutinas/page.tsx
+++ b/src/app/dashboard/rutinas/page.tsx
@@ -27,6 +27,7 @@ import {
   getHistorialRutinas,
   getObjetivos,
   getNiveles,
+  eliminarRutina,
 } from "@/services/apiClient";
 import RutinaDisplay from "@/components/dashboard/rutinas/RutinaDisplay";
 
@@ -41,6 +42,7 @@ export default function RutinasPage() {
     useAuthStore();
   const router = useRouter();
   const [rutinas, setRutinas] = useState<RutinaDisplayData[]>([]);
+  const [rutinasRefreshKey, setRutinasRefreshKey] = useState(0);
   const [searchTerm, setSearchTerm] = useState("");
   const [loading, setLoading] = useState(true);
   const [openModal, setOpenModal] = useState(false);
@@ -123,6 +125,37 @@ export default function RutinasPage() {
       console.error("Error al cargar niveles:", error);
     }
   }, [user, token]);
+
+  const refreshRutinas = useCallback(async () => {
+    await fetchRutinas();
+    setRutinasRefreshKey((current) => current + 1);
+  }, [fetchRutinas]);
+
+  const handleDeleteRutina = useCallback(
+    async (rutina: Rutina) => {
+      const confirmar = window.confirm(
+        "¿Está seguro de eliminar la rutina?",
+      );
+
+      if (!confirmar) return;
+
+      try {
+        const response = await eliminarRutina(rutina.id_rutina);
+
+        if (!response.ok) {
+          throw new Error(response.error || "Error al eliminar rutina");
+        }
+
+        toast.success("Rutina eliminada correctamente");
+        await refreshRutinas();
+      } catch (error) {
+        console.error("Error al eliminar rutina:", error);
+        toast.error("Error al eliminar la rutina");
+        throw error;
+      }
+    },
+    [refreshRutinas],
+  );
 
   useEffect(() => {
     initializeAuth();
@@ -298,6 +331,7 @@ export default function RutinasPage() {
               </CardHeader>
               <CardContent className="p-4">
                 <RutinaDisplay
+                  refreshKey={rutinasRefreshKey}
                   onView={(rutina) => {
                     let rutinaDesc = rutina.rutina_desc;
 
@@ -320,13 +354,7 @@ export default function RutinasPage() {
                     setSelectedRutina(rutina);
                     setOpenModal(true);
                   }}
-                  onDelete={async () => {
-                    const confirmar = window.confirm(
-                      "¿Está seguro de eliminar la rutina?",
-                    );
-                    if (!confirmar) return;
-                    await fetchRutinas();
-                  }}
+                  onDelete={handleDeleteRutina}
                 />
               </CardContent>
             </Card>
@@ -340,7 +368,7 @@ export default function RutinasPage() {
           setOpenModal(false);
           setSelectedRutina(null);
         }}
-        onCreated={fetchRutinas}
+        onCreated={refreshRutinas}
         rutina={selectedRutina}
         objetivos={objetivos}
         niveles={niveles}

--- a/src/components/dashboard/rutinas/RutinaDisplay.tsx
+++ b/src/components/dashboard/rutinas/RutinaDisplay.tsx
@@ -164,13 +164,15 @@ const obtenerTituloRutina = (rutina: Rutina): string => {
 };
 
 export default function RutinaEjercicios({
+  refreshKey = 0,
   onView,
   onEdit,
   onDelete,
 }: {
+  refreshKey?: number;
   onView?: (rutina: Rutina) => void;
   onEdit?: (rutina: Rutina) => void;
-  onDelete?: (rutina: Rutina) => void;
+  onDelete?: (rutina: Rutina) => Promise<void> | void;
 }) {
   const { user, token } = useAuthStore();
   const usuarioEsAdmin = isAdmin(user?.rol);
@@ -181,6 +183,7 @@ export default function RutinaEjercicios({
   }>({});
   const [rutinas, setRutinas] = useState<Rutina[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
   const [imagenVisible, setImagenVisible] = useState<{
     [key: string]: boolean;
   }>({});
@@ -209,7 +212,7 @@ export default function RutinaEjercicios({
 
   useEffect(() => {
     fetchRutinas();
-  }, [fetchRutinas]);
+  }, [fetchRutinas, refreshKey]);
 
   const toggleDia = (dia: string) => {
     setDiasExpandidos((prev) => ({
@@ -233,6 +236,23 @@ export default function RutinaEjercicios({
   const volverALista = () => {
     setViendoRutina(null);
     setDiasExpandidos({});
+  };
+
+  const handleDelete = async (rutina: Rutina) => {
+    if (!onDelete) return;
+
+    setDeletingId(rutina.id_rutina);
+
+    try {
+      await onDelete(rutina);
+      await fetchRutinas();
+
+      if (viendoRutina === rutina.id_rutina) {
+        volverALista();
+      }
+    } finally {
+      setDeletingId(null);
+    }
   };
 
   if (loading) {
@@ -495,10 +515,11 @@ export default function RutinaEjercicios({
                   </button>
 
                   <button
-                    onClick={() => onDelete?.(rutina)}
-                    className="px-6 py-2 text-xs font-medium tracking-wide text-red-600 transition-colors bg-transparent border border-red-600 rounded-full cursor-pointer sm:px-8 sm:py-3 sm:text-sm sm:tracking-widest hover:bg-red-50"
+                    onClick={() => handleDelete(rutina)}
+                    disabled={deletingId === rutina.id_rutina}
+                    className="px-6 py-2 text-xs font-medium tracking-wide text-red-600 transition-colors bg-transparent border border-red-600 rounded-full cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 sm:px-8 sm:py-3 sm:text-sm sm:tracking-widest hover:bg-red-50"
                   >
-                    ELIMINAR
+                    {deletingId === rutina.id_rutina ? "ELIMINANDO..." : "ELIMINAR"}
                   </button>
                 </div>
               </div>

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -249,6 +249,22 @@ export async function getRutinasPorSocio(idSocio: number | string) {
   return { ok: res.ok, data };
 }
 
+export async function eliminarRutina(idRutina: number | string) {
+  const token = getToken();
+  const headers: HeadersInit = token
+    ? { Authorization: `Bearer ${token}` }
+    : {};
+
+  const res = await fetch(`/api/rutina/${idRutina}`, {
+    method: 'DELETE',
+    headers,
+  });
+
+  const data = await res.json().catch(() => ({}));
+
+  return { ok: res.ok, ...data };
+}
+
 export async function crearEntrenador(body: any) {
   const token = getToken();
   const res = await fetch('/api/entrenadores', {

--- a/src/services/server/rutinaServerService.ts
+++ b/src/services/server/rutinaServerService.ts
@@ -1,0 +1,86 @@
+import { JwtUser } from '@/interfaces/jwtUser.interface';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+
+const isValidUUID = (value?: string | null): value is string => {
+  if (typeof value !== 'string') return false;
+
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value.trim()
+  );
+};
+
+const isAdmin = (rol?: string | null): boolean => {
+  const normalizedRol = rol?.trim().toLowerCase();
+
+  return normalizedRol === 'admin' || normalizedRol === 'administrador';
+};
+
+const resolveUserSocioId = async (user: JwtUser): Promise<string | null> => {
+  if (isValidUUID(user.id_socio)) {
+    return user.id_socio.trim();
+  }
+
+  if (!isValidUUID(user.id)) {
+    return null;
+  }
+
+  const supabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from('socio')
+    .select('id_socio')
+    .eq('usuario_id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`No se pudo resolver el socio asociado al usuario: ${error.message}`);
+  }
+
+  return isValidUUID(data?.id_socio) ? data.id_socio : null;
+};
+
+export const deleteRutinaById = async (
+  user: JwtUser,
+  idRutinaParam: string
+): Promise<{ id_rutina: number }> => {
+  const idRutina = Number(idRutinaParam);
+
+  if (!Number.isInteger(idRutina) || idRutina <= 0) {
+    throw new Error('El id de rutina no es válido');
+  }
+
+  const supabase = getSupabaseServerClient();
+
+  const { data: rutina, error: rutinaError } = await supabase
+    .from('rutina')
+    .select('id_rutina, id_socio')
+    .eq('id_rutina', idRutina)
+    .maybeSingle();
+
+  if (rutinaError) {
+    throw new Error(`Error al consultar la rutina: ${rutinaError.message}`);
+  }
+
+  if (!rutina) {
+    throw new Error('Rutina no encontrada');
+  }
+
+  if (!isAdmin(user.rol)) {
+    const idSocioUsuario = await resolveUserSocioId(user);
+
+    if (!idSocioUsuario || idSocioUsuario !== rutina.id_socio) {
+      throw new Error('No autorizado para eliminar esta rutina');
+    }
+  }
+
+  const { error: deleteError } = await supabase
+    .from('rutina')
+    .delete()
+    .eq('id_rutina', idRutina);
+
+  if (deleteError) {
+    throw new Error(`Error al eliminar la rutina: ${deleteError.message}`);
+  }
+
+  return { id_rutina: idRutina };
+};


### PR DESCRIPTION
# PR: fix: refresh and delete workout routines

## Descripción

Este PR corrige dos problemas funcionales detectados en el módulo **Rutinas** de Gym Master dentro del dashboard del socio:

1. Al generar una rutina nueva, el sistema mostraba el mensaje de éxito, pero el historial/listado no se actualizaba automáticamente. La rutina recién aparecía al presionar **F5**.
2. Al intentar eliminar una rutina, el sistema mostraba el cuadro de confirmación y aceptaba la acción, pero la rutina no se eliminaba del listado ni de la fuente de datos correspondiente.

El objetivo de esta rama es cerrar el flujo básico de gestión de rutinas para que el socio pueda generar, visualizar y eliminar rutinas sin depender de recargar manualmente la página.

## Contexto técnico

Gym Master ya quedó migrado a una arquitectura **single-tenant por instancia**, eliminando la lógica antigua basada en `dbName`. Además, se corrigió previamente el flujo de generación de rutinas para niveles Inicial e Intermedio mediante migraciones versionadas con Supabase CLI.

Durante pruebas funcionales posteriores se detectaron dos pendientes directos sobre la experiencia de usuario del módulo Rutinas:

- El listado no se refrescaba luego de crear una rutina.
- El flujo de eliminación no persistía la baja de la rutina.

Este PR aborda esos puntos sin mezclar mejoras mayores como exportación PDF, imágenes/gifs de ejercicios o rediseño completo del detalle de rutina.

## Cambios principales

### Frontend

- Se ajusta el flujo de generación de rutinas para actualizar el historial inmediatamente después de una creación exitosa.
- Se evita que el usuario dependa de presionar **F5** para ver la rutina recién creada.
- Se mejora el flujo visual de eliminación mostrando estado de proceso cuando corresponde.
- Se actualiza la vista/listado luego de eliminar una rutina.

### Backend / API Routes

- Se incorpora o ajusta el endpoint `DELETE` correspondiente al módulo de rutinas.
- Se valida que la rutina a eliminar corresponda al socio autenticado cuando la acción viene desde perfil de socio.
- Se centraliza la lógica de baja/eliminación en el servicio server-side correspondiente.
- Se evita confiar únicamente en lógica de UI para decidir qué rutina puede eliminarse.

### Servicios

- Se agrega o corrige el cliente/API method para eliminar rutinas.
- Se mantiene separación entre consumo frontend y operación server-side.
- Se conserva el enfoque de acceso seguro a Supabase desde backend cuando corresponde.

### Documentación

- Se documenta el flujo corregido de creación/refresco y eliminación de rutinas.
- Se agrega descripción de PR y reporte técnico del bloque.

## Archivos principales modificados

```txt
src/app/dashboard/rutinas/page.tsx
src/components/dashboard/rutinas/RutinaDisplay.tsx
src/services/apiClient.ts
src/app/api/rutina/[idSocio]/route.ts
src/services/server/rutinaServerService.ts
docs/rutinas/refresh-delete-flow.md
docs/pr/pr-rutinas-refresh-delete-fix.md
docs/informes/informe-ejecutivo-rutinas-refresh-delete.md
```

## Validaciones realizadas / a realizar

- [ ] Ejecutar `npm run build`.
- [ ] Iniciar la app con `npm run dev`.
- [ ] Iniciar sesión como socio.
- [ ] Entrar al módulo **Rutinas**.
- [ ] Generar una rutina nueva.
- [ ] Verificar que la rutina aparece automáticamente sin presionar **F5**.
- [ ] Eliminar una rutina desde el listado.
- [ ] Confirmar que la rutina desaparece del listado sin recargar manualmente.
- [ ] Refrescar la pantalla y validar que la rutina eliminada no vuelve a aparecer.
- [ ] Validar que el flujo no afecta la generación de rutinas por objetivo/nivel.

## Fuera de alcance de este PR

Este PR **no incluye**:

- Rediseño completo del modal de detalle de rutina.
- Exportación profesional de rutina a PDF.
- Inclusión de logo, nombre del socio, imágenes y estructura completa en PDF.
- Carga de imágenes/gifs/videos para ejercicios Inicial/Intermedio.
- Corrección de fallback visual para ejercicios sin imagen.
- Refactor completo de la UI de rutina.

Estos puntos quedan sugeridos para ramas futuras:

```txt
feature/rutinas-pdf-export
feature/rutinas-exercise-images
```

## Pendientes detectados para próximas ramas

- Crear exportación PDF profesional de rutinas con logo, nombre del socio, días ordenados, ejercicios ordenados e imágenes cuando existan.
- Revisar el modal actual de detalle de rutina, ya que actualmente no aporta valor suficiente al usuario.
- Cargar imágenes/gifs/videos para ejercicios nuevos de niveles Inicial e Intermedio.
- Definir fallback visual para ejercicios sin imagen.
- Revisar el endpoint `/api/cuota-estado`, que en pruebas anteriores devolvía `404`.
- Incorporar `/default-user.png` o ajustar fallback de avatar para evitar errores de imagen inexistente.

## Resultado esperado

Con este PR, el módulo Rutinas queda más usable y consistente:

- El socio genera una rutina y la ve inmediatamente.
- El socio elimina una rutina y el listado se actualiza correctamente.
- El flujo queda preparado para futuras mejoras de exportación PDF y visualización avanzada.
