### PR TITLE
test: add demo seeds for membership fees and payments

### DIFF
--- a/database/scripts/validar_cuotas_pagos_demo_seeds.sql
+++ b/database/scripts/validar_cuotas_pagos_demo_seeds.sql
@@ -1,0 +1,104 @@
+\echo '1. QA socios creados'
+SELECT
+  id_socio,
+  nombre_completo,
+  email,
+  activo,
+  fecha_alta
+FROM public.socio
+WHERE id_socio IN (
+  '00000000-0000-4000-8000-000000000801'::uuid,
+  '00000000-0000-4000-8000-000000000802'::uuid,
+  '00000000-0000-4000-8000-000000000803'::uuid,
+  '00000000-0000-4000-8000-000000000804'::uuid
+)
+ORDER BY nombre_completo;
+
+\echo '2. Pagos QA creados'
+SELECT
+  p.id,
+  s.nombre_completo,
+  p.fecha_pago,
+  p.fecha_vencimiento,
+  p.periodo_desde,
+  p.periodo_hasta,
+  p.meses_cubiertos,
+  p.metodo_pago,
+  p.estado,
+  p.monto_pagado,
+  p.total,
+  p.stripe_session_id,
+  p.activo
+FROM public.pago p
+JOIN public.socio s ON s.id_socio = p.socio_id
+WHERE p.id IN (
+  '00000000-0000-4000-8000-000000001001'::uuid,
+  '00000000-0000-4000-8000-000000001002'::uuid,
+  '00000000-0000-4000-8000-000000001003'::uuid
+)
+ORDER BY p.fecha_pago DESC;
+
+\echo '3. Estado de cuota por socio QA'
+SELECT *
+FROM public.obtener_socios_estado_cuota()
+WHERE id_socio IN (
+  '00000000-0000-4000-8000-000000000801'::uuid,
+  '00000000-0000-4000-8000-000000000802'::uuid,
+  '00000000-0000-4000-8000-000000000803'::uuid,
+  '00000000-0000-4000-8000-000000000804'::uuid
+)
+ORDER BY nombre_completo;
+
+\echo '4. Resumen por estado de cuota'
+SELECT
+  estado_cuota,
+  COUNT(*) AS cantidad_socios
+FROM public.obtener_socios_estado_cuota()
+WHERE id_socio IN (
+  '00000000-0000-4000-8000-000000000801'::uuid,
+  '00000000-0000-4000-8000-000000000802'::uuid,
+  '00000000-0000-4000-8000-000000000803'::uuid,
+  '00000000-0000-4000-8000-000000000804'::uuid
+)
+GROUP BY estado_cuota
+ORDER BY estado_cuota;
+
+\echo '5. Resumen por método de pago'
+SELECT
+  metodo_pago,
+  COUNT(DISTINCT socio_id) AS cantidad_socios,
+  SUM(monto_pagado) AS total_pagado
+FROM public.pago
+WHERE id IN (
+  '00000000-0000-4000-8000-000000001001'::uuid,
+  '00000000-0000-4000-8000-000000001002'::uuid,
+  '00000000-0000-4000-8000-000000001003'::uuid
+)
+GROUP BY metodo_pago
+ORDER BY metodo_pago;
+
+\echo '6. Función Data Science de conducta de pagos - disponibilidad'
+SELECT
+  EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'sp_analisis_conducta_pagos'
+  ) AS existe_sp_analisis_conducta_pagos;
+
+\echo '7. Data Science conducta de pagos - QA si existe'
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'sp_analisis_conducta_pagos'
+  ) THEN
+    RAISE NOTICE 'sp_analisis_conducta_pagos existe. Ejecutar consulta específica en remoto si se requiere.';
+  ELSE
+    RAISE NOTICE 'sp_analisis_conducta_pagos no existe en este baseline local. Validación no bloqueante.';
+  END IF;
+END $$;

