### PR TITLE
feat: add membership fee status API and dashboard

### DIFF
--- a/docs/cuotas-pagos/cuota-estado-api-dashboard.md
+++ b/docs/cuotas-pagos/cuota-estado-api-dashboard.md
@@ -1,0 +1,116 @@
+# Cuotas y pagos: API de estado de cuota y dashboard administrativo
+
+## Objetivo
+
+Esta feature conecta la base de cuotas/pagos preparada en ramas anteriores con la aplicación web de Gym Master.
+
+El sistema ya cuenta con:
+
+- `obtener_estado_cuota_socio(p_id_socio uuid)`
+- `obtener_socios_estado_cuota()`
+- datos QA para socios al día, vencidos, sin pagos, pagos en efectivo y Stripe simulado
+
+Con esta rama se exponen esos datos mediante API Routes y se muestran en el dashboard administrativo.
+
+## Endpoints agregados
+
+### `GET /api/cuota-estado`
+
+Endpoint general para consultar estado de cuota.
+
+Comportamiento:
+
+- Si el usuario logueado es `socio`, devuelve el estado de cuota de su propio `id_socio`.
+- Si el usuario logueado es `admin` o `usuario` y envía `?socio_id=...`, devuelve el estado del socio solicitado.
+- Si el usuario logueado es `admin` o `usuario` y no envía `socio_id`, devuelve el resumen administrativo completo.
+
+### `GET /api/admin/cuotas/estado-socios`
+
+Endpoint administrativo para dashboard.
+
+Devuelve:
+
+- resumen general de estados de cuota
+- listado completo de socios con estado de cuota
+- socios vencidos
+- socios sin pagos
+- socios próximos a vencer
+- resumen de pagos por método
+
+### `GET /api/admin/cuotas/resumen`
+
+Endpoint administrativo reducido para futuras cards o widgets.
+
+Devuelve:
+
+- resumen
+- pagos por método
+- socios vencidos
+- socios sin pagos
+- socios próximos a vencer
+
+## Servicios agregados
+
+### `src/services/server/cuotaEstadoServerService.ts`
+
+Servicio server-side que usa `SUPABASE_SERVICE_ROLE_KEY` desde API Routes.
+
+Funciones principales:
+
+- `getEstadoCuotaSocioServer()`
+- `getSociosEstadoCuotaServer()`
+- `getPagosPorMetodoServer()`
+- `getAdminCuotasEstadoServer()`
+
+## Frontend agregado
+
+### `src/components/dashboard/cuotas/CuotasEstadoDashboard.tsx`
+
+Componente de dashboard para administradores.
+
+Muestra:
+
+- total de socios
+- socios al día
+- socios vencidos
+- socios sin pagos
+- total cobrado por método
+- tabla de socios con atención requerida
+- pagos agrupados por método
+
+## Archivos modificados
+
+- `src/app/dashboard/page.tsx`
+- `src/services/apiClient.ts`
+
+## Archivos nuevos
+
+- `src/interfaces/cuotaEstado.interface.ts`
+- `src/services/server/cuotaEstadoServerService.ts`
+- `src/app/api/cuota-estado/route.ts`
+- `src/app/api/admin/cuotas/estado-socios/route.ts`
+- `src/app/api/admin/cuotas/resumen/route.ts`
+- `src/components/dashboard/cuotas/CuotasEstadoDashboard.tsx`
+
+## Validaciones sugeridas
+
+1. Login como administrador.
+2. Entrar al dashboard.
+3. Confirmar sección `Estado de cuotas`.
+4. Confirmar que aparecen los datos QA:
+   - `QA Socio Al Dia` como `al_dia`
+   - `QA Socia Adelantada` como `al_dia`
+   - `QA Socio Vencido` como `vencido`
+   - `QA Socia Sin Pagos` como `sin_pagos`
+5. Probar endpoint `/api/cuota-estado` con usuario socio.
+6. Probar endpoint `/api/admin/cuotas/estado-socios` con usuario admin.
+7. Ejecutar `npm run build`.
+
+## Próximos pasos
+
+Esta feature deja visible la lógica de cuotas en dashboard. Los siguientes bloques recomendados son:
+
+- pago manual desde administrador usando los nuevos campos de `pago`
+- integración final de Stripe/webhook con `periodo_desde`, `periodo_hasta`, `metodo_pago` y `estado`
+- reglas operativas para socios vencidos e inactivación automática
+- BI avanzado de cuotas y pagos

