### PR TITLE
feat: add manual membership payments from admin dashboard

### DIFF
--- a/database/scripts/validar_pagos_manuales_admin.sql
+++ b/database/scripts/validar_pagos_manuales_admin.sql
@@ -1,0 +1,40 @@
+-- Validación de pagos manuales desde administrador.
+-- Ejecutar después de registrar un pago manual desde la UI.
+
+SELECT '1. Últimos pagos manuales activos' AS seccion;
+SELECT
+  p.id,
+  s.nombre_completo,
+  p.fecha_pago,
+  p.fecha_vencimiento,
+  p.periodo_desde,
+  p.periodo_hasta,
+  p.meses_cubiertos,
+  p.metodo_pago,
+  p.estado,
+  p.monto_pagado,
+  p.activo,
+  u.nombre AS registrado_por
+FROM public.pago p
+JOIN public.socio s ON s.id_socio = p.socio_id
+LEFT JOIN public.usuario u ON u.id = p.registrado_por
+WHERE p.activo IS TRUE
+ORDER BY p.creado_en DESC
+LIMIT 10;
+
+SELECT '2. Estado de cuota de socios con últimos pagos' AS seccion;
+SELECT *
+FROM public.obtener_socios_estado_cuota()
+ORDER BY ultimo_pago DESC NULLS LAST, nombre_completo
+LIMIT 20;
+
+SELECT '3. Resumen por método y estado' AS seccion;
+SELECT
+  COALESCE(metodo_pago, 'sin_metodo') AS metodo_pago,
+  COALESCE(estado, 'sin_estado') AS estado,
+  COUNT(*) AS cantidad,
+  SUM(monto_pagado) AS total_pagado
+FROM public.pago
+WHERE activo IS TRUE
+GROUP BY metodo_pago, estado
+ORDER BY metodo_pago, estado;

--- a/docs/cuotas-pagos/pagos-manuales-admin-view-modal.md
+++ b/docs/cuotas-pagos/pagos-manuales-admin-view-modal.md
@@ -1,0 +1,34 @@
+# Corrección del modal de detalle de pagos
+
+## Contexto
+
+Durante la validación funcional de `feature/pagos-manuales-admin`, el modal de detalle del pago mostraba UUIDs internos para socio, cuota y usuario registrador.
+
+## Problema detectado
+
+La tabla de pagos ya recibía objetos enriquecidos desde la API (`socio`, `cuota`, `registrado_por`), pero la página transformaba el pago seleccionado al formato legacy `Pago`, reemplazando esos objetos por ids.
+
+Como consecuencia, el modal mostraba datos técnicos en lugar de información legible para administración.
+
+## Solución aplicada
+
+- `PagoViewModal` ahora recibe `ResponsePago` directamente.
+- La página `/dashboard/pagos` pasa `pagoVer` sin transformar.
+- El modal muestra:
+  - nombre del socio,
+  - descripción de la cuota,
+  - fecha de pago,
+  - vencimiento,
+  - período cubierto,
+  - meses cubiertos,
+  - monto pagado,
+  - total,
+  - método de pago,
+  - estado,
+  - usuario registrador,
+  - referencias Stripe si existen,
+  - observaciones si existen.
+
+## Resultado esperado
+
+El administrador ve información clara de negocio, no identificadores internos.

--- a/docs/cuotas-pagos/pagos-manuales-admin.md
+++ b/docs/cuotas-pagos/pagos-manuales-admin.md
@@ -1,0 +1,56 @@
+# Pagos manuales desde administrador
+
+## Objetivo
+
+Implementar el registro operativo de pagos manuales desde el panel de administración de Gym Master, especialmente para pagos en efectivo en recepción.
+
+Esta mejora utiliza la base preparada en las ramas anteriores:
+
+- columnas extendidas en `pago`, como `periodo_desde`, `periodo_hasta`, `meses_cubiertos`, `metodo_pago`, `estado` y `activo`;
+- funciones `obtener_estado_cuota_socio()` y `obtener_socios_estado_cuota()`;
+- seeds QA de cuotas/pagos para validar estados `al_dia`, `vencido` y `sin_pagos`.
+
+## Alcance funcional
+
+- Registrar un pago manual desde `/dashboard/pagos`.
+- Seleccionar socio activo.
+- Seleccionar cuota activa o usar la cuota vigente/última activa.
+- Definir fecha de pago.
+- Definir cantidad de meses cubiertos.
+- Calcular automáticamente el período cubierto.
+- Registrar método de pago `efectivo`, `transferencia` u `otro`.
+- Guardar observaciones administrativas.
+- Registrar automáticamente el usuario administrador que cargó el pago.
+- Refrescar el listado después de crear/editar/eliminar.
+- Eliminar pagos mediante baja lógica (`activo = false`, `estado = cancelado`).
+
+## Decisiones técnicas
+
+La lógica sensible se mueve al backend mediante `src/services/server/pagoServerService.ts` y la ruta `/api/pagos`.
+
+El frontend ya no llama directamente a Supabase para crear pagos. La pantalla usa `src/services/browser/pagoApiClient.ts`, enviando el token JWT para que el backend resuelva permisos y usuario registrante.
+
+## Reglas aplicadas
+
+- Solo roles `admin` y `usuario` pueden administrar pagos.
+- El socio debe estar activo.
+- El pago se crea con `estado = pagado`.
+- El método por defecto es `efectivo`.
+- El período cubierto se calcula a partir de `periodo_desde` y `meses_cubiertos`.
+- `fecha_vencimiento` queda alineada con `periodo_hasta`.
+- No se actualiza manualmente `pago.total`, porque en remoto puede ser una columna generada.
+
+## Validación sugerida
+
+1. Login como administrador.
+2. Entrar a `/dashboard/pagos`.
+3. Crear un pago manual para `QA Socia Sin Pagos`.
+4. Confirmar que el pago aparece en el listado.
+5. Confirmar que el socio pasa a estado `al_dia` en el dashboard de cuotas.
+6. Ejecutar `database/scripts/validar_pagos_manuales_admin.sql`.
+
+## Próximos pasos relacionados
+
+- Integrar pago Stripe real y webhook.
+- Mejorar dashboard BI de cuotas/pagos.
+- Implementar regla de inactividad por cuota vencida.

--- a/docs/informes/informe-ejecutivo-pagos-manuales-admin-view-modal-fix.md
+++ b/docs/informes/informe-ejecutivo-pagos-manuales-admin-view-modal-fix.md
@@ -1,0 +1,47 @@
+# Informe técnico - Corrección de modal de detalle de pagos
+
+## Proyecto
+
+Gym Master
+
+## Rama
+
+`feature/pagos-manuales-admin`
+
+## Objetivo
+
+Corregir la visualización del detalle de pagos para que el administrador vea datos claros de negocio en lugar de identificadores internos.
+
+## Situación inicial
+
+Durante la prueba funcional de pagos manuales, el modal **Detalle Pago** mostraba UUIDs para socio, cuota y usuario registrador.
+
+## Corrección aplicada
+
+Se actualizó el modal para consumir directamente el objeto enriquecido `ResponsePago`, que ya contiene datos relacionados de socio, cuota y usuario registrador.
+
+## Resultado
+
+El modal ahora presenta información legible:
+
+- socio,
+- cuota,
+- fecha de pago,
+- vencimiento,
+- período cubierto,
+- meses cubiertos,
+- método de pago,
+- estado,
+- monto pagado,
+- usuario registrador,
+- referencias Stripe si existen.
+
+## Impacto
+
+La experiencia administrativa queda más clara y profesional, facilitando la revisión de pagos manuales, pagos Stripe simulados y próximos flujos de auditoría/BI.
+
+## Validación recomendada
+
+- Probar el botón **Ver** en `/dashboard/pagos`.
+- Confirmar que no aparecen UUIDs como valor principal.
+- Ejecutar `npm run build`.

--- a/docs/informes/informe-ejecutivo-pagos-manuales-admin.md
+++ b/docs/informes/informe-ejecutivo-pagos-manuales-admin.md
@@ -1,0 +1,33 @@
+# Informe técnico - Pagos manuales desde administrador
+
+## Contexto
+
+Luego de preparar el modelo base de cuotas/pagos y cargar datos QA, se implementó la funcionalidad operativa para registrar pagos manuales desde el panel administrativo.
+
+## Objetivo
+
+Permitir que un administrador registre pagos presenciales o en efectivo, definiendo el socio, la cuota, el período cubierto, los meses abonados y el método de pago.
+
+## Resultado
+
+La pantalla de pagos queda preparada para registrar pagos reales y actualizar el estado de cuota del socio mediante las funciones existentes de base de datos.
+
+## Cambios técnicos
+
+- Nuevo servicio backend para pagos.
+- API `/api/pagos` protegida por JWT.
+- Formulario administrativo de pagos manuales.
+- Cliente frontend para consumir la API.
+- Tabla de pagos ampliada.
+- Validación SQL posterior al registro.
+
+## Riesgos mitigados
+
+- Se evita exponer service role en frontend.
+- Se evita escribir directamente sobre `pago.total`.
+- Se registra el administrador que cargó el pago.
+- Se usa baja lógica para eliminar pagos.
+
+## Próximo paso recomendado
+
+Implementar pago Stripe real y webhook, usando los mismos campos de trazabilidad agregados en la foundation de cuotas/pagos.

