### PR TITLE
docs: audit membership fees payments and expirations

### DIFF
--- a/database/scripts/diagnostico_cuotas_pagos_vencimientos.sql
+++ b/database/scripts/diagnostico_cuotas_pagos_vencimientos.sql
@@ -1,0 +1,225 @@
+-- =============================================================
+-- Gym Master - Diagnóstico de cuotas, pagos y vencimientos
+-- Rama: feature/cuotas-pagos-vencimientos
+-- Objetivo: auditar el estado real del modelo de cuotas/pagos antes de tocar código o migraciones.
+-- Uso local recomendado:
+--   docker exec -i supabase_db_gym-master psql -U postgres -d postgres < database/scripts/diagnostico_cuotas_pagos_vencimientos.sql
+-- Uso remoto recomendado:
+--   Ejecutar por secciones en Supabase SQL Editor, solo lectura.
+-- =============================================================
+
+-- 1) Estructura de tablas clave
+SELECT
+  'columns' AS section,
+  table_name,
+  ordinal_position,
+  column_name,
+  data_type,
+  is_nullable,
+  column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name IN ('cuota', 'historial_precios_cuota', 'pago', 'socio', 'asistencia')
+ORDER BY table_name, ordinal_position;
+
+-- 2) Constraints y relaciones
+SELECT
+  'constraints' AS section,
+  tc.table_name,
+  tc.constraint_type,
+  tc.constraint_name,
+  kcu.column_name,
+  ccu.table_name AS foreign_table_name,
+  ccu.column_name AS foreign_column_name
+FROM information_schema.table_constraints tc
+LEFT JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+ AND tc.table_schema = kcu.table_schema
+LEFT JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_name = tc.constraint_name
+ AND ccu.table_schema = tc.table_schema
+WHERE tc.table_schema = 'public'
+  AND tc.table_name IN ('cuota', 'historial_precios_cuota', 'pago', 'socio', 'asistencia')
+ORDER BY tc.table_name, tc.constraint_type, tc.constraint_name;
+
+-- 3) RLS y policies sobre tablas sensibles
+SELECT
+  'rls' AS section,
+  schemaname,
+  tablename,
+  rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public'
+  AND tablename IN ('cuota', 'historial_precios_cuota', 'pago', 'socio', 'asistencia')
+ORDER BY tablename;
+
+SELECT
+  'policies' AS section,
+  schemaname,
+  tablename,
+  policyname,
+  cmd,
+  roles,
+  qual,
+  with_check
+FROM pg_policies
+WHERE schemaname = 'public'
+  AND tablename IN ('cuota', 'historial_precios_cuota', 'pago', 'socio', 'asistencia')
+ORDER BY tablename, policyname;
+
+-- 4) Volumen de datos
+SELECT 'cuota' AS tabla, COUNT(*) AS total FROM public.cuota
+UNION ALL SELECT 'historial_precios_cuota', COUNT(*) FROM public.historial_precios_cuota
+UNION ALL SELECT 'pago', COUNT(*) FROM public.pago
+UNION ALL SELECT 'socio', COUNT(*) FROM public.socio
+UNION ALL SELECT 'asistencia', COUNT(*) FROM public.asistencia
+ORDER BY tabla;
+
+-- 5) Historial de cuotas/precios operativos
+SELECT
+  'cuotas' AS section,
+  id,
+  descripcion,
+  monto,
+  periodo,
+  fecha_inicio,
+  fecha_fin,
+  activo,
+  creado_en,
+  actualizado_en
+FROM public.cuota
+ORDER BY fecha_inicio DESC, creado_en DESC;
+
+SELECT
+  'historial_precios_cuota' AS section,
+  h.id,
+  h.id_socio,
+  s.nombre_completo AS socio,
+  h.precio,
+  h.fecha_inicio,
+  h.fecha_fin
+FROM public.historial_precios_cuota h
+LEFT JOIN public.socio s ON s.id_socio = h.id_socio
+ORDER BY h.fecha_inicio DESC, h.id_socio NULLS FIRST, h.id DESC;
+
+-- 6) Último pago por socio y estado operativo estimado
+WITH ultimos_pagos AS (
+  SELECT DISTINCT ON (p.socio_id)
+    p.socio_id,
+    p.id AS pago_id,
+    p.fecha_pago,
+    p.fecha_vencimiento,
+    p.monto_pagado,
+    p.cuota_id,
+    p.registrado_por,
+    p.enviar_email
+  FROM public.pago p
+  ORDER BY p.socio_id, p.fecha_vencimiento DESC NULLS LAST, p.fecha_pago DESC
+), ultima_asistencia AS (
+  SELECT
+    a.socio_id,
+    MAX(a.fecha) AS ultima_asistencia
+  FROM public.asistencia a
+  GROUP BY a.socio_id
+)
+SELECT
+  'estado_cuota_estimado' AS section,
+  s.id_socio,
+  s.nombre_completo,
+  s.activo,
+  s.fecha_alta,
+  up.pago_id,
+  up.fecha_pago,
+  up.fecha_vencimiento,
+  up.monto_pagado,
+  ua.ultima_asistencia,
+  CASE
+    WHEN up.pago_id IS NULL THEN 'SIN_PAGO'
+    WHEN up.fecha_vencimiento < CURRENT_DATE THEN 'VENCIDA'
+    WHEN up.fecha_vencimiento BETWEEN CURRENT_DATE AND CURRENT_DATE + INTERVAL '7 days' THEN 'POR_VENCER'
+    ELSE 'AL_DIA'
+  END AS estado_cuota,
+  CASE
+    WHEN up.fecha_vencimiento < CURRENT_DATE
+     AND (ua.ultima_asistencia IS NULL OR ua.ultima_asistencia < up.fecha_vencimiento + INTERVAL '7 days')
+    THEN true
+    ELSE false
+  END AS candidato_inactivacion_por_regla
+FROM public.socio s
+LEFT JOIN ultimos_pagos up ON up.socio_id = s.id_socio
+LEFT JOIN ultima_asistencia ua ON ua.socio_id = s.id_socio
+ORDER BY estado_cuota, s.nombre_completo;
+
+-- 7) Pagos registrados con detalle de cuota y usuario registrador
+SELECT
+  'pagos_detalle' AS section,
+  p.id,
+  p.socio_id,
+  s.nombre_completo AS socio,
+  p.cuota_id,
+  c.descripcion AS cuota,
+  c.periodo AS cuota_periodo,
+  c.monto AS cuota_monto,
+  p.fecha_pago,
+  p.fecha_vencimiento,
+  p.monto_pagado,
+  p.total,
+  p.registrado_por,
+  u.nombre AS registrado_por_nombre,
+  p.enviar_email,
+  p.creado_en
+FROM public.pago p
+LEFT JOIN public.socio s ON s.id_socio = p.socio_id
+LEFT JOIN public.cuota c ON c.id = p.cuota_id
+LEFT JOIN public.usuario u ON u.id = p.registrado_por
+ORDER BY p.fecha_pago DESC NULLS LAST, p.creado_en DESC;
+
+-- 8) Funciones/RPC relacionadas con cuota/pago/asistencia disponibles
+SELECT
+  'functions' AS section,
+  n.nspname AS schema,
+  p.proname AS function_name,
+  pg_get_function_arguments(p.oid) AS arguments,
+  pg_get_function_result(p.oid) AS result_type
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND (
+    p.proname ILIKE '%cuota%'
+    OR p.proname ILIKE '%pago%'
+    OR p.proname ILIKE '%asistencia%'
+    OR p.proname ILIKE '%moros%'
+    OR p.proname ILIKE '%venc%'
+    OR p.proname ILIKE '%retencion%'
+  )
+ORDER BY p.proname;
+
+-- 9) Ejecución segura de RPC existentes si están disponibles
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'obtener_evolucion_cuota'
+  ) THEN
+    RAISE NOTICE 'RPC disponible: obtener_evolucion_cuota()';
+  ELSE
+    RAISE NOTICE 'RPC no disponible: obtener_evolucion_cuota()';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'sp_analisis_conducta_pagos'
+  ) THEN
+    RAISE NOTICE 'RPC disponible: sp_analisis_conducta_pagos()';
+  ELSE
+    RAISE NOTICE 'RPC no disponible: sp_analisis_conducta_pagos()';
+  END IF;
+END $$;
+
+SELECT 'obtener_evolucion_cuota' AS rpc, *
+FROM public.obtener_evolucion_cuota()
+ORDER BY anio, mes;
+
+SELECT 'sp_analisis_conducta_pagos' AS rpc, *
+FROM public.sp_analisis_conducta_pagos()
+ORDER BY anio_mes, socio_id;