--- a/docs/informes/informe-ejecutivo-cuota-estado-api-dashboard.md
+++ b/docs/informes/informe-ejecutivo-cuota-estado-api-dashboard.md
@@ -1,0 +1,77 @@
+# Informe técnico: API y dashboard de estado de cuotas
+
+## Proyecto
+
+Gym Master
+
+## Rama
+
+`feature/cuota-estado-api-dashboard`
+
+## Objetivo
+
+Implementar la capa de aplicación para visualizar estados de cuota y pagos desde el dashboard administrativo.
+
+## Contexto
+
+En etapas anteriores se preparó la base de datos para gestionar pagos, vencimientos y cobertura de cuotas. También se crearon datos QA con distintos escenarios: socios al día, vencidos, sin pagos, pagos en efectivo y pago Stripe simulado.
+
+Esta rama conecta esa información con el sistema web.
+
+## Cambios realizados
+
+### Backend
+
+Se incorporaron API Routes para consultar estados de cuota:
+
+- `/api/cuota-estado`
+- `/api/admin/cuotas/estado-socios`
+- `/api/admin/cuotas/resumen`
+
+También se agregó un servicio server-side para centralizar la lógica de consulta contra Supabase y mantener la service role key fuera del navegador.
+
+### Frontend
+
+Se agregó una sección `Estado de cuotas` dentro del dashboard administrativo.
+
+La sección muestra:
+
+- total de socios
+- socios al día
+- socios vencidos
+- socios sin pagos
+- monto total cobrado según pagos disponibles
+- tabla de socios con atención requerida
+- resumen de pagos por método
+
+### Tipado
+
+Se agregó una interfaz específica para normalizar y tipar estados de cuota, resumen administrativo y pagos agrupados por método.
+
+## Impacto funcional
+
+El administrador ahora puede visualizar rápidamente qué socios están al día, cuáles tienen cuota vencida y cuáles no registran pagos.
+
+Esto prepara el camino para bloquear o advertir ingresos al gimnasio, generar métricas comerciales y construir BI de cuotas/pagos.
+
+## Validaciones recomendadas
+
+- Ejecutar `npm run build`.
+- Validar login de administrador.
+- Revisar dashboard principal.
+- Confirmar que los datos QA se visualizan correctamente.
+- Probar endpoints protegidos con token.
+
+## Riesgos y observaciones
+
+- El dashboard depende de las funciones SQL creadas en la foundation de cuotas/pagos.
+- Si no existen datos de pago, los socios aparecerán como `sin_pagos`.
+- Los datos QA deben usarse para prueba, demo y desarrollo; en producción real se puede decidir si mantenerlos o eliminarlos.
+
+## Próximos pasos recomendados
+
+1. Implementar pago manual desde administrador usando el modelo foundation.
+2. Integrar Stripe/webhook con los nuevos campos de pago.
+3. Agregar reglas de inactivación por cuota vencida y ausencia de asistencia.
+4. Extender BI de pagos y cuotas en dashboard.
+5. Agregar filtros por estado, método de pago y rango de fechas.