--- a/docs/pr/pr-pagos-manuales-admin-view-modal-fix.md
+++ b/docs/pr/pr-pagos-manuales-admin-view-modal-fix.md
@@ -1,0 +1,28 @@
+# fix: show readable payment details in admin modal
+
+## Resumen
+
+Este ajuste corrige el modal de detalle de pagos del panel administrador para mostrar datos legibles en lugar de UUIDs internos.
+
+## Problema
+
+Al presionar **Ver** sobre un pago, el modal mostraba ids técnicos para socio, cuota y usuario registrador. Esto dificultaba la validación administrativa del pago y generaba una mala experiencia de uso.
+
+## Cambios realizados
+
+- Se actualizó `PagoViewModal` para consumir `ResponsePago` directamente.
+- Se eliminó la transformación legacy del pago seleccionado en `/dashboard/pagos`.
+- El modal ahora muestra nombre del socio, cuota, fechas, cobertura, método, estado, montos, registrador y datos Stripe cuando existan.
+- Se agregó documentación técnica del ajuste.
+
+## Validación sugerida
+
+1. Iniciar sesión como administrador.
+2. Entrar a `/dashboard/pagos`.
+3. Presionar **Ver** en un pago QA o real.
+4. Confirmar que el modal muestra nombres/descripciones y no UUIDs.
+5. Ejecutar `npm run build`.
+
+## Alcance
+
+Este cambio no modifica base de datos ni migraciones. Es un ajuste de presentación y tipado frontend sobre la respuesta ya enriquecida de la API.

--- a/docs/pr/pr-pagos-manuales-admin.md
+++ b/docs/pr/pr-pagos-manuales-admin.md
@@ -1,0 +1,31 @@
+# PR: feat: add manual membership payments from admin dashboard
+
+## Resumen
+
+Este PR implementa el registro de pagos manuales desde el panel administrativo de Gym Master. La mejora permite registrar pagos en efectivo, transferencia u otro método manual, asociarlos a un socio, calcular el período cubierto y reflejar el resultado en el estado de cuota.
+
+## Cambios principales
+
+- Se agrega servicio backend `pagoServerService` para centralizar la lógica de pagos.
+- Se refactoriza `/api/pagos` para operar con autenticación y service role server-side.
+- Se agrega cliente browser `pagoApiClient` para consumir la API desde el frontend.
+- Se actualiza el formulario de pagos para seleccionar socio, cuota, meses cubiertos, período, método y observaciones.
+- Se actualiza la tabla de pagos para mostrar cobertura, método, estado y monto.
+- Se actualiza `/dashboard/pagos` para crear, editar, eliminar y exportar pagos con la nueva estructura.
+- Se agrega script SQL de validación operativa.
+- Se documenta el flujo de pagos manuales.
+
+## Validaciones sugeridas
+
+- `npm run build`
+- Login como administrador.
+- Crear pago manual para un socio QA sin pagos.
+- Confirmar que aparece en el listado.
+- Confirmar que `obtener_socios_estado_cuota()` refleja el nuevo estado.
+- Ejecutar `database/scripts/validar_pagos_manuales_admin.sql`.
+
+## Notas técnicas
+
+- No se agregan migraciones de base de datos en esta feature.
+- Esta feature depende de las migraciones previas de foundation y demo seeds de cuotas/pagos.
+- No se actualiza `pago.total` desde código, para respetar la columna generada en Supabase remoto.

--- a/src/app/api/pagos/route.ts
+++ b/src/app/api/pagos/route.ts
@@ -1,52 +1,99 @@
-import { createPago, deletePago, getAllPagos, updatePago } from "@/services/pagoService";
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  createPagoManualServer,
+  deactivatePagoServer,
+  fetchPagoFormOptionsServer,
+  fetchPagosServer,
+  updatePagoServer,
+} from '@/services/server/pagoServerService';
 