--- a/docs/cuotas-pagos/auditoria-cuotas-pagos-vencimientos.md
+++ b/docs/cuotas-pagos/auditoria-cuotas-pagos-vencimientos.md
@@ -1,0 +1,331 @@
+# Auditoría inicial de cuotas, pagos y vencimientos — Gym Master
+
+## 1. Contexto
+
+Esta auditoría corresponde a la rama `feature/cuotas-pagos-vencimientos` y toma como punto de partida el estado actualizado del repositorio y del dump `backup_completo_gym_master_20052026.sql`.
+
+El objetivo es revisar el estado real del módulo de cuotas/pagos antes de implementar reglas nuevas de negocio, especialmente:
+
+- pago manual desde administrador,
+- pago online con Stripe,
+- historial de precios de cuota,
+- cuotas vencidas,
+- pagos adelantados,
+- pagos que cubren varios meses,
+- inactivación por vencimiento + falta de asistencia,
+- métricas para dashboard/Business Intelligence.
+
+Regla operativa del proyecto: cualquier cambio de base de datos debe probarse primero con Supabase CLI en entorno local y luego aplicarse en remoto con historial de migraciones controlado.
+
+---
+
+## 2. Tablas detectadas en el dump actualizado
+
+### `cuota`
+
+Tabla principal para precios/cuotas por período.
+
+Columnas relevantes:
+
+- `id`
+- `descripcion`
+- `monto`
+- `periodo`
+- `fecha_inicio`
+- `fecha_fin`
+- `activo`
+- `creado_en`
+- `actualizado_en`
+
+Estado observado:
+
+- Existen cuotas mensuales históricas cargadas.
+- El campo `periodo` está representado como texto, por ejemplo `2024-11`, `2025-04`, etc.
+- La lógica actual parece tomar la cuota más reciente por `creado_en`, no necesariamente por `fecha_inicio` o vigencia real.
+
+Riesgo:
+
+- Si se crea o edita una cuota fuera de orden, tomar la última por `creado_en` puede no representar la cuota vigente.
+
+---
+
+### `historial_precios_cuota`
+
+Tabla de historial de precios.
+
+Columnas relevantes:
+
+- `id`
+- `id_socio`
+- `precio`
+- `fecha_inicio`
+- `fecha_fin`
+
+Estado observado:
+
+- La tabla tiene relación con `socio` mediante `id_socio`.
+- Existen registros asociados a socios específicos.
+
+Riesgo / decisión pendiente:
+
+- Hay que definir si el precio de cuota es global del gimnasio o individual por socio.
+- Si la cuota es global, esta tabla debería modelarse como historial global de precios.
+- Si existen precios especiales por socio, debe diferenciarse claramente entre precio base global y excepción/descuento individual.
+
+---
+
+### `pago`
+
+Tabla de pagos registrados.
+
+Columnas relevantes:
+
+- `id`
+- `socio_id`
+- `cuota_id`
+- `fecha_pago`
+- `monto_pagado`
+- `total` generado como `monto_pagado`
+- `registrado_por`
+- `fecha_vencimiento`
+- `enviar_email`
+- `creado_en`
+- `actualizado_en`
+
+Estado observado:
+
+- En el dump actualizado, la tabla `pago` no contiene registros de negocio cargados.
+- La tabla no tiene campos explícitos para `periodo_desde`, `periodo_hasta`, `meses_cubiertos`, `metodo_pago`, `estado`, `stripe_session_id`, ni `stripe_payment_intent_id`.
+- La tabla tampoco tiene columna `activo`, pero el servicio actual intenta hacer borrado lógico actualizando `{ activo: false }`.
+
+Riesgos:
+
+- El borrado de pagos puede fallar porque `pago.activo` no existe.
+- No se puede representar de manera limpia un pago adelantado o un pago que cubre varios meses.
+- No queda trazabilidad completa entre pago manual y pago Stripe.
+- El cálculo de cobertura depende de `fecha_vencimiento`, pero no hay `periodo_desde/periodo_hasta` explícitos.
+
+---
+
+### `socio`
+
+Tabla de socios.
+
+Columnas relevantes para esta auditoría:
+
+- `id_socio`
+- `usuario_id`
+- `nombre_completo`
+- `activo`
+- `fecha_alta`
+- `fecha_baja`
+- `descuento_activo`
+
+Estado observado:
+
+- Existe bandera `activo`.
+- Existe `descuento_activo`, actualmente usado en lógica de pagos.
+- No existe campo directo de estado de cuota; debe calcularse a partir de pagos/vencimientos.
+
+---
+
+### `asistencia`
+
+Tabla de asistencias.
+
+Columnas relevantes:
+
+- `socio_id`
+- `fecha`
+- `hora_ingreso`
+- `hora_egreso`
+
+Uso futuro:
+
+- Será clave para la regla de inactivación: si la cuota venció y el socio no registra asistencia durante una semana, puede pasar a inactivo hasta que pague y vuelva.
+
+---
+
+## 3. Servicios y APIs actuales detectados
+
+### APIs principales
+
+- `GET /api/cuota`
+- `POST /api/cuota`
+- `PUT /api/cuota`
+- `DELETE /api/cuota`
+- `GET /api/cuota/[id]`
+- `GET /api/pagos`
+- `POST /api/pagos`
+- `PUT /api/pagos`
+- `DELETE /api/pagos`
+- `GET /api/pagos/[id]`
+- `POST /api/pagar-cuota`
+- `POST /api/stripe-webhook`
+
+### Servicios relacionados
+
+- `src/services/cuotaService.ts`
+- `src/services/pagoService.ts`
+- `src/services/stripeService.ts`
+
+---
+
+## 4. Hallazgos de código
+
+### 4.1 Creación de pago manual
+
+`createPago` recibe `socio_id` y `registrado_por`. Luego:
+
+- busca la cuota más reciente,
+- calcula `fecha_pago` como hoy,
+- calcula `fecha_vencimiento` como hoy + 30 días,
+- toma el monto de la cuota,
+- aplica 10% de descuento si `socio.descuento_activo = true`,
+- inserta el pago,
+- desactiva `descuento_activo` en el socio.
+
+Riesgos:
+
+- No permite pagar varios meses.
+- No permite elegir período cubierto.
+- No usa explícitamente `fecha_inicio/fecha_fin` de la cuota para cobertura.
+- No contempla pagos adelantados de forma clara.
+- No deja trazabilidad del método de pago.
+
+---
+
+### 4.2 Pago Stripe
+
+`createSessionPago`:
+
+- obtiene la cuota más reciente,
+- obtiene socio desde usuario,
+- verifica último pago,
+- crea sesión Stripe,
+- guarda en metadata `socio_id` y `cuota_id`.
+
+`stripe-webhook`:
+
+- escucha `checkout.session.completed`,
+- obtiene `socio_id` desde metadata,
+- llama a `createPago`,
+- usa un `registrado_por` hardcodeado.
+
+Riesgos:
+
+- El webhook no usa `cuota_id` de metadata para registrar el pago.
+- El usuario registrador está hardcodeado.
+- No guarda `stripe_session_id` ni `payment_intent_id` en `pago`.
+- La lógica de `createPago` vuelve a buscar la última cuota, lo que puede no coincidir con la cuota que se pagó en Stripe.
+
+---
+
+### 4.3 Eliminación de pagos
+
+El servicio `deletePago` intenta:
+
+```ts
+supabase.from("pago").update({ activo: false })
+```
+
+Pero en el dump actualizado la tabla `pago` no tiene columna `activo`.
+
+Conclusión:
+
+- La eliminación de pagos probablemente falla o está incompleta.
+- Debe decidirse si `pago` tendrá borrado lógico con `activo`, `estado`, `anulado_en`, `anulado_por`, o si no se permitirá eliminar pagos por razones contables.
+
+---
+
+### 4.4 Formulario de pagos
+
+`PagoForm` contiene campos para:
+
+- `socio_id`,
+- `cuota_id`,
+- `fecha_pago`,
+- `fecha_vencimiento`,
+- `monto_pagado`,
+- `registrado_por`.
+
+Pero la API `POST /api/pagos` solo valida `socio_id` y `registrado_por`, y `createPago` ignora el resto.
+
+Riesgo:
+
+- Hay desalineación entre formulario, API, DTO y lógica real de negocio.
+
+---
+
+## 5. RPC / Data Science detectado
+
+Funciones relevantes detectadas:
+
+- `obtener_evolucion_cuota()`
+- `sp_analisis_conducta_pagos()`
+
+### `obtener_evolucion_cuota()`
+
+Devuelve evolución de monto por período usando `cuota.fecha_inicio` y `cuota.monto`.
+
+Uso recomendado:
+
+- gráfica de evolución histórica del precio de cuota en dashboard BI.
+
+### `sp_analisis_conducta_pagos()`
+
+Clasifica pagos por puntualidad/morosidad según diferencia entre `fecha_pago` y `fecha_vencimiento`.
+
+Riesgo:
+
+- Si `fecha_vencimiento` representa vencimiento posterior al pago, la fórmula puede no medir correctamente retrasos respecto al período adeudado.
+- La función depende de que existan registros reales en `pago`; actualmente el dump no trae pagos cargados.
+
+---
+
+## 6. Decisiones pendientes antes de desarrollo
+
+1. Definir si `cuota` representa un precio mensual global o una cuota concreta por período.
+2. Definir si `historial_precios_cuota` debe ser global o por socio.
+3. Definir cómo representar pagos que cubren varios meses.
+4. Definir si se agregan campos a `pago`:
+   - `periodo_desde`
+   - `periodo_hasta`
+   - `meses_cubiertos`
+   - `metodo_pago`
+   - `estado`
+   - `stripe_session_id`
+   - `stripe_payment_intent_id`
+   - `observaciones`
+5. Definir si los pagos pueden eliminarse o solo anularse.
+6. Definir la regla exacta de inactivación por vencimiento + asistencia.
+7. Definir cómo se mostrarán los vencidos en el dashboard inicial.
+
+---
+
+## 7. Recomendación técnica
+
+No implementar UI todavía. Primero conviene cerrar un sub-bloque de modelo de datos y reglas de negocio.
+
+Orden sugerido:
+
+1. Ejecutar diagnóstico SQL en local/remoto.
+2. Confirmar estado real de datos actuales.
+3. Diseñar migración controlada para extender `pago` o crear tabla complementaria.
+4. Probar migración con Supabase local.
+5. Crear seeds demo de pagos para socio hombre/mujer.
+6. Recién después corregir APIs y frontend.
+
+---
+
+## 8. Próxima rama/sub-bloque sugerido
+
+Dentro de `feature/cuotas-pagos-vencimientos`, el primer sub-bloque real debería ser:
+
+```txt
+modelo de pagos y cobertura de cuotas
+```
+
+Objetivo:
+
+- dejar el modelo preparado para efectivo, Stripe, pagos adelantados y cobertura multi-mes.