--- a/docs/pr/pr-cuota-estado-api-dashboard.md
+++ b/docs/pr/pr-cuota-estado-api-dashboard.md
@@ -1,0 +1,68 @@
+# PR: feature/cuota-estado-api-dashboard
+
+## Resumen
+
+Este PR implementa la primera visualización operativa de cuotas/pagos dentro del dashboard administrativo de Gym Master.
+
+A partir de la foundation de pagos/cuotas y de los seeds QA ya validados, se agregan endpoints para consultar estados de cuota y un componente visual en el dashboard para mostrar socios al día, vencidos, sin pagos, pagos por método y socios con atención requerida.
+
+## Cambios principales
+
+### API Routes
+
+- Se agrega `GET /api/cuota-estado`.
+- Se agrega `GET /api/admin/cuotas/estado-socios`.
+- Se agrega `GET /api/admin/cuotas/resumen`.
+
+### Backend server-side
+
+- Se agrega `src/services/server/cuotaEstadoServerService.ts`.
+- Se consumen las funciones SQL:
+  - `obtener_estado_cuota_socio(p_id_socio uuid)`
+  - `obtener_socios_estado_cuota()`
+- Se agrega agrupación server-side de pagos por método.
+- Se agrega resumen administrativo de estados de cuota.
+
+### Frontend
+
+- Se agrega `CuotasEstadoDashboard` en el dashboard administrativo.
+- Se agregan cards de:
+  - total socios
+  - al día
+  - vencidos
+  - sin pagos
+  - total cobrado
+- Se agrega tabla de socios con atención requerida.
+- Se agrega resumen de pagos por método.
+
+### Cliente API
+
+Se agregan helpers en `src/services/apiClient.ts`:
+
+- `getCuotaEstado()`
+- `getAdminCuotasEstadoSocios()`
+- `getAdminCuotasResumen()`
+
+## Contexto técnico
+
+Esta feature se apoya en ramas previas donde ya se implementó:
+
+- ampliación de tabla `pago`
+- funciones de estado de cuota
+- seeds QA para socios al día, vencidos, sin pagos, efectivo y Stripe simulado
+
+## Validaciones sugeridas
+
+- `npm run build`
+- Login como administrador
+- Revisar dashboard principal
+- Confirmar que se ve la sección `Estado de cuotas`
+- Confirmar datos QA:
+  - `QA Socio Al Dia` al día
+  - `QA Socia Adelantada` al día con Stripe y 3 meses cubiertos
+  - `QA Socio Vencido` vencido
+  - `QA Socia Sin Pagos` sin pagos
+
+## Notas
+
+Este PR no agrega nuevas migraciones de base de datos. Consume funciones y datos ya creados y validados en ramas previas.