--- a/docs/cuotas-pagos/seeds-demo-cuotas-pagos.md
+++ b/docs/cuotas-pagos/seeds-demo-cuotas-pagos.md
@@ -1,0 +1,79 @@
+# Seeds demo de cuotas, pagos y vencimientos
+
+## Objetivo
+
+Esta rama incorpora datos QA determinísticos para probar el nuevo foundation de cuotas/pagos sin depender de datos reales de clientes.
+
+Los seeds permiten validar:
+
+- socio al día;
+- socio con pago adelantado por varios meses;
+- socio vencido;
+- socio sin pagos;
+- pago en efectivo;
+- pago Stripe simulado;
+- lectura desde `obtener_socios_estado_cuota()`;
+- base para futuros dashboards de morosidad, pagos e ingresos.
+
+## Migración incluida
+
+```txt
+supabase/migrations/202605201620_cuotas_pagos_demo_seeds.sql
+```
+
+La migración es idempotente y usa UUIDs determinísticos para evitar duplicados.
+
+## Socios QA creados
+
+| Caso | Socio | Estado esperado |
+|---|---|---|
+| Pago efectivo actual | QA Socio Al Dia | al_dia |
+| Pago Stripe adelantado | QA Socia Adelantada | al_dia |
+| Pago antiguo vencido | QA Socio Vencido | vencido |
+| Sin pago | QA Socia Sin Pago | sin_pagos |
+
+## Pagos QA
+
+La migración crea tres pagos:
+
+1. Pago en efectivo de un mes.
+2. Pago Stripe simulado de tres meses por adelantado.
+3. Pago vencido para validar morosidad.
+
+No se inserta manualmente la columna `pago.total`, porque en la base actual es una columna generada.
+
+## Validación
+
+Script incluido:
+
+```txt
+database/scripts/validar_cuotas_pagos_demo_seeds.sql
+```
+
+Validaciones principales:
+
+- socios QA existentes;
+- pagos QA existentes;
+- estados de cuota por socio;
+- resumen por estado;
+- resumen por método de pago;
+- salida parcial de `sp_analisis_conducta_pagos()`.
+
+## Flujo operativo obligatorio
+
+1. Aplicar el paquete en la rama `feature/cuotas-pagos-demo-seeds`.
+2. Probar la migración en Supabase local.
+3. Ejecutar el script de validación.
+4. Si pasa correctamente, aplicar remoto con Supabase CLI.
+5. Confirmar historial con `npx supabase migration list`.
+6. Hacer commit, push, PR e informe técnico.
+
+## Próximo paso después de esta rama
+
+Con los datos QA disponibles, el siguiente bloque recomendado será construir el endpoint faltante y/o dashboard:
+
+```txt
+feature/cuota-estado-api-dashboard
+```
+
+Objetivo: exponer y mostrar en la app el estado de cuota del socio y el listado de socios vencidos o sin pagos.

--- a/docs/informes/informe-ejecutivo-cuotas-pagos-demo-seeds.md
+++ b/docs/informes/informe-ejecutivo-cuotas-pagos-demo-seeds.md
@@ -1,0 +1,47 @@
+# Informe técnico - Seeds demo de cuotas, pagos y vencimientos
+
+## Resumen ejecutivo
+
+Se incorpora una base de datos QA determinística para validar el módulo de cuotas, pagos y vencimientos de Gym Master. Esta etapa permite probar los estados reales de cuota sin depender de pagos reales cargados por usuarios.
+
+## Contexto
+
+La rama anterior dejó preparada la estructura de pagos con campos para período cubierto, método de pago, estado, trazabilidad Stripe y funciones de estado de cuota. Sin embargo, la base remota no tenía pagos reales cargados, por lo que todos los socios aparecían como `sin_pagos`.
+
+## Solución implementada
+
+Se agrega una migración con datos QA para los casos operativos principales:
+
+- socio al día con pago en efectivo;
+- socia con pago adelantado por tres meses mediante Stripe simulado;
+- socio vencido;
+- socia sin pagos.
+
+También se agregan cuotas QA y asistencias mínimas para futuras reglas de inactividad.
+
+## Archivos agregados
+
+- `supabase/migrations/202605201620_cuotas_pagos_demo_seeds.sql`
+- `database/scripts/validar_cuotas_pagos_demo_seeds.sql`
+- `docs/cuotas-pagos/seeds-demo-cuotas-pagos.md`
+- `docs/pr/pr-cuotas-pagos-demo-seeds.md`
+- `docs/informes/informe-ejecutivo-cuotas-pagos-demo-seeds.md`
+
+## Validación esperada
+
+El script de validación permite confirmar:
+
+- creación de socios QA;
+- creación de pagos QA;
+- estado de cuota por socio;
+- resumen por estado;
+- resumen por método de pago;
+- compatibilidad con la función de Data Science `sp_analisis_conducta_pagos()`.
+
+## Impacto
+
+Este bloque no modifica la UI, pero desbloquea el trabajo del dashboard y de los endpoints de cuota. A partir de estos datos, se podrán desarrollar y probar pantallas con socios al día, vencidos, sin pagos y pagos adelantados.
+
+## Próximo paso recomendado
+
+Implementar la rama `feature/cuota-estado-api-dashboard`, orientada a exponer el estado de cuota desde API y mostrarlo en el dashboard de inicio/administración.