-export async function GET() {
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
   try {
-    const pagos = await getAllPagos();
-    
+    const { user } = await authMiddleware(req);
+    const url = new URL(req.url);
+
+    if (url.searchParams.get('options') === 'true') {
+      const options = await fetchPagoFormOptionsServer(user);
+      return NextResponse.json({ data: options }, { status: 200 });
+    }
+
+    const pagos = await fetchPagosServer(user);
     return NextResponse.json({ data: pagos }, { status: 200 });
   } catch (error: any) {
-    return NextResponse.json({ error: "Error al obtener los pagos" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al obtener pagos' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function POST(req: Request) {
   try {
+    const { user } = await authMiddleware(req);
     const body = await req.json();
-    
-    if (!body.socio_id || !body.registrado_por) {
-      return NextResponse.json({ error: "Todos los campos son obligatorios" }, { status: 400 });
-    }
-    const pago = await createPago(body);
-    return NextResponse.json({ message: "Pago registrado con éxito", data: pago }, { status: 201 });
+    const pago = await createPagoManualServer(user, body);
+
+    return NextResponse.json(
+      { message: 'Pago registrado con éxito', data: pago },
+      { status: 201 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || "Error al registrar el pago" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al registrar el pago' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function PUT(req: Request) {
-  const { id, updateData } = await req.json();
   try {
-    if (!id || typeof id !== "string") {
-      return NextResponse.json({ error: "ID inválido para actualizar" }, { status: 400 });
+    const { user } = await authMiddleware(req);
+    const { id, updateData } = await req.json();
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json(
+        { error: 'ID inválido para actualizar' },
+        { status: 400 }
+      );
     }
-    const pagoModificado = await updatePago(id, updateData);
-    return NextResponse.json({ message: "Pago actualizado con éxito", data: pagoModificado }, { status: 200 });
+
+    const pago = await updatePagoServer(user, id, updateData);
+    return NextResponse.json(
+      { message: 'Pago actualizado con éxito', data: pago },
+      { status: 200 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || "Error al actualizar pago" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al actualizar pago' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }
 
 export async function DELETE(req: Request) {
-  const { id } = await req.json();
   try {
-    if (!id || typeof id !== "string") {
-      return NextResponse.json({ error: "ID inválido para eliminar" }, { status: 400 });
+    const { user } = await authMiddleware(req);
+    const { id } = await req.json();
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json(
+        { error: 'ID inválido para eliminar' },
+        { status: 400 }
+      );
     }
-    await deletePago(id);
-    return NextResponse.json({ message: "Pago eliminado con éxito" }, { status: 200 });
+
+    const pago = await deactivatePagoServer(user, id);
+    return NextResponse.json(
+      { message: 'Pago eliminado con éxito', data: pago },
+      { status: 200 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || "Error al eliminar pago" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al eliminar pago' },
+      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+    );
   }
 }

--- a/src/app/dashboard/pagos/page.tsx
+++ b/src/app/dashboard/pagos/page.tsx
@@ -9,7 +9,10 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, Printer, FileSpreadsheet } from "lucide-react";
-import { getAllPagos, deletePago } from "@/services/pagoService";
+import {
+  deletePagoApi,
+  fetchPagosApi,
+} from "@/services/browser/pagoApiClient";
 import PagoModal from "@/components/modal/PagoModal";
 import PagoViewModal from "@/components/modal/PagoViewModal";
 import PagoTable from "@/components/tables/PagoTable";
@@ -19,9 +22,13 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
 
+function numberOrZero(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export default function PagosPage() {
-  const { user, isAuthenticated, initializeAuth, isInitialized } =
-    useAuthStore();
+  const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
   const [pagos, setPagos] = useState<ResponsePago[]>([]);
   const [filteredPagos, setFilteredPagos] = useState<ResponsePago[]>([]);
@@ -43,11 +50,16 @@ export default function PagosPage() {
   }, [isAuthenticated, isInitialized, router]);
 
   const loadPagos = async () => {
-    setLoading(true);
-    const data = await getAllPagos();
-    setPagos(data ?? []);
-    setFilteredPagos(data ?? []);
-    setLoading(false);
+    try {
+      setLoading(true);
+      const data = await fetchPagosApi();
+      setPagos(data ?? []);
+      setFilteredPagos(data ?? []);
+    } catch (error: any) {
+      toast.error(error.message || "Error al cargar pagos");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handlePrint = () => {
@@ -59,12 +71,15 @@ export default function PagosPage() {
     const worksheet = workbook.addWorksheet("Pagos");
 
     worksheet.columns = [
-      { header: "Socio", key: "socio", width: 20 },
-      { header: "Cuota", key: "cuota", width: 20 },
-      { header: "Fecha Pago", key: "fecha_pago", width: 20 },
-      { header: "Vencimiento", key: "fecha_vencimiento", width: 20 },
+      { header: "Socio", key: "socio", width: 28 },
+      { header: "Cuota", key: "cuota", width: 24 },
+      { header: "Fecha Pago", key: "fecha_pago", width: 16 },
+      { header: "Periodo Desde", key: "periodo_desde", width: 16 },
+      { header: "Periodo Hasta", key: "periodo_hasta", width: 16 },
+      { header: "Meses", key: "meses", width: 10 },
+      { header: "Método", key: "metodo", width: 14 },
+      { header: "Estado", key: "estado", width: 14 },
       { header: "Monto Pagado", key: "monto_pagado", width: 15 },
-      { header: "Total", key: "total", width: 15 },
       { header: "Registrado Por", key: "registrado_por", width: 20 },
     ];
 
@@ -73,9 +88,12 @@ export default function PagosPage() {
         socio: p.socio?.nombre_completo || "",
         cuota: p.cuota?.descripcion || "",
         fecha_pago: p.fecha_pago,
-        fecha_vencimiento: p.fecha_vencimiento,
+        periodo_desde: p.periodo_desde || p.fecha_pago,
+        periodo_hasta: p.periodo_hasta || p.fecha_vencimiento,
+        meses: p.meses_cubiertos || 1,
+        metodo: p.metodo_pago || "",
+        estado: p.estado || "",
         monto_pagado: p.monto_pagado,
-        total: p.total,
         registrado_por: p.registrado_por?.nombre || "",
       });
     });
@@ -111,11 +129,17 @@ export default function PagosPage() {
           .toLowerCase()
           .includes(lowercaseSearch) ||
         (p.cuota?.descripcion || "").toLowerCase().includes(lowercaseSearch) ||
-        (p.registrado_por?.nombre || "").toLowerCase().includes(lowercaseSearch)
+        (p.registrado_por?.nombre || "").toLowerCase().includes(lowercaseSearch) ||
+        (p.metodo_pago || "").toLowerCase().includes(lowercaseSearch) ||
+        (p.estado || "").toLowerCase().includes(lowercaseSearch)
     );
 
     setFilteredPagos(filtered);
   }, [searchTerm, pagos]);
+
+  const totalEfectivo = filteredPagos
+    .filter((p) => p.metodo_pago === "efectivo" && p.estado !== "cancelado")
+    .reduce((acc, pago) => acc + numberOrZero(pago.monto_pagado), 0);
 
   if (!isInitialized) {
     return <div>Cargando...</div>;
@@ -134,13 +158,18 @@ export default function PagosPage() {
           <main className="flex-1 p-6 space-y-6">
             <Card className="w-full">
               <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
-                <h2 className="text-xl font-bold">Listado de Pagos</h2>
+                <div>
+                  <h2 className="text-xl font-bold">Listado de Pagos</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Total efectivo filtrado: ${totalEfectivo.toLocaleString("es-AR")}
+                  </p>
+                </div>
                 <div className="flex flex-wrap items-center w-full gap-2 md:w-auto">
                   <div className="relative flex-grow md:flex-grow-0">
                     <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
                       type="search"
-                      placeholder="Buscar por socio, cuota, usuario..."
+                      placeholder="Buscar por socio, cuota, método..."
                       className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
@@ -166,7 +195,7 @@ export default function PagosPage() {
                     onClick={() => setOpenModal(true)}
                     className="bg-[#02a8e1] hover:bg-[#0288b1]"
                   >
-                    <span className="hidden sm:inline">Añadir Pago</span>
+                    <span className="hidden sm:inline">Registrar Pago Manual</span>
                     <span className="sm:hidden">Añadir</span>
                   </Button>
                 </div>
@@ -191,11 +220,11 @@ export default function PagosPage() {
                       if (!confirmar) return;
 
                       try {
-                        await deletePago(pago.id);
+                        await deletePagoApi(pago.id);
                         toast.success("Pago eliminado correctamente");
                         await loadPagos();
-                      } catch (err) {
-                        toast.error("Error al eliminar pago");
+                      } catch (err: any) {
+                        toast.error(err.message || "Error al eliminar pago");
                       }
                     }}
                   />
@@ -223,21 +252,7 @@ export default function PagosPage() {
           setOpenModalVer(false);
           setPagoVer(null);
         }}
-        pago={
-          pagoVer
-            ? {
-                id: pagoVer.id,
-                socio_id: pagoVer.socio?.id_socio ?? "",
-                cuota_id: pagoVer.cuota?.id ?? "",
-                fecha_pago: pagoVer.fecha_pago,
-                fecha_vencimiento: pagoVer.fecha_vencimiento,
-                monto_pagado: pagoVer.monto_pagado,
-                total: pagoVer.total,
-                registrado_por: pagoVer.registrado_por?.id ?? "",
-                enviar_email: pagoVer.enviar_email ?? false,
-              }
-            : null
-        }
+        pago={pagoVer}
       />
     </SidebarProvider>
   );

--- a/src/components/forms/PagoForm.tsx
+++ b/src/components/forms/PagoForm.tsx
@@ -1,116 +1,203 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { createPago, updatePago } from "@/services/pagoService";
+import {
+  createPagoManualApi,
+  fetchPagoFormOptionsApi,
+  updatePagoApi,
+} from "@/services/browser/pagoApiClient";
+import { PagoManualFormOptions, ResponsePago } from "@/interfaces/pago.interface";
 import { toast } from "sonner";
 
 export interface PagoFormProps {
-  pago?: {
-    id?: string;
-    socio_id: string;
-    cuota_id: string;
-    fecha_pago: string;
-    fecha_vencimiento: string;
-    monto_pagado: number;
-    total: number;
-    registrado_por: string;
-  } | null;
+  pago?: ResponsePago | null;
   onCreated: () => void;
+}
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+function addMonthsIso(dateIso: string, months: number) {
+  const [year, month, day] = dateIso.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  date.setUTCMonth(date.getUTCMonth() + months);
+  return date.toISOString().slice(0, 10);
 }
 
 const emptyForm = {
   socio_id: "",
   cuota_id: "",
-  fecha_pago: "",
-  fecha_vencimiento: "",
+  fecha_pago: todayIso(),
+  periodo_desde: todayIso(),
+  periodo_hasta: addMonthsIso(todayIso(), 1),
+  meses_cubiertos: 1,
   monto_pagado: 0,
-  registrado_por: "",
+  metodo_pago: "efectivo" as const,
+  observaciones: "",
 };
 
 export default function PagoForm({ pago, onCreated }: PagoFormProps) {
   const [form, setForm] = useState(emptyForm);
+  const [options, setOptions] = useState<PagoManualFormOptions>({
+    socios: [],
+    cuotas: [],
+  });
   const [loading, setLoading] = useState(false);
+  const [loadingOptions, setLoadingOptions] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadOptions() {
+      try {
+        setLoadingOptions(true);
+        const data = await fetchPagoFormOptionsApi();
+        if (!mounted) return;
+        setOptions(data);
+      } catch (error: any) {
+        toast.error(error.message || "Error al cargar opciones de pago");
+      } finally {
+        if (mounted) setLoadingOptions(false);
+      }
+    }
+
+    loadOptions();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (pago) {
       setForm({
-        socio_id: pago.socio_id ?? "",
-        cuota_id: pago.cuota_id ?? "",
-        fecha_pago: pago.fecha_pago ?? "",
-        fecha_vencimiento: pago.fecha_vencimiento ?? "",
+        socio_id: pago.socio?.id_socio ?? "",
+        cuota_id: pago.cuota?.id ?? "",
+        fecha_pago: pago.fecha_pago ?? todayIso(),
+        periodo_desde: pago.periodo_desde ?? pago.fecha_pago ?? todayIso(),
+        periodo_hasta:
+          pago.periodo_hasta ?? pago.fecha_vencimiento ?? addMonthsIso(todayIso(), 1),
+        meses_cubiertos: pago.meses_cubiertos ?? 1,
         monto_pagado: pago.monto_pagado ?? 0,
-        registrado_por: pago.registrado_por ?? "",
+        metodo_pago: (pago.metodo_pago as "efectivo") ?? "efectivo",
+        observaciones: pago.observaciones ?? "",
       });
     } else {
       setForm(emptyForm);
     }
   }, [pago]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
+  const selectedCuota = useMemo(
+    () => options.cuotas.find((cuota) => cuota.id === form.cuota_id),
+    [form.cuota_id, options.cuotas]
+  );
+
+  useEffect(() => {
+    if (!selectedCuota || pago) return;
+
+    const monto = Number(selectedCuota.monto || 0) * Number(form.meses_cubiertos || 1);
     setForm((prev) => ({
       ...prev,
-      [name]: name === "monto_pagado" ? Number(value) : value,
+      monto_pagado: monto,
     }));
+  }, [selectedCuota, form.meses_cubiertos, pago]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+
+    setForm((prev) => {
+      const next = {
+        ...prev,
+        [name]:
+          name === "monto_pagado" || name === "meses_cubiertos"
+            ? Number(value)
+            : value,
+      };
+
+      if (name === "fecha_pago") {
+        next.periodo_desde = value;
+        next.periodo_hasta = addMonthsIso(value, Number(next.meses_cubiertos || 1));
+      }
+
+      if (name === "periodo_desde" || name === "meses_cubiertos") {
+        next.periodo_hasta = addMonthsIso(
+          name === "periodo_desde" ? value : next.periodo_desde,
+          Number(name === "meses_cubiertos" ? value : next.meses_cubiertos || 1)
+        );
+      }
+
+      return next;
+    });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+
     try {
-      if (pago && pago.id) {
-        await updatePago(pago.id, form);
+      if (pago?.id) {
+        await updatePagoApi(pago.id, form);
         toast.success("Pago actualizado");
       } else {
-        await createPago(form);
-        toast.success("Pago creado");
+        await createPagoManualApi(form);
+        toast.success("Pago manual registrado");
       }
+
       setForm(emptyForm);
       onCreated();
     } catch (error: any) {
-      let msg = error.message || "Error al guardar pago";
-      if (msg.includes("value too long")) {
-        msg =
-          "Uno de los campos excede la cantidad máxima de caracteres permitidos.";
-      }
-      toast.error(msg);
+      toast.error(error.message || "Error al guardar pago");
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="grid grid-cols-1 gap-4 md:grid-cols-2"
-    >
+    <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2">
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="socio_id">Socio</Label>
-        <Input
+        <select
           id="socio_id"
           name="socio_id"
-          placeholder="ID del socio"
           value={form.socio_id}
           onChange={handleChange}
           required
-        />
+          disabled={loadingOptions || Boolean(pago)}
+          className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="">Seleccionar socio</option>
+          {options.socios.map((socio) => (
+            <option key={socio.id_socio} value={socio.id_socio}>
+              {socio.nombre_completo}
+            </option>
+          ))}
+        </select>
       </div>
+
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="cuota_id">Cuota</Label>
-        <Input
+        <select
           id="cuota_id"
           name="cuota_id"
-          placeholder="ID de la cuota"
           value={form.cuota_id}
           onChange={handleChange}
-          required
-        />
+          disabled={loadingOptions || Boolean(pago)}
+          className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="">Cuota vigente / última activa</option>
+          {options.cuotas.map((cuota) => (
+            <option key={cuota.id} value={cuota.id}>
+              {cuota.descripcion} - ${Number(cuota.monto).toLocaleString("es-AR")}
+            </option>
+          ))}
+        </select>
       </div>
+
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha_pago">Fecha de Pago</Label>
+        <Label htmlFor="fecha_pago">Fecha de pago</Label>
         <Input
           id="fecha_pago"
           name="fecha_pago"
@@ -120,19 +207,47 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
           required
         />
       </div>
+
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha_vencimiento">Fecha de Vencimiento</Label>
+        <Label htmlFor="meses_cubiertos">Meses cubiertos</Label>
         <Input
-          id="fecha_vencimiento"
-          name="fecha_vencimiento"
-          type="date"
-          value={form.fecha_vencimiento}
+          id="meses_cubiertos"
+          name="meses_cubiertos"
+          type="number"
+          min={1}
+          max={24}
+          value={form.meses_cubiertos}
           onChange={handleChange}
           required
         />
       </div>
+
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="monto_pagado">Monto Pagado</Label>
+        <Label htmlFor="periodo_desde">Cubre desde</Label>
+        <Input
+          id="periodo_desde"
+          name="periodo_desde"
+          type="date"
+          value={form.periodo_desde}
+          onChange={handleChange}
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="periodo_hasta">Cubre hasta</Label>
+        <Input
+          id="periodo_hasta"
+          name="periodo_hasta"
+          type="date"
+          value={form.periodo_hasta}
+          onChange={handleChange}
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="monto_pagado">Monto pagado</Label>
         <Input
           id="monto_pagado"
           name="monto_pagado"
@@ -144,24 +259,39 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
           min={0}
         />
       </div>
+
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="registrado_por">Registrado Por</Label>
-        <Input
-          id="registrado_por"
-          name="registrado_por"
-          placeholder="Usuario"
-          value={form.registrado_por}
+        <Label htmlFor="metodo_pago">Método de pago</Label>
+        <select
+          id="metodo_pago"
+          name="metodo_pago"
+          value={form.metodo_pago}
           onChange={handleChange}
-          required
+          className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          <option value="efectivo">Efectivo</option>
+          <option value="transferencia">Transferencia</option>
+          <option value="otro">Otro</option>
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1.5 md:col-span-2">
+        <Label htmlFor="observaciones">Observaciones</Label>
+        <textarea
+          id="observaciones"
+          name="observaciones"
+          value={form.observaciones}
+          onChange={handleChange}
+          placeholder="Ejemplo: pago en efectivo en recepción"
+          className="min-h-20 rounded-md border border-input bg-background px-3 py-2 text-sm"
         />
       </div>
-      <button
-        type="submit"
-        className="px-4 py-2 text-white bg-blue-600 rounded col-span-full justify-self-end hover:bg-blue-700"
-        disabled={loading}
-      >
-        {loading ? "Guardando..." : pago ? "Actualizar Pago" : "Crear Pago"}
-      </button>
+
+      <div className="flex items-center justify-end gap-2 md:col-span-2">
+        <Button type="submit" disabled={loading || loadingOptions}>
+          {loading ? "Guardando..." : pago ? "Actualizar Pago" : "Registrar pago"}
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/components/modal/PagoViewModal.tsx
+++ b/src/components/modal/PagoViewModal.tsx
@@ -6,7 +6,58 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Pago } from "@/interfaces/pago.interface";
+import { ResponsePago } from "@/interfaces/pago.interface";
+
+function money(value?: number | null) {
+  if (value === null || value === undefined) return "-";
+  return `$${Number(value).toLocaleString("es-AR")}`;
+}
+
+function date(value?: string | null) {
+  if (!value) return "-";
+  return value;
+}
+
+
+function Pill({
+  children,
+  variant = "outline",
+}: {
+  children: React.ReactNode;
+  variant?: "outline" | "destructive";
+}) {
+  const variantClass =
+    variant === "destructive"
+      ? "border-red-200 bg-red-50 text-red-700"
+      : "border-border bg-background text-foreground";
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold capitalize ${variantClass}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Field({
+  label,
+  value,
+}: {
+  label: string;
+  value?: string | number | null;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </label>
+      <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm text-foreground">
+        {value === null || value === undefined || value === "" ? "-" : value}
+      </div>
+    </div>
+  );
+}
 
 export default function PagoViewModal({
   open,
@@ -15,63 +66,66 @@ export default function PagoViewModal({
 }: {
   open: boolean;
   onClose: () => void;
-  pago?: Pago | null;
+  pago?: ResponsePago | null;
 }) {
   if (!pago) return null;
 
+  const estado = pago.estado ?? "-";
+  const metodo = pago.metodo_pago ?? "-";
+  const periodoDesde = pago.periodo_desde ?? pago.fecha_pago;
+  const periodoHasta = pago.periodo_hasta ?? pago.fecha_vencimiento;
+
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="!max-w-[90vw] sm:!max-w-[800px] !w-full bg-background text-foreground">
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent className="!max-w-[90vw] sm:!max-w-[840px] !w-full bg-background text-foreground">
         <DialogHeader>
           <DialogTitle className="text-xl font-semibold text-foreground">
-            Detalle Pago
+            Detalle del pago
           </DialogTitle>
           <div className="text-sm text-right text-muted-foreground">
-            {new Date().toLocaleString()}
+            {new Date().toLocaleString("es-AR")}
           </div>
         </DialogHeader>
-        <div className="grid grid-cols-1 gap-6 mt-4 md:grid-cols-2">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Socio</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                {pago.socio_id || "-"}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Cuota</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                {pago.cuota_id || "-"}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Fecha Pago</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                {pago.fecha_pago || "-"}
-              </div>
-            </div>
-          </div>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Monto Pagado</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                ${pago.monto_pagado}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Registrado Por</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                {pago.registrado_por || "-"}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Total</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                ${pago.total}
-              </div>
-            </div>
-          </div>
+
+        <div className="grid grid-cols-1 gap-4 mt-4 md:grid-cols-2">
+          <Field label="Socio" value={pago.socio?.nombre_completo} />
+          <Field label="Cuota" value={pago.cuota?.descripcion} />
+          <Field label="Fecha de pago" value={date(pago.fecha_pago)} />
+          <Field label="Fecha de vencimiento" value={date(pago.fecha_vencimiento)} />
+          <Field label="Periodo desde" value={date(periodoDesde)} />
+          <Field label="Periodo hasta" value={date(periodoHasta)} />
+          <Field label="Meses cubiertos" value={pago.meses_cubiertos ?? 1} />
+          <Field label="Monto pagado" value={money(pago.monto_pagado)} />
+          <Field label="Total" value={money(pago.total ?? pago.monto_pagado)} />
+          <Field label="Registrado por" value={pago.registrado_por?.nombre} />
         </div>
+
+        <div className="grid grid-cols-1 gap-4 pt-4 mt-4 border-t md:grid-cols-2">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Método de pago
+            </label>
+            <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm capitalize">
+              <Pill variant="outline">{metodo}</Pill>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Estado
+            </label>
+            <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm capitalize">
+              <Pill variant={estado === "cancelado" ? "destructive" : "outline"}>{estado}</Pill>
+            </div>
+          </div>
+          <Field label="Stripe session" value={pago.stripe_session_id} />
+          <Field label="Stripe payment intent" value={pago.stripe_payment_intent_id} />
+        </div>
+
+        {pago.observaciones ? (
+          <div className="pt-4 mt-4 border-t">
+            <Field label="Observaciones" value={pago.observaciones} />
+          </div>
+        ) : null}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/tables/PagoTable.tsx
+++ b/src/components/tables/PagoTable.tsx
@@ -15,6 +15,11 @@ import {
 } from "@/components/ui/table";
 import { ResponsePago } from "@/interfaces/pago.interface";
 
+function money(value?: number | null) {
+  if (value === null || value === undefined) return "-";
+  return `$${Number(value).toLocaleString("es-AR")}`;
+}
+
 export default function PagoTable({
   pagos,
   loading,
@@ -53,28 +58,36 @@ export default function PagoTable({
           <TableHead>Socio</TableHead>
           <TableHead>Cuota</TableHead>
           <TableHead>Fecha Pago</TableHead>
-          <TableHead>Vencimiento</TableHead>
-          <TableHead>Monto Pagado</TableHead>
-          <TableHead>Total</TableHead>
+          <TableHead>Cobertura</TableHead>
+          <TableHead>Método</TableHead>
+          <TableHead>Estado</TableHead>
+          <TableHead>Monto</TableHead>
           <TableHead>Registrado Por</TableHead>
           <TableHead>Acciones</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {pagos.map((p, i) => (
+        {pagos.map((p) => (
           <TableRow
-            key={i}
+            key={p.id}
             className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors"
           >
             <TableCell className="font-medium">
-              {p.socio.nombre_completo}
+              {p.socio?.nombre_completo ?? "-"}
             </TableCell>
-            <TableCell>{p.cuota.descripcion}</TableCell>
+            <TableCell>{p.cuota?.descripcion ?? "-"}</TableCell>
             <TableCell>{p.fecha_pago}</TableCell>
-            <TableCell>{p.fecha_vencimiento}</TableCell>
-            <TableCell>${p.monto_pagado}</TableCell>
-            <TableCell>${p.total}</TableCell>
-            <TableCell>{p.registrado_por.nombre}</TableCell>
+            <TableCell>
+              <div className="flex flex-col text-xs">
+                <span>{p.periodo_desde ?? p.fecha_pago}</span>
+                <span>hasta {p.periodo_hasta ?? p.fecha_vencimiento}</span>
+                <span>{p.meses_cubiertos ?? 1} mes/es</span>
+              </div>
+            </TableCell>
+            <TableCell className="capitalize">{p.metodo_pago ?? "-"}</TableCell>
+            <TableCell className="capitalize">{p.estado ?? "-"}</TableCell>
+            <TableCell>{money(p.monto_pagado)}</TableCell>
+            <TableCell>{p.registrado_por?.nombre ?? "-"}</TableCell>
             <TableCell className="flex gap-2">
               <Button
                 size="sm"
@@ -104,7 +117,7 @@ export default function PagoTable({
       </TableBody>
       <TableFooter>
         <TableRow>
-          <TableCell colSpan={7}>Total de pagos</TableCell>
+          <TableCell colSpan={8}>Total de pagos</TableCell>
           <TableCell className="text-right">{pagos.length}</TableCell>
         </TableRow>
       </TableFooter>

--- a/src/interfaces/pago.interface.ts
+++ b/src/interfaces/pago.interface.ts
@@ -1,3 +1,6 @@
+export type MetodoPago = 'efectivo' | 'stripe' | 'transferencia' | 'otro';
+export type EstadoPago = 'pagado' | 'pendiente' | 'cancelado';
+
 export interface Pago {
   id: string;
   socio_id: string;
@@ -5,46 +8,112 @@ export interface Pago {
   fecha_pago: string;
   fecha_vencimiento: string;
   monto_pagado: number;
-  total: number;
-  registrado_por: string;
-  enviar_email: boolean; 
+  total: number | null;
+  registrado_por: string | null;
+  enviar_email: boolean;
+  periodo_desde?: string | null;
+  periodo_hasta?: string | null;
+  meses_cubiertos?: number | null;
+  metodo_pago?: MetodoPago | string | null;
+  estado?: EstadoPago | string | null;
+  stripe_session_id?: string | null;
+  stripe_payment_intent_id?: string | null;
+  observaciones?: string | null;
+  activo?: boolean | null;
 }
 
 export interface CreatePagoDto {
   socio_id: string;
-  registrado_por: string;
+  cuota_id?: string;
+  fecha_pago?: string;
+  periodo_desde?: string;
+  periodo_hasta?: string;
+  meses_cubiertos?: number;
+  monto_pagado?: number;
+  metodo_pago?: MetodoPago;
+  observaciones?: string;
+  enviar_email?: boolean;
+  /**
+   * Compatibilidad temporal con el flujo legacy de Stripe webhook.
+   * El registro manual desde admin usa el usuario autenticado en server-side.
+   * Este campo se mantendrá hasta refactorizar stripe-webhook a la nueva base de pagos.
+   */
+  registrado_por?: string;
 }
-
 
 export interface UpdatePagoDto {
   socio_id?: string;
   cuota_id?: string;
   fecha_pago?: string;
   fecha_vencimiento?: string;
+  periodo_desde?: string;
+  periodo_hasta?: string;
+  meses_cubiertos?: number;
   monto_pagado?: number;
   registrado_por?: string;
+  metodo_pago?: MetodoPago;
+  estado?: EstadoPago;
+  observaciones?: string;
   activo?: boolean;
-  enviar_email?: boolean; // Indica si se debe enviar un email de notificación
+  enviar_email?: boolean;
 }
 
 export interface ResponsePago {
+  id: string;
+
+  fecha_pago: string;
+  fecha_vencimiento: string;
+
+  periodo_desde?: string | null;
+  periodo_hasta?: string | null;
+  meses_cubiertos?: number | null;
+
+  monto_pagado: number;
+  total: number | null;
+
+  metodo_pago?: string | null;
+  estado?: string | null;
+  observaciones?: string | null;
+  enviar_email: boolean;
+  activo?: boolean | null;
+
+  stripe_session_id?: string | null;
+  stripe_payment_intent_id?: string | null;
+
+  registrado_por: {
     id: string;
-    fecha_pago: string;
-    fecha_vencimiento: string;
-    monto_pagado: number;
-    total: number;
-    enviar_email: boolean;
-    registrado_por: {
-        id: string;
-        nombre: string;
-    };
-    socio: {
-        id_socio: string;
-        nombre_completo: string;
-    };
-    cuota: {
-        id: string;
-        descripcion: string;
-    };
-    
+    nombre: string;
+  } | null;
+
+  socio: {
+    id_socio: string;
+    nombre_completo: string;
+    email?: string | null;
+  };
+
+  cuota: {
+    id: string;
+    descripcion: string;
+    monto?: number | null;
+    periodo?: string | null;
+  };
+}
+
+export interface PagoManualFormOptions {
+  socios: Array<{
+    id_socio: string;
+    nombre_completo: string;
+    email?: string | null;
+    activo: boolean;
+    descuento_activo?: boolean | null;
+  }>;
+  cuotas: Array<{
+    id: string;
+    descripcion: string;
+    monto: number;
+    periodo?: string | null;
+    fecha_inicio: string;
+    fecha_fin: string;
+    activo?: boolean | null;
+  }>;
 }

--- a/src/services/browser/pagoApiClient.ts
+++ b/src/services/browser/pagoApiClient.ts
@@ -1,0 +1,79 @@
+import {
+  CreatePagoDto,
+  PagoManualFormOptions,
+  ResponsePago,
+  UpdatePagoDto,
+} from '@/interfaces/pago.interface';
+import { authHeader } from '@/services/storageService';
+
+async function parseResponse<T>(res: Response): Promise<T> {
+  const payload = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    throw new Error(payload.error || payload.message || 'Error en la operación de pagos');
+  }
+
+  return payload as T;
+}
+
+export async function fetchPagosApi(): Promise<ResponsePago[]> {
+  const res = await fetch('/api/pagos', {
+    method: 'GET',
+    headers: authHeader(),
+  });
+  const payload = await parseResponse<{ data: ResponsePago[] }>(res);
+  return payload.data ?? [];
+}
+
+export async function fetchPagoFormOptionsApi(): Promise<PagoManualFormOptions> {
+  const res = await fetch('/api/pagos?options=true', {
+    method: 'GET',
+    headers: authHeader(),
+  });
+  const payload = await parseResponse<{ data: PagoManualFormOptions }>(res);
+  return payload.data;
+}
+
+export async function createPagoManualApi(
+  payload: CreatePagoDto
+): Promise<ResponsePago> {
+  const res = await fetch('/api/pagos', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify(payload),
+  });
+  const response = await parseResponse<{ data: ResponsePago }>(res);
+  return response.data;
+}
+
+export async function updatePagoApi(
+  id: string,
+  updateData: UpdatePagoDto
+): Promise<ResponsePago> {
+  const res = await fetch('/api/pagos', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify({ id, updateData }),
+  });
+  const response = await parseResponse<{ data: ResponsePago }>(res);
+  return response.data;
+}
+
+export async function deletePagoApi(id: string): Promise<ResponsePago> {
+  const res = await fetch('/api/pagos', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader(),
+    },
+    body: JSON.stringify({ id }),
+  });
+  const response = await parseResponse<{ data: ResponsePago }>(res);
+  return response.data;
+}

--- a/src/services/pagoService.ts
+++ b/src/services/pagoService.ts
@@ -1,7 +1,12 @@
 import { getSupabaseClient, supabase } from "./supabaseClient";
-import { Pago, CreatePagoDto, UpdatePagoDto, ResponsePago } from "../interfaces/pago.interface";
-import  dayjs  from 'dayjs';
-import { getSocioById, updateSocio } from "./socioService";
+import {
+  Pago,
+  CreatePagoDto,
+  UpdatePagoDto,
+  ResponsePago,
+} from "../interfaces/pago.interface";
+import dayjs from "dayjs";
+import { getSocioById } from "./socioService";
 
 /*export const getAllPagos = async (): Promise<Pago[]> => {
   const { data, error } = await supabase.from("pago").select();
@@ -9,163 +14,327 @@ import { getSocioById, updateSocio } from "./socioService";
   return data as Pago[];
 };
 */
-export const getAllPagos = async () : Promise<ResponsePago[]> => {
-    
+
+type PagoRow = {
+  id: string;
+  socio_id?: string;
+  cuota_id?: string;
+  fecha_pago: string;
+  fecha_vencimiento: string;
+  periodo_desde?: string | null;
+  periodo_hasta?: string | null;
+  meses_cubiertos?: number | null;
+  monto_pagado: number;
+  total?: number | null;
+  metodo_pago?: string | null;
+  estado?: string | null;
+  observaciones?: string | null;
+  enviar_email?: boolean | null;
+  activo?: boolean | null;
+  stripe_session_id?: string | null;
+  stripe_payment_intent_id?: string | null;
+  registrado_por:
+    | {
+        id: string;
+        nombre: string;
+      }
+    | null;
+  socio:
+    | {
+        id_socio: string;
+        nombre_completo: string;
+        email?: string | null;
+      }
+    | null;
+  cuota:
+    | {
+        id: string;
+        descripcion: string;
+        monto?: number | null;
+        periodo?: string | null;
+        fecha_fin?: string | null;
+      }
+    | null;
+};
+
+export const getAllPagos = async (): Promise<ResponsePago[]> => {
   const { data, error } = await supabase
-  .from("pago")
-  .select(`*, 
-    socio: socio_id ( id_socio, nombre_completo ),
-    cuota: cuota_id (id, descripcion, fecha_fin),
-    registrado_por: registrado_por( id, nombre )
-    `);
-    
-console.log(error, data);
+    .from("pago")
+    .select(`
+      *,
+      socio:socio_id (
+        id_socio,
+        nombre_completo,
+        email
+      ),
+      cuota:cuota_id (
+        id,
+        descripcion,
+        monto,
+        periodo,
+        fecha_fin
+      ),
+      registrado_por:registrado_por (
+        id,
+        nombre
+      )
+    `)
+    .order("fecha_pago", { ascending: false });
+
+  console.log(error, data);
 
   if (error) throw new Error(error.message);
 
-  const response = responseAllPagos(data as ResponsePago[]);
-  return response;
+  return responseAllPagos((data ?? []) as PagoRow[]);
 };
 
-//Genere esta funcion para transformar el formato de la respuesta y simplificar el uso en la funcion del get
-const responseAllPagos = (data : ResponsePago[]) :  ResponsePago[] =>{
- const response : ResponsePago[] = data.map(pago=>(responsePago(pago)));
-  return response;
-}
-const responsePago = (data: ResponsePago): ResponsePago => {
+// Genera una respuesta segura y simplificada para consumir en UI.
+const responseAllPagos = (data: PagoRow[]): ResponsePago[] => {
+  return data.map((pago) => responsePago(pago));
+};
+
+const responsePago = (data: PagoRow): ResponsePago => {
   return {
     id: data.id,
+
     fecha_pago: data.fecha_pago,
     fecha_vencimiento: data.fecha_vencimiento,
+
+    periodo_desde: data.periodo_desde ?? null,
+    periodo_hasta: data.periodo_hasta ?? null,
+    meses_cubiertos: data.meses_cubiertos ?? null,
+
     monto_pagado: data.monto_pagado,
-    total: data.total,
-    enviar_email: data.enviar_email,
-    registrado_por:{
-        id: data.registrado_por.id,
-        nombre: data.registrado_por.nombre
-    },
-    cuota:{
-        id: data.cuota.id,
-        descripcion: data.cuota.descripcion
-    },
-    socio:{
-        id_socio: data.socio.id_socio,
-        nombre_completo: data.socio.nombre_completo
-    }
+    total: data.total ?? null,
+
+    metodo_pago: data.metodo_pago ?? null,
+    estado: data.estado ?? null,
+    observaciones: data.observaciones ?? null,
+    enviar_email: data.enviar_email ?? false,
+    activo: data.activo ?? true,
+
+    stripe_session_id: data.stripe_session_id ?? null,
+    stripe_payment_intent_id: data.stripe_payment_intent_id ?? null,
+
+    registrado_por: data.registrado_por
+      ? {
+          id: data.registrado_por.id,
+          nombre: data.registrado_por.nombre,
+        }
+      : null,
+
+    cuota: data.cuota
+      ? {
+          id: data.cuota.id,
+          descripcion: data.cuota.descripcion,
+          monto: data.cuota.monto ?? null,
+          periodo: data.cuota.periodo ?? null,
+        }
+      : {
+          id: data.cuota_id ?? "",
+          descripcion: "Cuota no disponible",
+          monto: null,
+          periodo: null,
+        },
+
+    socio: data.socio
+      ? {
+          id_socio: data.socio.id_socio,
+          nombre_completo: data.socio.nombre_completo,
+          email: data.socio.email ?? null,
+        }
+      : {
+          id_socio: data.socio_id ?? "",
+          nombre_completo: "Socio no disponible",
+          email: null,
+        },
   };
-}
+};
 
+export const createPago = async (payload: CreatePagoDto): Promise<Pago> => {
+  const dto = payload as CreatePagoDto & {
+    cuota_id?: string;
+    fecha_pago?: string;
+    fecha_vencimiento?: string;
+    periodo_desde?: string;
+    periodo_hasta?: string;
+    meses_cubiertos?: number;
+    monto_pagado?: number;
+    metodo_pago?: string;
+    estado?: string;
+    registrado_por?: string | null;
+    observaciones?: string | null;
+    enviar_email?: boolean;
+    stripe_session_id?: string | null;
+    stripe_payment_intent_id?: string | null;
+  };
 
-export const createPago = async (payload: CreatePagoDto) :Promise<Pago> => {
+  const { data: cuota, error: cuotaError } = dto.cuota_id
+    ? await supabase.from("cuota").select().eq("id", dto.cuota_id).single()
+    : await supabase
+        .from("cuota")
+        .select()
+        .eq("activo", true)
+        .order("creado_en", { ascending: false })
+        .limit(1)
+        .single();
 
-    const { data :cuota , error:cuotaError } = await supabase
-  .from("cuota")
-  .select()
-  .order('creado_en', { ascending: false })
-  .limit(1)
-  .single();
-
-    if (cuotaError) {
+  if (cuotaError) {
     console.log(cuotaError.message);
-    throw new Error("Error al traer la cuota")}
-    ;
-  
-  const id_cuota = cuota.id
-  const fecha_pago = dayjs().format("YYYY-MM-DD");
-  const fecha_vencimiento = dayjs(fecha_pago).add(30, 'day').format("YYYY-MM-DD"); // fecha de vencimiento es hoy + 30 dias
-  
-  const { socio_id, registrado_por } = payload; 
-  
-  const socio = await getSocioById(socio_id);
-  let monto_pagado;
-
-  if (socio.descuento_activo) {
-monto_pagado = cuota.monto - (cuota.monto * 0.10); // Asignar el monto de la cuota al pago con descuento
-  } else {
-    monto_pagado = cuota.monto; // en caso que no tenga descuento, se le asigna el monto total de la cuota
+    throw new Error("Error al traer la cuota");
   }
 
+  const socioId = dto.socio_id;
+  const cuotaId = cuota.id;
 
+  const fechaPago = dto.fecha_pago ?? dayjs().format("YYYY-MM-DD");
+  const mesesCubiertos = dto.meses_cubiertos ?? 1;
 
-  const { data, error } = await supabase.from("pago").insert({
-    socio_id,
-    cuota_id: id_cuota,
-    fecha_pago,
-    fecha_vencimiento,
-    monto_pagado,
-    registrado_por,
-    enviar_email: true, // Por defecto, se envía el email de notificación
-    
-  }).select().single();
+  const periodoDesde = dto.periodo_desde ?? fechaPago;
+  const periodoHasta =
+    dto.periodo_hasta ??
+    dto.fecha_vencimiento ??
+    dayjs(periodoDesde).add(mesesCubiertos, "month").format("YYYY-MM-DD");
+
+  const fechaVencimiento = dto.fecha_vencimiento ?? periodoHasta;
+
+  const socio = await getSocioById(socioId);
+
+  let montoPagado = dto.monto_pagado;
+
+  if (!montoPagado) {
+    if (socio.descuento_activo) {
+      montoPagado = cuota.monto - cuota.monto * 0.1;
+    } else {
+      montoPagado = cuota.monto;
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("pago")
+    .insert({
+      socio_id: socioId,
+      cuota_id: cuotaId,
+      fecha_pago: fechaPago,
+      fecha_vencimiento: fechaVencimiento,
+      periodo_desde: periodoDesde,
+      periodo_hasta: periodoHasta,
+      meses_cubiertos: mesesCubiertos,
+      monto_pagado: montoPagado,
+      metodo_pago: dto.metodo_pago ?? "efectivo",
+      estado: dto.estado ?? "pagado",
+      registrado_por: dto.registrado_por ?? null,
+      observaciones: dto.observaciones ?? null,
+      enviar_email: dto.enviar_email ?? true,
+      activo: true,
+      stripe_session_id: dto.stripe_session_id ?? null,
+      stripe_payment_intent_id: dto.stripe_payment_intent_id ?? null,
+    })
+    .select()
+    .single();
+
   if (error) {
     console.log(error.message);
-    throw new Error("Error al crear el pago")}
-    ;
+    throw new Error("Error al crear el pago");
+  }
 
-    //TODO: Debo crear la logica para pasarle el user logueado a todo los endpoint pagos
-    //updateSocio(user, id_socio, { descuento_activo: false }); // Desactivar el descuento del socio después de realizar el pago
-
-    const {data: dataSocio,error: errorSocio} = await supabase
-    .from('socio')
+  const { data: dataSocio, error: errorSocio } = await supabase
+    .from("socio")
     .update({ descuento_activo: false })
-    .eq('id_socio', socio_id);
-    if (errorSocio) {
-        console.log(errorSocio.message);
-        throw new Error("Error al actualizar el socio para desactivar el descuento");
-    }
-    if (dataSocio) {
-        console.log("Descuento del socio desactivado correctamente");
-        console.log("dataSocio", dataSocio);
-        
-    }
+    .eq("id_socio", socioId);
 
-    
+  if (errorSocio) {
+    console.log(errorSocio.message);
+    throw new Error("Error al actualizar el socio para desactivar el descuento");
+  }
+
+  if (dataSocio) {
+    console.log("Descuento del socio desactivado correctamente");
+    console.log("dataSocio", dataSocio);
+  }
+
   return data as Pago;
 };
 
+export const updatePago = async (
+  id: string,
+  updateData: UpdatePagoDto
+): Promise<Pago> => {
+  const { data, error } = await supabase
+    .from("pago")
+    .update(updateData)
+    .eq("id", id)
+    .select()
+    .single();
 
-export const updatePago = async (id: string, updateData: UpdatePagoDto): Promise<Pago> => {
-  const { data, error } = await supabase.from("pago").update(updateData).eq("id", id).select().single();
   if (error) throw new Error(error.message);
-  if (!data || data.length === 0) throw new Error("No se encontró pago con ese id");
+  if (!data) throw new Error("No se encontró pago con ese id");
+
   return data as Pago;
 };
 
 export const deletePago = async (id: string): Promise<Pago> => {
-  const { data, error } = await supabase.from("pago").update({ activo: false }).eq("id", id).select().single();
+  const { data, error } = await supabase
+    .from("pago")
+    .update({
+      activo: false,
+      estado: "cancelado",
+    })
+    .eq("id", id)
+    .select()
+    .single();
+
   if (error) throw new Error(error.message);
   if (!data) throw new Error("No se encontró pago con ese id");
+
   return data as Pago;
 };
 
 export const getPagoById = async (id: string): Promise<ResponsePago> => {
   const { data, error } = await supabase
     .from("pago")
-      .select(`*, 
-    socio: socio_id ( id_socio, nombre_completo ),
-    cuota: cuota_id (id, descripcion, fecha_fin),
-    registrado_por: registrado_por( id, nombre )
+    .select(`
+      *,
+      socio:socio_id (
+        id_socio,
+        nombre_completo,
+        email
+      ),
+      cuota:cuota_id (
+        id,
+        descripcion,
+        monto,
+        periodo,
+        fecha_fin
+      ),
+      registrado_por:registrado_por (
+        id,
+        nombre
+      )
     `)
     .eq("id", id)
     .single();
+
   if (error) {
     console.log(error.message);
     throw new Error("No se encontró el pago con ese id");
   }
-  const response = responsePago(data);
-  return response;
+
+  return responsePago(data as PagoRow);
 };
 
 // Funciones para métricas de pagos
 export const dataAnalisisConductaPagos = async (user: any) => {
-    const supabase = getSupabaseClient();
-    const { data, error } = await supabase
-        .rpc('sp_analisis_conducta_pagos');
-    if (error) throw new Error(error.message);
-    return data;
-}
+  const supabase = getSupabaseClient();
+
+  const { data, error } = await supabase.rpc("sp_analisis_conducta_pagos");
+
+  if (error) throw new Error(error.message);
+
+  return data;
+};
 
 export const dataProyeccionIngresos = async (user: any) => {
-    //TODO IMPLEMENTAR LÓGICA DE PROYECCIÓN DE INGRESOS
-    throw new Error("Funcionalidad no implementada");
-}
+  // TODO IMPLEMENTAR LÓGICA DE PROYECCIÓN DE INGRESOS
+  throw new Error("Funcionalidad no implementada");
+};

--- a/src/services/server/pagoServerService.ts
+++ b/src/services/server/pagoServerService.ts
@@ -1,0 +1,294 @@
+import { JwtUser } from '@/interfaces/jwtUser.interface';
+import {
+  CreatePagoDto,
+  Pago,
+  PagoManualFormOptions,
+  ResponsePago,
+  UpdatePagoDto,
+} from '@/interfaces/pago.interface';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+
+const allowedManagerRoles = new Set(['admin', 'usuario']);
+
+function assertCanManagePayments(user: JwtUser) {
+  if (!allowedManagerRoles.has(user.rol)) {
+    throw new Error('No autorizado para administrar pagos');
+  }
+}
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addMonthsIso(dateIso: string, months: number) {
+  const [year, month, day] = dateIso.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  date.setUTCMonth(date.getUTCMonth() + months);
+  return date.toISOString().slice(0, 10);
+}
+
+function toNumber(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function toPositiveInteger(value: unknown, fallback = 1) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.floor(parsed);
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+}
+
+function normalizePago(row: any): ResponsePago {
+  return {
+    id: row.id,
+    fecha_pago: row.fecha_pago,
+    fecha_vencimiento: row.fecha_vencimiento,
+    periodo_desde: row.periodo_desde ?? null,
+    periodo_hasta: row.periodo_hasta ?? null,
+    meses_cubiertos: row.meses_cubiertos ?? null,
+    monto_pagado: Number(row.monto_pagado ?? 0),
+    total: row.total === null || row.total === undefined ? null : Number(row.total),
+    metodo_pago: row.metodo_pago ?? null,
+    estado: row.estado ?? null,
+    observaciones: row.observaciones ?? null,
+    enviar_email: Boolean(row.enviar_email),
+    activo: row.activo ?? null,
+    registrado_por: row.registrado_por
+      ? {
+          id: row.registrado_por.id,
+          nombre: row.registrado_por.nombre,
+        }
+      : null,
+    socio: {
+      id_socio: row.socio?.id_socio ?? row.socio_id,
+      nombre_completo: row.socio?.nombre_completo ?? 'Socio sin nombre',
+    },
+    cuota: {
+      id: row.cuota?.id ?? row.cuota_id,
+      descripcion: row.cuota?.descripcion ?? 'Cuota',
+      monto: row.cuota?.monto ?? null,
+    },
+  };
+}
+
+const pagoSelect = `
+  *,
+  socio:socio_id(id_socio,nombre_completo,email),
+  cuota:cuota_id(id,descripcion,monto,fecha_fin),
+  registrado_por:registrado_por(id,nombre)
+`;
+
+export async function fetchPagosServer(user: JwtUser): Promise<ResponsePago[]> {
+  assertCanManagePayments(user);
+  const supabase = getSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from('pago')
+    .select(pagoSelect)
+    .eq('activo', true)
+    .order('fecha_pago', { ascending: false })
+    .order('creado_en', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []).map(normalizePago);
+}
+
+export async function fetchPagoFormOptionsServer(
+  user: JwtUser
+): Promise<PagoManualFormOptions> {
+  assertCanManagePayments(user);
+  const supabase = getSupabaseServerClient();
+
+  const [sociosResult, cuotasResult] = await Promise.all([
+    supabase
+      .from('socio')
+      .select('id_socio,nombre_completo,email,activo,descuento_activo')
+      .eq('activo', true)
+      .order('nombre_completo', { ascending: true }),
+    supabase
+      .from('cuota')
+      .select('id,descripcion,monto,periodo,fecha_inicio,fecha_fin,activo')
+      .eq('activo', true)
+      .order('fecha_inicio', { ascending: false }),
+  ]);
+
+  if (sociosResult.error) throw new Error(sociosResult.error.message);
+  if (cuotasResult.error) throw new Error(cuotasResult.error.message);
+
+  return {
+    socios: sociosResult.data ?? [],
+    cuotas: cuotasResult.data ?? [],
+  };
+}
+
+async function resolveCuota(cuotaId?: string | null) {
+  const supabase = getSupabaseServerClient();
+
+  if (cuotaId) {
+    const { data, error } = await supabase
+      .from('cuota')
+      .select('id,descripcion,monto,fecha_inicio,fecha_fin,activo')
+      .eq('id', cuotaId)
+      .single();
+
+    if (error || !data) throw new Error('No se encontró la cuota seleccionada');
+    return data;
+  }
+
+  const today = todayIso();
+  const current = await supabase
+    .from('cuota')
+    .select('id,descripcion,monto,fecha_inicio,fecha_fin,activo')
+    .eq('activo', true)
+    .lte('fecha_inicio', today)
+    .gte('fecha_fin', today)
+    .order('fecha_inicio', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (current.error) throw new Error(current.error.message);
+  if (current.data) return current.data;
+
+  const latest = await supabase
+    .from('cuota')
+    .select('id,descripcion,monto,fecha_inicio,fecha_fin,activo')
+    .eq('activo', true)
+    .order('fecha_inicio', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (latest.error) throw new Error(latest.error.message);
+  if (!latest.data) throw new Error('No existe una cuota activa para registrar el pago');
+  return latest.data;
+}
+
+async function resolveSocio(socioId: string) {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('socio')
+    .select('id_socio,nombre_completo,activo,descuento_activo')
+    .eq('id_socio', socioId)
+    .single();
+
+  if (error || !data) throw new Error('No se encontró el socio seleccionado');
+  if (!data.activo) throw new Error('El socio seleccionado está inactivo');
+  return data;
+}
+
+export async function createPagoManualServer(
+  user: JwtUser,
+  payload: CreatePagoDto
+): Promise<ResponsePago> {
+  assertCanManagePayments(user);
+
+  if (!payload.socio_id) throw new Error('El socio es obligatorio');
+
+  const supabase = getSupabaseServerClient();
+  const cuota = await resolveCuota(payload.cuota_id);
+  const socio = await resolveSocio(payload.socio_id);
+
+  const fechaPago = normalizeString(payload.fecha_pago) ?? todayIso();
+  const mesesCubiertos = Math.min(
+    Math.max(toPositiveInteger(payload.meses_cubiertos, 1), 1),
+    24
+  );
+  const periodoDesde = normalizeString(payload.periodo_desde) ?? fechaPago;
+  const periodoHasta =
+    normalizeString(payload.periodo_hasta) ?? addMonthsIso(periodoDesde, mesesCubiertos);
+
+  const montoBase = toNumber(cuota.monto, 0) * mesesCubiertos;
+  const montoConDescuento = socio.descuento_activo ? montoBase * 0.9 : montoBase;
+  const montoPagado = toNumber(payload.monto_pagado, montoConDescuento);
+
+  if (montoPagado <= 0) throw new Error('El monto pagado debe ser mayor a 0');
+
+  const insertPayload = {
+    socio_id: payload.socio_id,
+    cuota_id: cuota.id,
+    fecha_pago: fechaPago,
+    fecha_vencimiento: periodoHasta,
+    periodo_desde: periodoDesde,
+    periodo_hasta: periodoHasta,
+    meses_cubiertos: mesesCubiertos,
+    monto_pagado: montoPagado,
+    registrado_por: user.id,
+    metodo_pago: payload.metodo_pago ?? 'efectivo',
+    estado: 'pagado',
+    observaciones: normalizeString(payload.observaciones),
+    enviar_email: payload.enviar_email ?? true,
+    activo: true,
+  };
+
+  const { data, error } = await supabase
+    .from('pago')
+    .insert(insertPayload)
+    .select(pagoSelect)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  if (socio.descuento_activo) {
+    await supabase
+      .from('socio')
+      .update({ descuento_activo: false })
+      .eq('id_socio', payload.socio_id);
+  }
+
+  return normalizePago(data);
+}
+
+export async function updatePagoServer(
+  user: JwtUser,
+  id: string,
+  updateData: UpdatePagoDto
+): Promise<ResponsePago> {
+  assertCanManagePayments(user);
+  if (!id) throw new Error('ID de pago requerido');
+
+  const supabase = getSupabaseServerClient();
+  const payload: Record<string, unknown> = { ...updateData };
+  delete payload.total;
+
+  if (payload.periodo_hasta) {
+    payload.fecha_vencimiento = payload.periodo_hasta;
+  }
+
+  const { data, error } = await supabase
+    .from('pago')
+    .update(payload)
+    .eq('id', id)
+    .select(pagoSelect)
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el pago');
+
+  return normalizePago(data);
+}
+
+export async function deactivatePagoServer(
+  user: JwtUser,
+  id: string
+): Promise<ResponsePago> {
+  assertCanManagePayments(user);
+  if (!id) throw new Error('ID de pago requerido');
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('pago')
+    .update({ activo: false, estado: 'cancelado' })
+    .eq('id', id)
+    .select(pagoSelect)
+    .single();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('No se encontró el pago');
+
+  return normalizePago(data);
+}


### PR DESCRIPTION
# PR: feat: add manual membership payments from admin dashboard

## Resumen

Este PR incorpora el flujo de pagos manuales desde el panel de administración de Gym Master, permitiendo registrar pagos de cuotas directamente desde el dashboard sin operar manualmente sobre Supabase.

La mejora se apoya sobre la base ya creada en `feature/cuotas-pagos-foundation`, utilizando los campos `periodo_desde`, `periodo_hasta`, `meses_cubiertos`, `metodo_pago`, `estado`, `observaciones`, `activo` y trazabilidad Stripe cuando corresponde.

## Cambios principales

- Se actualiza el módulo de pagos del dashboard administrativo.
- Se agrega flujo de registro de pago manual desde `/dashboard/pagos`.
- Se permite seleccionar socio, cuota, fecha de pago, meses cubiertos, método de pago y observaciones.
- Se calcula y persiste el período cubierto por el pago.
- Se agrega soporte para baja lógica de pagos mediante `activo = false` y `estado = cancelado`.
- Se actualiza el servicio de pagos para trabajar con datos enriquecidos de socio, cuota y usuario registrador.
- Se corrige el modal de detalle de pago para mostrar información legible en lugar de UUIDs.
- Se agregan campos de detalle como período cubierto, meses cubiertos, método de pago, estado, Stripe session, payment intent y observaciones.
- Se agrega compatibilidad temporal con el webhook legacy de Stripe para evitar errores de tipado durante build.
- Se actualizan interfaces TypeScript para reflejar el modelo real de pagos posterior a la foundation de cuotas/pagos.

## Archivos principales modificados

- `src/app/api/pagos/route.ts`
- `src/services/server/pagoServerService.ts`
- `src/services/browser/pagoApiClient.ts`
- `src/services/pagoService.ts`
- `src/interfaces/pago.interface.ts`
- `src/components/forms/PagoForm.tsx`
- `src/components/tables/PagoTable.tsx`
- `src/components/modal/PagoViewModal.tsx`
- `src/app/dashboard/pagos/page.tsx`
- `src/app/api/stripe-webhook/route.ts`
- `database/scripts/validar_pagos_manuales_admin.sql`
- `docs/cuotas-pagos/pagos-manuales-admin.md`

## Validaciones realizadas

- Se validó visualmente el listado de pagos en `/dashboard/pagos`.
- Se validó el modal de detalle del pago mostrando datos legibles:
  - socio,
  - cuota,
  - fecha de pago,
  - fecha de vencimiento,
  - período desde/hasta,
  - meses cubiertos,
  - monto pagado,
  - total,
  - usuario registrador,
  - método de pago,
  - estado,
  - observaciones.
- Se confirmó que el modal ya no muestra UUIDs como dato principal.
- Se corrigieron errores de tipado relacionados con `ResponsePago`, `registrado_por` nulo y campos Stripe.

## Validación recomendada antes de merge

Ejecutar:

```bash
npm run build
npm run dev
```

Pruebas funcionales sugeridas:

1. Login como administrador.
2. Entrar a `/dashboard/pagos`.
3. Registrar un pago manual para un socio QA sin pagos.
4. Verificar que el pago aparece en el listado.
5. Abrir el modal con el botón **Ver**.
6. Confirmar que se muestran nombres/descripciones y no UUIDs.
7. Revisar que el dashboard de estado de cuotas refleje el cambio.
8. Probar baja lógica con **Eliminar**.

## Impacto funcional

Esta feature convierte el módulo de pagos en una herramienta operativa para el administrador del gimnasio, permitiendo registrar pagos en efectivo o medios manuales y dejando preparada la base para integrar mejor el flujo Stripe en una rama posterior.

## Próximos pasos sugeridos

- Refactorizar el flujo Stripe y webhook en `feature/pagos-stripe-webhook`.
- Conectar pagos manuales con el dashboard BI de cuotas/pagos.
- Agregar validaciones UX para fecha, cantidad de meses y cuota vigente.
- Revisar permisos y auditoría administrativa para pagos sensibles.