--- a/docs/informes/informe-ejecutivo-cuotas-pagos-auditoria.md
+++ b/docs/informes/informe-ejecutivo-cuotas-pagos-auditoria.md
@@ -1,0 +1,65 @@
+# Informe ejecutivo — Auditoría inicial de cuotas, pagos y vencimientos
+
+## Proyecto
+
+Gym Master
+
+## Rama
+
+`feature/cuotas-pagos-vencimientos`
+
+## Objetivo del bloque
+
+Iniciar la revisión técnica del módulo de cuotas, pagos y vencimientos antes de implementar cambios funcionales o migraciones de base de datos.
+
+## Contexto
+
+El módulo de cuotas y pagos es crítico para la operación del gimnasio. Debe permitir registrar pagos en efectivo desde administración, pagos online por Stripe, pagos adelantados, pagos que cubren varios meses y vencimientos de socios. Además, debe alimentar métricas de negocio como ingresos mensuales, morosidad, socios activos e historial de precios de cuota.
+
+## Estado actual detectado
+
+El sistema ya cuenta con tablas relacionadas con cuota, pago, socios, asistencia e historial de precios. También existen funciones de análisis como `obtener_evolucion_cuota()` y `sp_analisis_conducta_pagos()`.
+
+Sin embargo, el modelo actual todavía no parece cubrir todos los escenarios requeridos para producción:
+
+- pago adelantado,
+- pago de varios meses juntos,
+- trazabilidad completa de Stripe,
+- método de pago,
+- estado/anulación de pagos,
+- cobertura desde/hasta,
+- dashboard de socios vencidos.
+
+## Hallazgos relevantes
+
+1. La tabla `pago` no incluye campos explícitos de cobertura como `periodo_desde`, `periodo_hasta` o `meses_cubiertos`.
+2. La tabla `pago` no incluye `metodo_pago`, `estado`, `stripe_session_id` ni `stripe_payment_intent_id`.
+3. El servicio actual de eliminación de pagos intenta actualizar una columna `activo`, que no existe en la tabla `pago`.
+4. La lógica de pago manual calcula vencimiento como fecha actual + 30 días, sin modelar cobertura mensual de manera explícita.
+5. La lógica Stripe no guarda trazabilidad completa del evento de pago.
+6. El historial de precios está asociado a socios, por lo que debe definirse si se trata de precio global o precio individual.
+
+## Riesgos técnicos
+
+- Inconsistencia entre frontend, DTOs, APIs y modelo real de base de datos.
+- Posible falla al eliminar pagos.
+- Dificultad para calcular estado de cuota vencida de manera precisa.
+- Dificultad para soportar pagos adelantados o de varios meses.
+- Métricas BI incompletas por falta de datos reales de pagos.
+
+## Recomendación
+
+Antes de tocar UI, conviene cerrar una etapa de diseño técnico del modelo de pagos. Si se requieren cambios en base de datos, deberán implementarse como migraciones formales en `supabase/migrations`, probarse primero en Supabase local y recién luego aplicarse en remoto.
+
+## Próximo paso sugerido
+
+Diseñar e implementar una migración controlada para extender la tabla `pago` o agregar una estructura complementaria que permita:
+
+- método de pago,
+- estado/anulación,
+- cobertura desde/hasta,
+- meses cubiertos,
+- trazabilidad Stripe,
+- observaciones administrativas.
+
+Luego, crear seeds demo para validar pagos de un socio hombre y una socia mujer, incluyendo pagos en efectivo, Stripe, pagos vencidos y pagos adelantados.