--- a/docs/pr/pr-cuotas-pagos-demo-seeds.md
+++ b/docs/pr/pr-cuotas-pagos-demo-seeds.md
@@ -1,0 +1,55 @@
+## Descripción
+
+Este PR incorpora seeds demo para validar el foundation de cuotas, pagos y vencimientos de Gym Master.
+
+La rama crea datos QA determinísticos para cubrir los principales escenarios operativos del gimnasio: socio al día, socio con pago adelantado, socio vencido y socio sin pagos.
+
+## Cambios incluidos
+
+- Se agrega la migración `202605201620_cuotas_pagos_demo_seeds.sql`.
+- Se crean usuarios y socios QA determinísticos.
+- Se crean cuotas QA para períodos de prueba.
+- Se crean pagos QA en efectivo y Stripe simulado.
+- Se agrega un caso de pago adelantado de tres meses.
+- Se agrega un caso de pago vencido.
+- Se conserva un caso sin pagos para validar estado `sin_pagos`.
+- Se agregan asistencias QA mínimas para futuras reglas de inactividad.
+- Se agrega script de validación SQL.
+- Se documenta el uso de estos seeds para futuras tareas de dashboard y API.
+
+## Validaciones esperadas
+
+El script de validación debe confirmar:
+
+- existencia de los socios QA;
+- existencia de pagos QA;
+- estados correctos desde `obtener_socios_estado_cuota()`;
+- resumen por estado de cuota;
+- resumen por método de pago;
+- compatibilidad con `sp_analisis_conducta_pagos()`.
+
+## Alcance
+
+Este PR no implementa todavía UI ni endpoints nuevos. Su objetivo es preparar datos confiables para probar los próximos bloques funcionales:
+
+- `/api/cuota-estado`;
+- dashboard de socios vencidos;
+- dashboard BI de pagos/cuotas;
+- validación de pago manual;
+- validación de flujo Stripe.
+
+## Notas técnicas
+
+- No se inserta manualmente la columna `pago.total` porque es una columna generada.
+- La migración usa `ON CONFLICT` para ser segura ante reejecuciones.
+- Los datos son QA y pueden distinguirse por emails `@gymmaster.local` y DNIs `QA-PAGO-*`.
+
+## Próximo paso recomendado
+
+Crear la rama:
+
+```bash
+feature/cuota-estado-api-dashboard
+```
+
+para exponer y visualizar el estado de cuota de cada socio.