--- a/src/app/api/admin/cuotas/estado-socios/route.ts
+++ b/src/app/api/admin/cuotas/estado-socios/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getAdminCuotasEstadoServer } from '@/services/server/cuotaEstadoServerService';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    const data = await getAdminCuotasEstadoServer(user);
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error: any) {
+    console.error('ERROR al obtener estado de cuotas admin:', error.message || error);
+    const message = error.message || 'Error al obtener estado de cuotas';
+    const status =
+      message.includes('Token') || message.includes('No autorizado') ? 403 : 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/admin/cuotas/resumen/route.ts
+++ b/src/app/api/admin/cuotas/resumen/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getAdminCuotasEstadoServer } from '@/services/server/cuotaEstadoServerService';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    const data = await getAdminCuotasEstadoServer(user);
+
+    return NextResponse.json(
+      {
+        data: {
+          resumen: data.resumen,
+          pagos_por_metodo: data.pagos_por_metodo,
+          vencidos: data.vencidos,
+          sin_pagos: data.sin_pagos,
+          proximos_vencer: data.proximos_vencer,
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    console.error('ERROR al obtener resumen de cuotas admin:', error.message || error);
+    const message = error.message || 'Error al obtener resumen de cuotas';
+    const status =
+      message.includes('Token') || message.includes('No autorizado') ? 403 : 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/cuota-estado/route.ts
+++ b/src/app/api/cuota-estado/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  getAdminCuotasEstadoServer,
+  getEstadoCuotaSocioServer,
+} from '@/services/server/cuotaEstadoServerService';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    const url = new URL(req.url);
+    const socioIdFromQuery = url.searchParams.get('socio_id');
+
+    if (user.rol === 'socio') {
+      if (!user.id_socio) {
+        return NextResponse.json(
+          { error: 'El usuario socio no tiene id_socio asociado' },
+          { status: 400 }
+        );
+      }
+
+      const estado = await getEstadoCuotaSocioServer(user, user.id_socio);
+      return NextResponse.json({ data: estado }, { status: 200 });
+    }
+
+    if (socioIdFromQuery) {
+      const estado = await getEstadoCuotaSocioServer(user, socioIdFromQuery);
+      return NextResponse.json({ data: estado }, { status: 200 });
+    }
+
+    const estadoGeneral = await getAdminCuotasEstadoServer(user);
+    return NextResponse.json({ data: estadoGeneral }, { status: 200 });
+  } catch (error: any) {
+    console.error('ERROR al obtener estado de cuota:', error.message || error);
+    const message = error.message || 'Error al obtener estado de cuota';
+    const status =
+      message.includes('Token') || message.includes('No autorizado') ? 403 : 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { useRouter } from 'next/navigation';
 import { AppSidebar } from '@/components/sidebar/AppSidebar';
 import DashboardInitialContent from '@/components/dashboard/DashboardInitialContent';
+import CuotasEstadoDashboard from '@/components/dashboard/cuotas/CuotasEstadoDashboard';
 
 import { useEffect, useState } from 'react';
 import QrDisplayModal from '@/components/ui/qr-display';
@@ -339,6 +340,8 @@ export default function DashboardPage() {
                 </div>
 
                 <div className='grid grid-cols-1 gap-4 mt-6 md:grid-cols-2 xl:grid-cols-3'>
+                  <CuotasEstadoDashboard />
+
                   <Card>
                     <CardHeader>
                       <CardTitle>Equipos Totales</CardTitle>

--- a/src/components/dashboard/cuotas/CuotasEstadoDashboard.tsx
+++ b/src/components/dashboard/cuotas/CuotasEstadoDashboard.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, CreditCard, DollarSign, Users } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  AdminCuotasEstadoResponse,
+  EstadoCuotaSocio,
+} from '@/interfaces/cuotaEstado.interface';
+import { getAdminCuotasEstadoSocios } from '@/services/apiClient';
+
+function formatDate(value: string | null): string {
+  if (!value) return '-';
+
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(date);
+}
+
+function formatMoney(value: number): string {
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function EstadoBadge({ estado }: { estado: EstadoCuotaSocio['estado_cuota'] }) {
+  const className =
+    estado === 'al_dia'
+      ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300'
+      : estado === 'vencido'
+      ? 'bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300'
+      : 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300';
+
+  const label =
+    estado === 'al_dia' ? 'Al día' : estado === 'vencido' ? 'Vencido' : 'Sin pagos';
+
+  return (
+    <span className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+function SociosCriticosTable({ socios }: { socios: EstadoCuotaSocio[] }) {
+  if (socios.length === 0) {
+    return (
+      <div className='rounded-xl border border-dashed p-6 text-sm text-muted-foreground'>
+        No hay socios vencidos ni sin pagos para mostrar.
+      </div>
+    );
+  }
+
+  return (
+    <div className='overflow-x-auto rounded-xl border'>
+      <table className='w-full min-w-[760px] text-sm'>
+        <thead className='bg-muted/60 text-left'>
+          <tr>
+            <th className='px-4 py-3 font-semibold'>Socio</th>
+            <th className='px-4 py-3 font-semibold'>Estado</th>
+            <th className='px-4 py-3 font-semibold'>Último pago</th>
+            <th className='px-4 py-3 font-semibold'>Cobertura hasta</th>
+            <th className='px-4 py-3 font-semibold'>Días vencido</th>
+            <th className='px-4 py-3 font-semibold'>Método</th>
+          </tr>
+        </thead>
+        <tbody>
+          {socios.map((socio) => (
+            <tr key={socio.id_socio} className='border-t'>
+              <td className='px-4 py-3 font-medium'>{socio.nombre_completo}</td>
+              <td className='px-4 py-3'>
+                <EstadoBadge estado={socio.estado_cuota} />
+              </td>
+              <td className='px-4 py-3'>{formatDate(socio.ultimo_pago)}</td>
+              <td className='px-4 py-3'>{formatDate(socio.periodo_hasta)}</td>
+              <td className='px-4 py-3'>{socio.dias_vencido}</td>
+              <td className='px-4 py-3 capitalize'>{socio.metodo_pago ?? '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function CuotasEstadoDashboard() {
+  const [data, setData] = useState<AdminCuotasEstadoResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    setLoading(true);
+    setError(null);
+
+    const result = await getAdminCuotasEstadoSocios();
+
+    if (result.ok && result.data) {
+      setData(result.data);
+    } else {
+      setError(result.error || 'No se pudo obtener el estado de cuotas');
+    }
+
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const sociosCriticos = useMemo(() => {
+    if (!data) return [];
+
+    return [...data.vencidos, ...data.sin_pagos].sort((a, b) => {
+      if (a.estado_cuota === b.estado_cuota) {
+        return a.nombre_completo.localeCompare(b.nombre_completo);
+      }
+
+      return a.estado_cuota === 'vencido' ? -1 : 1;
+    });
+  }, [data]);
+
+  const totalCobrado = useMemo(() => {
+    if (!data) return 0;
+    return data.pagos_por_metodo.reduce((acc, item) => acc + item.total_pagado, 0);
+  }, [data]);
+
+  if (loading) {
+    return (
+      <Card className='col-span-12'>
+        <CardHeader>
+          <CardTitle>Estado de cuotas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className='text-sm text-muted-foreground'>Cargando estado de cuotas...</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className='col-span-12 border-red-200 dark:border-red-900'>
+        <CardHeader className='flex flex-row items-center justify-between gap-4'>
+          <CardTitle className='flex items-center gap-2'>
+            <AlertTriangle className='h-5 w-5 text-red-500' />
+            Estado de cuotas
+          </CardTitle>
+          <Button variant='outline' size='sm' onClick={fetchData}>
+            Reintentar
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <p className='text-sm text-red-600 dark:text-red-300'>{error}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <section className='col-span-12 space-y-4'>
+      <div className='flex flex-col gap-2 md:flex-row md:items-end md:justify-between'>
+        <div>
+          <h2 className='text-2xl font-bold'>Estado de cuotas</h2>
+          <p className='text-sm text-muted-foreground'>
+            Control operativo de socios al día, vencidos y sin pagos.
+          </p>
+        </div>
+        <Button variant='outline' size='sm' onClick={fetchData}>
+          Actualizar
+        </Button>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5'>
+        <Card>
+          <CardHeader className='pb-2'>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <Users className='h-4 w-4' />
+              Total socios
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className='text-3xl font-bold'>{data.resumen.total_socios}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className='pb-2'>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <CheckCircle2 className='h-4 w-4 text-emerald-500' />
+              Al día
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className='text-3xl font-bold text-emerald-600'>{data.resumen.al_dia}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className='pb-2'>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <AlertTriangle className='h-4 w-4 text-red-500' />
+              Vencidos
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className='text-3xl font-bold text-red-600'>{data.resumen.vencidos}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className='pb-2'>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <AlertTriangle className='h-4 w-4 text-amber-500' />
+              Sin pagos
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className='text-3xl font-bold text-amber-600'>{data.resumen.sin_pagos}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className='pb-2'>
+            <CardTitle className='flex items-center gap-2 text-sm font-medium'>
+              <DollarSign className='h-4 w-4' />
+              Cobrado QA/actual
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className='text-2xl font-bold'>{formatMoney(totalCobrado)}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className='grid grid-cols-1 gap-4 xl:grid-cols-3'>
+        <Card className='xl:col-span-2'>
+          <CardHeader>
+            <CardTitle>Socios con atención requerida</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SociosCriticosTable socios={sociosCriticos} />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <CreditCard className='h-5 w-5' />
+              Pagos por método
+            </CardTitle>
+          </CardHeader>
+          <CardContent className='space-y-3'>
+            {data.pagos_por_metodo.length === 0 ? (
+              <p className='text-sm text-muted-foreground'>No hay pagos registrados.</p>
+            ) : (
+              data.pagos_por_metodo.map((item) => (
+                <div
+                  key={`${item.metodo_pago}-${item.estado}`}
+                  className='flex items-center justify-between rounded-xl border p-3'
+                >
+                  <div>
+                    <p className='font-semibold capitalize'>{item.metodo_pago}</p>
+                    <p className='text-xs text-muted-foreground'>
+                      {item.cantidad} pago(s) · {item.estado}
+                    </p>
+                  </div>
+                  <p className='font-bold'>{formatMoney(item.total_pagado)}</p>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/interfaces/cuotaEstado.interface.ts
+++ b/src/interfaces/cuotaEstado.interface.ts
@@ -1,0 +1,38 @@
+export type EstadoCuotaValor = 'al_dia' | 'vencido' | 'sin_pagos';
+
+export interface EstadoCuotaSocio {
+  id_socio: string;
+  nombre_completo: string;
+  activo: boolean;
+  ultimo_pago: string | null;
+  ultimo_vencimiento: string | null;
+  periodo_hasta: string | null;
+  estado_cuota: EstadoCuotaValor;
+  dias_vencido: number;
+  metodo_pago: string | null;
+  meses_cubiertos: number | null;
+}
+
+export interface ResumenEstadoCuotas {
+  total_socios: number;
+  al_dia: number;
+  vencidos: number;
+  sin_pagos: number;
+  proximos_a_vencer: number;
+}
+
+export interface ResumenPagoPorMetodo {
+  metodo_pago: string;
+  estado: string;
+  cantidad: number;
+  total_pagado: number;
+}
+
+export interface AdminCuotasEstadoResponse {
+  resumen: ResumenEstadoCuotas;
+  socios: EstadoCuotaSocio[];
+  vencidos: EstadoCuotaSocio[];
+  sin_pagos: EstadoCuotaSocio[];
+  proximos_vencer: EstadoCuotaSocio[];
+  pagos_por_metodo: ResumenPagoPorMetodo[];
+}

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -641,3 +641,34 @@ export async function getFichaMedicaHistorial(
   }
   return { ok: res.ok, data };
 }
+
+export async function getCuotaEstado(socioId?: string) {
+  const token = getToken();
+  const query = socioId ? `?socio_id=${encodeURIComponent(socioId)}` : '';
+  const res = await fetch(`/api/cuota-estado${query}`, {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}
+
+export async function getAdminCuotasEstadoSocios() {
+  const token = getToken();
+  const res = await fetch('/api/admin/cuotas/estado-socios', {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}
+
+export async function getAdminCuotasResumen() {
+  const token = getToken();
+  const res = await fetch('/api/admin/cuotas/resumen', {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}

--- a/src/services/server/cuotaEstadoServerService.ts
+++ b/src/services/server/cuotaEstadoServerService.ts
@@ -1,0 +1,192 @@
+import { JwtUser } from '@/interfaces/jwtUser.interface';
+import {
+  AdminCuotasEstadoResponse,
+  EstadoCuotaSocio,
+  ResumenEstadoCuotas,
+  ResumenPagoPorMetodo,
+} from '@/interfaces/cuotaEstado.interface';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+
+const managerRoles = new Set(['admin', 'usuario']);
+
+function assertCanViewAdminCuotas(user: JwtUser) {
+  if (!managerRoles.has(user.rol)) {
+    throw new Error('No autorizado para consultar estados de cuota administrativos');
+  }
+}
+
+function assertCanViewSocioCuota(user: JwtUser, socioId: string) {
+  if (user.rol === 'socio' && user.id_socio !== socioId) {
+    throw new Error('No autorizado para consultar la cuota de otro socio');
+  }
+
+  if (user.rol !== 'socio' && !managerRoles.has(user.rol)) {
+    throw new Error('No autorizado para consultar estado de cuota');
+  }
+}
+
+function toNumber(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeEstadoCuota(row: any): EstadoCuotaSocio {
+  return {
+    id_socio: String(row.id_socio),
+    nombre_completo: String(row.nombre_completo ?? ''),
+    activo: Boolean(row.activo),
+    ultimo_pago: row.ultimo_pago ?? null,
+    ultimo_vencimiento: row.ultimo_vencimiento ?? null,
+    periodo_hasta: row.periodo_hasta ?? null,
+    estado_cuota: row.estado_cuota,
+    dias_vencido: toNumber(row.dias_vencido),
+    metodo_pago: row.metodo_pago ?? null,
+    meses_cubiertos:
+      row.meses_cubiertos === null || row.meses_cubiertos === undefined
+        ? null
+        : toNumber(row.meses_cubiertos),
+  };
+}
+
+function getTodayOnlyDate(): Date {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+}
+
+function daysBetween(start: Date, end: Date): number {
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const startDate = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+  const endDate = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+  return Math.ceil((endDate.getTime() - startDate.getTime()) / msPerDay);
+}
+
+function isNextSevenDays(dateValue: string | null): boolean {
+  if (!dateValue) return false;
+  const today = getTodayOnlyDate();
+  const target = new Date(`${dateValue}T00:00:00`);
+  const diff = daysBetween(today, target);
+  return diff >= 0 && diff <= 7;
+}
+
+function buildResumen(socios: EstadoCuotaSocio[]): ResumenEstadoCuotas {
+  return socios.reduce<ResumenEstadoCuotas>(
+    (acc, socio) => {
+      acc.total_socios += 1;
+
+      if (socio.estado_cuota === 'al_dia') acc.al_dia += 1;
+      if (socio.estado_cuota === 'vencido') acc.vencidos += 1;
+      if (socio.estado_cuota === 'sin_pagos') acc.sin_pagos += 1;
+      if (socio.estado_cuota === 'al_dia' && isNextSevenDays(socio.periodo_hasta)) {
+        acc.proximos_a_vencer += 1;
+      }
+
+      return acc;
+    },
+    {
+      total_socios: 0,
+      al_dia: 0,
+      vencidos: 0,
+      sin_pagos: 0,
+      proximos_a_vencer: 0,
+    }
+  );
+}
+
+export async function getEstadoCuotaSocioServer(
+  user: JwtUser,
+  socioId: string
+): Promise<EstadoCuotaSocio> {
+  assertCanViewSocioCuota(user, socioId);
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase.rpc('obtener_estado_cuota_socio', {
+    p_id_socio: socioId,
+  });
+
+  if (error) throw new Error(error.message);
+
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row) throw new Error('No se encontró estado de cuota para el socio solicitado');
+
+  return normalizeEstadoCuota(row);
+}
+
+export async function getSociosEstadoCuotaServer(
+  user: JwtUser
+): Promise<EstadoCuotaSocio[]> {
+  assertCanViewAdminCuotas(user);
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase.rpc('obtener_socios_estado_cuota');
+
+  if (error) throw new Error(error.message);
+
+  return ((data ?? []) as any[]).map(normalizeEstadoCuota).sort((a, b) => {
+    const statePriority: Record<string, number> = {
+      vencido: 0,
+      sin_pagos: 1,
+      al_dia: 2,
+    };
+
+    const priorityDiff =
+      (statePriority[a.estado_cuota] ?? 99) - (statePriority[b.estado_cuota] ?? 99);
+
+    if (priorityDiff !== 0) return priorityDiff;
+    return a.nombre_completo.localeCompare(b.nombre_completo);
+  });
+}
+
+export async function getPagosPorMetodoServer(
+  user: JwtUser
+): Promise<ResumenPagoPorMetodo[]> {
+  assertCanViewAdminCuotas(user);
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('pago')
+    .select('metodo_pago, estado, monto_pagado, activo')
+    .eq('activo', true);
+
+  if (error) throw new Error(error.message);
+
+  const grouped = new Map<string, ResumenPagoPorMetodo>();
+
+  for (const pago of data ?? []) {
+    const metodo = pago.metodo_pago ?? 'sin_metodo';
+    const estado = pago.estado ?? 'sin_estado';
+    const key = `${metodo}::${estado}`;
+    const current = grouped.get(key) ?? {
+      metodo_pago: metodo,
+      estado,
+      cantidad: 0,
+      total_pagado: 0,
+    };
+
+    current.cantidad += 1;
+    current.total_pagado += toNumber(pago.monto_pagado);
+    grouped.set(key, current);
+  }
+
+  return Array.from(grouped.values()).sort((a, b) =>
+    `${a.metodo_pago}-${a.estado}`.localeCompare(`${b.metodo_pago}-${b.estado}`)
+  );
+}
+
+export async function getAdminCuotasEstadoServer(
+  user: JwtUser
+): Promise<AdminCuotasEstadoResponse> {
+  const socios = await getSociosEstadoCuotaServer(user);
+  const pagosPorMetodo = await getPagosPorMetodoServer(user);
+
+  return {
+    resumen: buildResumen(socios),
+    socios,
+    vencidos: socios.filter((socio) => socio.estado_cuota === 'vencido'),
+    sin_pagos: socios.filter((socio) => socio.estado_cuota === 'sin_pagos'),
+    proximos_vencer: socios.filter(
+      (socio) => socio.estado_cuota === 'al_dia' && isNextSevenDays(socio.periodo_hasta)
+    ),
+    pagos_por_metodo: pagosPorMetodo,
+  };
+}


### PR DESCRIPTION
# PR: feature/cuota-estado-api-dashboard

## Título sugerido

`feat: add membership fee status API and dashboard`

## Resumen

Este PR implementa la primera capa operativa para visualizar el estado de cuotas y pagos dentro del dashboard administrativo de Gym Master.

La feature conecta la base de cuotas/pagos preparada en ramas anteriores con la aplicación web, exponiendo endpoints internos y mostrando en el dashboard la situación de los socios: al día, vencidos, sin pagos, próximos a vencer y pagos agrupados por método.

## Contexto

En ramas previas se incorporó la foundation de cuotas/pagos, incluyendo:

- ampliación de la tabla `pago` con período cubierto, método de pago, estado y trazabilidad Stripe;
- función `obtener_estado_cuota_socio(p_id_socio uuid)`;
- función `obtener_socios_estado_cuota()`;
- seeds QA con socios al día, vencidos, sin pagos, pago efectivo y pago Stripe simulado.

Esta rama lleva esa lógica a la capa de aplicación para que el administrador pueda verla desde el dashboard.

## Cambios principales

### API Routes agregadas

- `GET /api/cuota-estado`
- `GET /api/admin/cuotas/estado-socios`
- `GET /api/admin/cuotas/resumen`

### Servicio server-side

Se agrega:

- `src/services/server/cuotaEstadoServerService.ts`

Este servicio centraliza las consultas contra Supabase desde el backend y evita exponer credenciales server-side en el navegador.

### Tipado

Se agrega:

- `src/interfaces/cuotaEstado.interface.ts`

Incluye tipos para estado de cuota, resumen administrativo y pagos agrupados por método.

### Frontend/dashboard

Se agrega:

- `src/components/dashboard/cuotas/CuotasEstadoDashboard.tsx`

El dashboard administrativo ahora puede mostrar:

- total de socios evaluados;
- socios al día;
- socios vencidos;
- socios sin pagos;
- total cobrado según pagos disponibles;
- tabla de socios con atención requerida;
- resumen de pagos por método.

### Archivos modificados

- `src/app/dashboard/page.tsx`
- `src/services/apiClient.ts`

### Documentación agregada

- `docs/cuotas-pagos/cuota-estado-api-dashboard.md`
- `docs/pr/pr-cuota-estado-api-dashboard.md`
- `docs/informes/informe-ejecutivo-cuota-estado-api-dashboard.md`

## Validaciones sugeridas

- Ejecutar `npm run build`.
- Iniciar la app con `npm run dev`.
- Iniciar sesión como administrador.
- Entrar al dashboard principal.
- Confirmar que se visualiza la sección `Estado de cuotas`.
- Confirmar que los datos QA se muestran correctamente:
  - `QA Socio Al Dia` como `al_dia`;
  - `QA Socia Adelantada` como `al_dia`, método `stripe`, 3 meses cubiertos;
  - `QA Socio Vencido` como `vencido`;
  - `QA Socia Sin Pagos` como `sin_pagos`.
- Probar los endpoints protegidos:
  - `/api/cuota-estado`;
  - `/api/admin/cuotas/estado-socios`;
  - `/api/admin/cuotas/resumen`.

## Impacto funcional

El administrador obtiene visibilidad inmediata del estado de cuotas de los socios. Esto permite avanzar hacia control de ingreso, alertas de vencimiento, gestión de morosidad y BI financiero del gimnasio.

## Notas técnicas

Este PR no agrega nuevas migraciones de base de datos. Consume las funciones y datos creados y validados en las ramas previas de cuotas/pagos.

## Próximos pasos recomendados

1. Implementar pago manual desde administrador usando el modelo foundation.
2. Integrar Stripe/webhook con `periodo_desde`, `periodo_hasta`, `metodo_pago`, `estado` y trazabilidad.
3. Agregar reglas de inactivación por cuota vencida y ausencia de asistencia.
4. Extender el dashboard con filtros por estado, método de pago y rango de fechas.
5. Consolidar BI de cuotas/pagos con métricas históricas.