--- a/docs/pr/pr-cuotas-pagos-vencimientos-auditoria.md
+++ b/docs/pr/pr-cuotas-pagos-vencimientos-auditoria.md
@@ -1,0 +1,62 @@
+# PR: Auditoría inicial de cuotas, pagos y vencimientos
+
+## Descripción
+
+Este PR incorpora una primera auditoría técnica del módulo de cuotas, pagos y vencimientos de Gym Master, tomando como base el estado actualizado del repositorio y del dump de base de datos `backup_completo_gym_master_20052026.sql`.
+
+El objetivo de este bloque es documentar el estado real antes de implementar cambios de lógica o migraciones, especialmente porque el módulo de pagos afecta reglas críticas del negocio: cuota vencida, socios activos/inactivos, pagos manuales, Stripe, pagos adelantados y métricas financieras.
+
+## Cambios incluidos
+
+- Se agrega documentación de auditoría para cuotas, pagos y vencimientos.
+- Se agrega script SQL de diagnóstico para revisar estructura, datos, RLS, policies, pagos, cuotas e historial de precios.
+- Se documentan hallazgos sobre el modelo actual de datos.
+- Se identifican riesgos actuales en servicios y APIs.
+- Se deja preparado el camino para una futura migración controlada con Supabase CLI.
+
+## Archivos agregados
+
+```txt
+database/scripts/diagnostico_cuotas_pagos_vencimientos.sql
+docs/cuotas-pagos/auditoria-cuotas-pagos-vencimientos.md
+docs/pr/pr-cuotas-pagos-vencimientos-auditoria.md
+docs/informes/informe-ejecutivo-cuotas-pagos-auditoria.md
+```
+
+## Hallazgos principales
+
+- La tabla `pago` no tiene registros cargados en el dump actualizado.
+- La tabla `pago` no tiene campos explícitos para período cubierto, meses cubiertos, método de pago, estado ni referencias Stripe.
+- El servicio actual de eliminación de pagos intenta actualizar `activo = false`, pero la tabla `pago` no posee columna `activo`.
+- El formulario de pagos solicita más campos de los que realmente usa la API.
+- Stripe crea una sesión con `socio_id` y `cuota_id`, pero el webhook vuelve a llamar a la lógica genérica de `createPago` y no conserva trazabilidad completa de Stripe.
+- Existe `obtener_evolucion_cuota()` para evolución histórica de precios.
+- Existe `sp_analisis_conducta_pagos()`, pero requiere pagos reales para generar métricas útiles.
+
+## Validaciones sugeridas
+
+Ejecutar el script de diagnóstico en Supabase local o remoto:
+
+```bash
+docker exec -i supabase_db_gym-master psql -U postgres -d postgres < database/scripts/diagnostico_cuotas_pagos_vencimientos.sql
+```
+
+También ejecutar:
+
+```bash
+npm run build
+```
+
+## Alcance
+
+Este PR es principalmente documental y de diagnóstico. No modifica todavía código productivo ni estructura de base de datos.
+
+## Próximos pasos
+
+- Diseñar modelo definitivo para pagos/cobertura de cuotas.
+- Definir si `historial_precios_cuota` será global o por socio.
+- Agregar migración formal si se requieren campos nuevos en `pago`.
+- Probar toda migración primero con Supabase local.
+- Corregir pago manual desde administrador.
+- Corregir trazabilidad de Stripe.
+- Incorporar dashboard de cuotas vencidas y métricas BI.