--- a/supabase/migrations/202605201620_cuotas_pagos_demo_seeds.sql
+++ b/supabase/migrations/202605201620_cuotas_pagos_demo_seeds.sql
@@ -1,0 +1,243 @@
+-- -----------------------------------------------------------------------------
+-- Gym Master - Demo seeds for membership fees and payments
+-- Migration: 202605201620_cuotas_pagos_demo_seeds.sql
+-- Purpose:
+--   Creates deterministic QA users, members, fee and payments to validate:
+--   - member up to date
+--   - member paid ahead
+--   - expired member
+--   - member without payments
+--   - cash and simulated Stripe payments
+-- Notes:
+--   - Does NOT call crypt() or gen_salt(); password_hash is a fixed bcrypt string.
+--   - Does NOT insert into public.asistencia; minimal local baselines may not include it.
+--   - Does NOT insert/update pago.total because it may be a generated column.
+-- -----------------------------------------------------------------------------
+
+-- Common demo password reference: GymMaster2026!
+-- This hash is only for QA/demo users and should not be used for production users.
+WITH constants AS (
+  SELECT
+    '$2a$10$7zJ7Pj2x2zI2L4l8VfJj1uSvZHvHdzdDaTxLqE0vQ9TR5w3EyQcfK'::text AS demo_password_hash
+)
+INSERT INTO public.usuario (
+  id,
+  nombre,
+  email,
+  password_hash,
+  rol,
+  activo
+)
+SELECT *
+FROM (
+  SELECT '00000000-0000-4000-8000-000000000700'::uuid, 'QA Admin Pagos', 'qa.admin.pagos@gymmaster.local', demo_password_hash, 'admin', true FROM constants
+  UNION ALL
+  SELECT '00000000-0000-4000-8000-000000000701'::uuid, 'QA Socio Al Dia', 'qa.socio.aldia@gymmaster.local', demo_password_hash, 'socio', true FROM constants
+  UNION ALL
+  SELECT '00000000-0000-4000-8000-000000000702'::uuid, 'QA Socia Adelantada', 'qa.socia.adelantada@gymmaster.local', demo_password_hash, 'socio', true FROM constants
+  UNION ALL
+  SELECT '00000000-0000-4000-8000-000000000703'::uuid, 'QA Socio Vencido', 'qa.socio.vencido@gymmaster.local', demo_password_hash, 'socio', true FROM constants
+  UNION ALL
+  SELECT '00000000-0000-4000-8000-000000000704'::uuid, 'QA Socia Sin Pagos', 'qa.socia.sinpagos@gymmaster.local', demo_password_hash, 'socio', true FROM constants
+) AS v(id, nombre, email, password_hash, rol, activo)
+ON CONFLICT (id) DO UPDATE
+SET
+  nombre = EXCLUDED.nombre,
+  email = EXCLUDED.email,
+  password_hash = EXCLUDED.password_hash,
+  rol = EXCLUDED.rol,
+  activo = EXCLUDED.activo,
+  actualizado_en = CURRENT_TIMESTAMP;
+
+INSERT INTO public.socio (
+  id_socio,
+  usuario_id,
+  nombre_completo,
+  dni,
+  direccion,
+  telefono,
+  activo,
+  fecha_alta,
+  email
+)
+VALUES
+  (
+    '00000000-0000-4000-8000-000000000801',
+    '00000000-0000-4000-8000-000000000701',
+    'QA Socio Al Dia',
+    'QA-PAGOS-801',
+    'Dirección QA 801',
+    '3810000801',
+    true,
+    CURRENT_DATE - INTERVAL '90 days',
+    'qa.socio.aldia@gymmaster.local'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000802',
+    '00000000-0000-4000-8000-000000000702',
+    'QA Socia Adelantada',
+    'QA-PAGOS-802',
+    'Dirección QA 802',
+    '3810000802',
+    true,
+    CURRENT_DATE - INTERVAL '120 days',
+    'qa.socia.adelantada@gymmaster.local'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000803',
+    '00000000-0000-4000-8000-000000000703',
+    'QA Socio Vencido',
+    'QA-PAGOS-803',
+    'Dirección QA 803',
+    '3810000803',
+    true,
+    CURRENT_DATE - INTERVAL '180 days',
+    'qa.socio.vencido@gymmaster.local'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000804',
+    '00000000-0000-4000-8000-000000000704',
+    'QA Socia Sin Pagos',
+    'QA-PAGOS-804',
+    'Dirección QA 804',
+    '3810000804',
+    true,
+    CURRENT_DATE - INTERVAL '45 days',
+    'qa.socia.sinpagos@gymmaster.local'
+  )
+ON CONFLICT (id_socio) DO UPDATE
+SET
+  usuario_id = EXCLUDED.usuario_id,
+  nombre_completo = EXCLUDED.nombre_completo,
+  dni = EXCLUDED.dni,
+  direccion = EXCLUDED.direccion,
+  telefono = EXCLUDED.telefono,
+  activo = EXCLUDED.activo,
+  fecha_alta = EXCLUDED.fecha_alta,
+  email = EXCLUDED.email,
+  actualizado_en = CURRENT_TIMESTAMP;
+
+INSERT INTO public.cuota (
+  id,
+  descripcion,
+  monto,
+  periodo,
+  fecha_inicio,
+  fecha_fin,
+  activo
+)
+VALUES (
+  '00000000-0000-4000-8000-000000000900',
+  'Cuota mensual QA pagos',
+  20500.00,
+  TO_CHAR(CURRENT_DATE, 'YYYY-MM'),
+  DATE_TRUNC('month', CURRENT_DATE)::date,
+  (DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month - 1 day')::date,
+  true
+)
+ON CONFLICT (id) DO UPDATE
+SET
+  descripcion = EXCLUDED.descripcion,
+  monto = EXCLUDED.monto,
+  periodo = EXCLUDED.periodo,
+  fecha_inicio = EXCLUDED.fecha_inicio,
+  fecha_fin = EXCLUDED.fecha_fin,
+  activo = EXCLUDED.activo,
+  actualizado_en = CURRENT_TIMESTAMP;
+
+INSERT INTO public.pago (
+  id,
+  socio_id,
+  cuota_id,
+  fecha_pago,
+  monto_pagado,
+  registrado_por,
+  fecha_vencimiento,
+  enviar_email,
+  periodo_desde,
+  periodo_hasta,
+  meses_cubiertos,
+  metodo_pago,
+  estado,
+  stripe_session_id,
+  stripe_payment_intent_id,
+  observaciones,
+  activo
+)
+VALUES
+  (
+    '00000000-0000-4000-8000-000000001001',
+    '00000000-0000-4000-8000-000000000801',
+    '00000000-0000-4000-8000-000000000900',
+    CURRENT_DATE - INTERVAL '5 days',
+    20500.00,
+    '00000000-0000-4000-8000-000000000700',
+    CURRENT_DATE + INTERVAL '25 days',
+    false,
+    CURRENT_DATE - INTERVAL '5 days',
+    CURRENT_DATE + INTERVAL '25 days',
+    1,
+    'efectivo',
+    'pagado',
+    NULL,
+    NULL,
+    'Pago QA efectivo al día',
+    true
+  ),
+  (
+    '00000000-0000-4000-8000-000000001002',
+    '00000000-0000-4000-8000-000000000802',
+    '00000000-0000-4000-8000-000000000900',
+    CURRENT_DATE,
+    61500.00,
+    '00000000-0000-4000-8000-000000000700',
+    CURRENT_DATE + INTERVAL '3 months',
+    false,
+    CURRENT_DATE,
+    CURRENT_DATE + INTERVAL '3 months',
+    3,
+    'stripe',
+    'pagado',
+    'cs_test_gymmaster_demo_000000001002',
+    'pi_test_gymmaster_demo_000000001002',
+    'Pago QA Stripe simulado adelantado por 3 meses',
+    true
+  ),
+  (
+    '00000000-0000-4000-8000-000000001003',
+    '00000000-0000-4000-8000-000000000803',
+    '00000000-0000-4000-8000-000000000900',
+    CURRENT_DATE - INTERVAL '70 days',
+    20500.00,
+    '00000000-0000-4000-8000-000000000700',
+    CURRENT_DATE - INTERVAL '40 days',
+    false,
+    CURRENT_DATE - INTERVAL '70 days',
+    CURRENT_DATE - INTERVAL '40 days',
+    1,
+    'efectivo',
+    'pagado',
+    NULL,
+    NULL,
+    'Pago QA vencido para validar mora',
+    true
+  )
+ON CONFLICT (id) DO UPDATE
+SET
+  socio_id = EXCLUDED.socio_id,
+  cuota_id = EXCLUDED.cuota_id,
+  fecha_pago = EXCLUDED.fecha_pago,
+  monto_pagado = EXCLUDED.monto_pagado,
+  registrado_por = EXCLUDED.registrado_por,
+  fecha_vencimiento = EXCLUDED.fecha_vencimiento,
+  enviar_email = EXCLUDED.enviar_email,
+  periodo_desde = EXCLUDED.periodo_desde,
+  periodo_hasta = EXCLUDED.periodo_hasta,
+  meses_cubiertos = EXCLUDED.meses_cubiertos,
+  metodo_pago = EXCLUDED.metodo_pago,
+  estado = EXCLUDED.estado,
+  stripe_session_id = EXCLUDED.stripe_session_id,
+  stripe_payment_intent_id = EXCLUDED.stripe_payment_intent_id,
+  observaciones = EXCLUDED.observaciones,
+  activo = EXCLUDED.activo,
+  actualizado_en = CURRENT_TIMESTAMP;


### PR DESCRIPTION
# PR: test: add demo seeds for membership fees and payments

## Resumen

Este PR incorpora una migración de datos demo para el módulo de cuotas, pagos y vencimientos de Gym Master. El objetivo es contar con información QA consistente para validar los estados de cuota, métodos de pago, pagos adelantados y futuros dashboards/BI de cobranza.

La rama trabajada es:

```bash
feature/cuotas-pagos-demo-seeds
```

## Contexto

En la rama anterior `feature/cuotas-pagos-foundation` se dejó preparada la base técnica del módulo de cuotas/pagos:

- Corrección de `obtener_evolucion_cuota()`.
- Nuevas columnas en `public.pago` para `periodo_desde`, `periodo_hasta`, `meses_cubiertos`, `metodo_pago`, `estado`, trazabilidad Stripe, observaciones y activo.
- Nuevas funciones para consultar estado de cuota por socio.

Sin datos de prueba, el dashboard y las APIs de cuotas no tenían forma de mostrar escenarios reales como socios al día, vencidos, sin pagos o con pago adelantado. Este PR cubre esa necesidad.

## Cambios incluidos

### Migración agregada

```txt
supabase/migrations/202605201620_cuotas_pagos_demo_seeds.sql
```

La migración crea datos QA idempotentes para:

- `QA Socio Al Dia`.
- `QA Socia Adelantada`.
- `QA Socio Vencido`.
- `QA Socia Sin Pagos`.

También inserta pagos demo para:

- Pago efectivo al día.
- Pago Stripe simulado adelantado por 3 meses.
- Pago efectivo vencido.
- Socia sin pagos para validar estado `sin_pagos`.

### Script de validación agregado

```txt
database/scripts/validar_cuotas_pagos_demo_seeds.sql
```

El script valida:

- Creación de socios QA.
- Creación de pagos QA.
- Estado de cuota por socio.
- Resumen por estado de cuota.
- Resumen por método de pago.
- Disponibilidad de `sp_analisis_conducta_pagos()` como validación no bloqueante.

### Documentación agregada

```txt
docs/cuotas-pagos/seeds-demo-cuotas-pagos.md
docs/pr/pr-cuotas-pagos-demo-seeds.md
docs/informes/informe-ejecutivo-cuotas-pagos-demo-seeds.md
```

## Validaciones realizadas

### Supabase local

Se validó primero en Supabase local con:

```bash
npx supabase stop --no-backup
npx supabase start -x storage-api -x imgproxy -x studio -x logflare
docker exec -i supabase_db_gym-master psql -U postgres -d postgres < database/scripts/validar_cuotas_pagos_demo_seeds.sql
```

Resultado local esperado y obtenido:

| Escenario | Resultado |
|---|---|
| Socios QA creados | 4 socios |
| Pagos QA creados | 3 pagos |
| Socios al día | 2 |
| Socios vencidos | 1 |
| Socios sin pagos | 1 |
| Pagos efectivo | 2 pagos / 41000.00 |
| Pagos Stripe simulado | 1 pago / 61500.00 |

La función `sp_analisis_conducta_pagos()` no existe en el baseline local mínimo, por lo que el script la trata como validación no bloqueante.

### Supabase remoto

La migración fue aplicada en remoto mediante Supabase CLI y validada con consultas sobre `obtener_socios_estado_cuota()`.

Resultado remoto validado:

| Socio QA | Estado | Método | Meses cubiertos |
|---|---|---|---:|
| QA Socia Adelantada | al_dia | stripe | 3 |
| QA Socio Al Dia | al_dia | efectivo | 1 |
| QA Socio Vencido | vencido | efectivo | 1 |
| QA Socia Sin Pagos | sin_pagos | null | null |

Resumen remoto por método:

| Método | Estado | Cantidad | Total pagado |
|---|---|---:|---:|
| efectivo | pagado | 2 | 41000.00 |
| stripe | pagado | 1 | 61500.00 |

## Consideraciones técnicas

- La migración es idempotente y utiliza UUIDs controlados para escenarios QA.
- No inserta registros en `public.asistencia` para mantener compatibilidad con el baseline local mínimo.
- No usa `crypt()` ni `gen_salt()` para evitar diferencias de extensiones/search_path entre local y remoto.
- Se utiliza un hash fijo de contraseña para usuarios demo.
- Los datos son de QA y deben ser identificables por el prefijo `QA`.

## Impacto

Este PR permite probar y construir con datos reales los próximos bloques:

- Dashboard de cuotas y pagos.
- API de estado de cuota.
- Cards de socios vencidos, al día y sin pagos.
- BI de métodos de pago.
- Morosidad y comportamiento de pago.
- Validación de pagos adelantados.

## Riesgos

- Los datos QA quedan en remoto; deben mantenerse claramente identificados y evitar mezclarlos con clientes reales.
- La contraseña demo debe considerarse solo para entornos de desarrollo/QA.
- En una futura etapa productiva se podrá mover este seed a un entorno demo o marcarlo explícitamente como dataset de prueba.

## Checklist

- [x] Migración creada en `supabase/migrations`.
- [x] Validación local con Supabase CLI.
- [x] Migración aplicada en remoto con `supabase db push`.
- [x] Validación remota de estados de cuota.
- [x] Validación remota por método de pago.
- [x] Documentación agregada.
- [x] Rama pusheada para PR.

## Próximos pasos sugeridos

Luego de este PR, el siguiente bloque recomendado es:

```bash
feature/cuota-estado-api-dashboard
```

Objetivo: exponer el estado de cuota desde API y comenzar a mostrar en dashboard los socios al día, vencidos y sin pagos.