### PR DESCRIPTION
# PR: docs: audit membership fees payments and expirations - new

## Descripción

Este PR incorpora la primera auditoría técnica específica del módulo de **cuotas, pagos y vencimientos** de Gym Master.

El objetivo de este bloque es documentar el estado real del modelo actual antes de avanzar con cambios de base de datos, lógica de pagos, integración Stripe, dashboard de vencimientos o métricas de Business Intelligence.

No se introducen cambios funcionales en la aplicación ni migraciones productivas. Este PR agrega documentación y un script SQL de diagnóstico para identificar con precisión qué existe, qué está incompleto y qué debe corregirse en la siguiente etapa.

## Contexto

Gym Master ya fue migrado a una arquitectura **single-tenant por instancia**, eliminando la dependencia de `dbName`. También se corrigieron y estabilizaron funcionalidades clave de rutinas, incluyendo generación para niveles Inicial e Intermedio, migraciones con Supabase CLI y exportación profesional de rutinas a PDF.

Luego de cerrar esos bloques, el siguiente punto crítico del negocio es revisar la lógica de cuotas y pagos, ya que impacta directamente en:

- control de socios al día o vencidos,
- pagos manuales en efectivo,
- pagos online por Stripe,
- historial de precios de cuota,
- socios activos/inactivos,
- métricas de ingresos y morosidad,
- dashboard administrativo y BI.

## Archivos agregados

```txt
database/scripts/diagnostico_cuotas_pagos_vencimientos.sql
docs/cuotas-pagos/auditoria-cuotas-pagos-vencimientos.md
docs/pr/pr-cuotas-pagos-vencimientos-auditoria.md
docs/informes/informe-ejecutivo-cuotas-pagos-auditoria.md
```

## Hallazgos principales

### 1. Modelo actual de pagos

La tabla `pago` existe y contiene los campos base para registrar pagos:

- `socio_id`
- `cuota_id`
- `fecha_pago`
- `monto_pagado`
- `total`
- `registrado_por`
- `fecha_vencimiento`
- `enviar_email`

Sin embargo, todavía no cuenta con campos explícitos para cubrir correctamente los próximos casos de negocio:

- método de pago (`efectivo`, `stripe`, etc.),
- estado del pago (`pagado`, `pendiente`, `cancelado`, etc.),
- período cubierto desde/hasta,
- cantidad de meses cubiertos,
- pagos adelantados,
- pagos de varios meses juntos,
- trazabilidad Stripe (`stripe_session_id`, `stripe_payment_intent_id`),
- observaciones administrativas,
- borrado lógico mediante `activo`.

### 2. Tabla de pagos sin datos reales

Durante la auditoría se verificó que la tabla `pago` no tiene registros cargados en el entorno analizado. Por este motivo, todos los socios aparecen como `sin_pagos` al consultar su estado de cuota.

Esto impide validar correctamente vencimientos, morosidad, socios al día y métricas de pago hasta que se incorporen datos demo o registros reales.

### 3. Evolución histórica del precio de cuota

La tabla `cuota` contiene una evolución mensual de precios, por ejemplo:

```txt
2024-09 -> 15000.00
2024-10 -> 15500.00
2024-11 -> 16000.00
2024-12 -> 16500.00
2025-01 -> 17000.00
...
2025-08 -> 20500.00
```

Esto confirma que existe una base válida para alimentar dashboards de evolución de precio de cuota.

### 4. Bug detectado en función `obtener_evolucion_cuota()`

Al ejecutar el diagnóstico se detectó un error en la función:

```sql
public.obtener_evolucion_cuota()
```

Error detectado:

```txt
ERROR: 42702: column reference "monto" is ambiguous
```

Causa probable:

La función usa `monto` sin alias dentro de un `RETURN QUERY`, y PostgreSQL no puede determinar si se refiere a la columna de la tabla `cuota` o a la columna de retorno de la función.

Corrección propuesta para una próxima migración:

```sql
SELECT
  TO_CHAR(c.fecha_inicio, 'YYYY-MM')::text AS periodo,
  EXTRACT(YEAR FROM c.fecha_inicio)::integer AS anio,
  EXTRACT(MONTH FROM c.fecha_inicio)::integer AS mes,
  c.monto::numeric AS monto
FROM public.cuota c
WHERE c.fecha_inicio >= DATE '2024-09-01'
ORDER BY c.fecha_inicio;
```

### 5. Relación `historial_precios_cuota`

La tabla `historial_precios_cuota` tiene una relación opcional con `socio` mediante `id_socio`. Esto requiere revisión conceptual, ya que el historial de precio de cuota parece ser global del gimnasio, mientras que `id_socio` sugiere una lógica de precio individual.

Se recomienda revisar si esta tabla debe mantenerse como historial individual, historial global o si debe separarse en dos conceptos.

### 6. API pendiente `/api/cuota-estado`

En pruebas anteriores se detectó que `/api/cuota-estado` responde 404. Este endpoint será necesario para mostrar al socio y al administrador el estado actual de cuota.

Queda pendiente implementarlo o corregir su ruta/consumo.

## Validaciones realizadas

- Se revisó la estructura de tablas relacionadas con cuotas, pagos, socios y asistencias.
- Se revisaron constraints y relaciones entre tablas.
- Se identificaron funciones existentes relacionadas con cuotas/pagos.
- Se verificó que la tabla `cuota` tiene historial mensual de precios.
- Se detectó el error de ambigüedad en `obtener_evolucion_cuota()`.
- Se confirmó que no existen pagos reales cargados en la tabla `pago`.

## Alcance de este PR

Este PR es de **auditoría y documentación técnica**. No incluye:

- migraciones productivas,
- cambios en APIs,
- cambios en frontend,
- cambios en Stripe,
- modificación directa de datos remotos,
- implementación de vencimientos.

## Próximos pasos recomendados

Crear una nueva rama para el primer bloque funcional de corrección:

```bash
git checkout main
git pull origin main
git checkout -b feature/cuotas-pagos-foundation
```

Objetivos de la próxima rama:

1. Corregir `obtener_evolucion_cuota()` mediante migración formal.
2. Ampliar `pago` con campos para método, estado, período cubierto, meses cubiertos y trazabilidad Stripe.
3. Crear seeds demo de pagos para al menos un socio hombre y una socia mujer.
4. Validar todo primero con Supabase local.
5. Aplicar remoto con Supabase CLI solo después de validar local.
6. Implementar o corregir `/api/cuota-estado`.
7. Preparar base para dashboard de socios vencidos y métricas BI.

## Regla de base de datos

Cualquier cambio de base de datos derivado de esta auditoría deberá seguir el flujo acordado:

```txt
Supabase local -> validación SQL/RPC/RLS/seeds -> Supabase remoto -> migration list -> commit/push/PR
```

No se deben ejecutar cambios manuales directos en la base remota sin migración formal versionada.

## Título sugerido del PR

```txt
docs: audit membership fees payments and expirations
```
