### PR TITLE
feat: add fallback images for workout exercises

### DIFF
--- a/database/scripts/validar_rutinas_exercise_images_fallback.sql
+++ b/database/scripts/validar_rutinas_exercise_images_fallback.sql
@@ -1,0 +1,40 @@
+-- =============================================================================
+-- Validación: rutinas exercise images fallback
+-- =============================================================================
+
+\echo '1. Resumen de ejercicios por objetivo/nivel e imágenes'
+
+SELECT
+  id_objetivo,
+  id_nivel,
+  COUNT(*) AS total_ejercicios,
+  COUNT(*) FILTER (
+    WHERE imagen IS NOT NULL AND btrim(imagen::text) <> ''
+  ) AS ejercicios_con_imagen,
+  COUNT(*) FILTER (
+    WHERE imagen = '/images/exercises/gym-master-exercise-fallback.svg'
+  ) AS ejercicios_con_fallback,
+  COUNT(*) FILTER (
+    WHERE imagen IS NULL OR btrim(imagen::text) = ''
+  ) AS ejercicios_sin_imagen
+FROM public.ejercicio
+GROUP BY id_objetivo, id_nivel
+ORDER BY id_objetivo, id_nivel;
+
+\echo '2. Muestra de ejercicios Inicial/Intermedio con fallback'
+
+SELECT
+  *
+FROM public.ejercicio
+WHERE id_objetivo = 1
+  AND id_nivel IN (1, 2)
+  AND imagen = '/images/exercises/gym-master-exercise-fallback.svg'
+LIMIT 10;
+
+\echo '3. Validación puntual: niveles Inicial e Intermedio sin imagen'
+
+SELECT
+  COUNT(*) AS inicial_intermedio_sin_imagen
+FROM public.ejercicio
+WHERE id_nivel IN (1, 2)
+  AND (imagen IS NULL OR btrim(imagen::text) = '');

--- a/docs/informes/informe-ejecutivo-rutinas-exercise-images-fallback.md
+++ b/docs/informes/informe-ejecutivo-rutinas-exercise-images-fallback.md
@@ -1,0 +1,36 @@
+# Informe ejecutivo — Rutinas: fallback visual para ejercicios sin imagen
+
+## 1. Resumen ejecutivo
+
+Se incorporó una mejora en el módulo de rutinas para resolver el problema visual detectado en ejercicios de niveles Inicial e Intermedio que no tenían imagen asociada.
+
+El sistema ya podía generar rutinas para esos niveles, pero al no existir valor en la columna `imagen`, algunos componentes visuales no mostraban el botón/ícono de visualización o no tenían recurso para exportación.
+
+## 2. Objetivo
+
+Agregar un fallback visual controlado, versionado y seguro para ejercicios sin imagen, evitando inconsistencias visuales y preparando la base para una carga posterior de imágenes reales.
+
+## 3. Cambios incorporados
+
+- Asset SVG local para imagen no disponible.
+- Migración SQL defensiva para completar `public.ejercicio.imagen`.
+- Script de validación SQL.
+- Documentación técnica de la feature.
+
+## 4. Impacto funcional
+
+- Las rutinas Iniciales e Intermedias tendrán un recurso visual disponible.
+- Se reduce la diferencia de comportamiento entre rutinas avanzadas y rutinas de menor nivel.
+- El PDF de rutinas tendrá un fallback visual cuando el ejercicio no tenga imagen real.
+
+## 5. Alcance excluido
+
+No se cargaron imágenes reales por ejercicio. Esta tarea requiere una curaduría posterior de recursos gráficos/gifs/videos y validación de licencias.
+
+## 6. Próximos pasos sugeridos
+
+- Validar migración en Supabase local.
+- Aplicar remoto con Supabase CLI.
+- Probar generación de rutina Inicial e Intermedia.
+- Exportar PDF de rutina.
+- Planificar carga de imágenes reales por grupo muscular.

--- a/docs/pr/pr-rutinas-exercise-images-fallback.md
+++ b/docs/pr/pr-rutinas-exercise-images-fallback.md
@@ -1,0 +1,41 @@
+# PR: Rutinas — fallback visual para ejercicios sin imagen
+
+## Descripción
+
+Este PR agrega un fallback visual para ejercicios de rutinas que no tienen imagen cargada, principalmente los ejercicios de niveles Inicial e Intermedio incorporados recientemente.
+
+El cambio busca corregir el comportamiento donde el sistema no mostraba el ícono de visualización cuando `public.ejercicio.imagen` estaba vacío o en `NULL`.
+
+## Cambios principales
+
+- Se agrega el asset local:
+  - `public/images/exercises/gym-master-exercise-fallback.svg`
+- Se agrega migración:
+  - `supabase/migrations/202605202000_rutinas_exercise_images_fallback.sql`
+- Se agrega script de validación:
+  - `database/scripts/validar_rutinas_exercise_images_fallback.sql`
+- Se documenta el alcance en:
+  - `docs/rutinas/rutinas-exercise-images-fallback.md`
+
+## Alcance técnico
+
+La migración:
+
+- No reemplaza imágenes existentes.
+- Solo completa ejercicios sin imagen.
+- Prioriza niveles Inicial e Intermedio.
+- Usa un asset local versionado para mantener compatibilidad con frontend y exportación PDF.
+
+## Validaciones sugeridas
+
+- Ejecutar migración en Supabase local.
+- Ejecutar script de validación SQL.
+- Aplicar remoto con Supabase CLI.
+- Confirmar historial con `npx supabase migration list`.
+- Generar rutina Inicial o Intermedia.
+- Verificar que el botón/ícono de imagen aparece.
+- Exportar rutina a PDF y verificar fallback visual.
+
+## Nota
+
+Este PR no carga imágenes reales por ejercicio. Eso queda para una feature posterior con curaduría visual y validación de licencias.

--- a/docs/rutinas/rutinas-exercise-images-fallback.md
+++ b/docs/rutinas/rutinas-exercise-images-fallback.md
@@ -1,0 +1,52 @@
+# Rutinas — Fallback visual para ejercicios sin imagen
+
+## Objetivo
+
+Esta feature agrega un fallback visual versionado para ejercicios que no tienen imagen cargada, especialmente los ejercicios incorporados para niveles Inicial e Intermedio.
+
+El objetivo principal es corregir el comportamiento donde el sistema no mostraba el ícono/botón de visualización cuando `public.ejercicio.imagen` estaba en `NULL`.
+
+## Alcance
+
+- Se agrega un asset local: `/images/exercises/gym-master-exercise-fallback.svg`.
+- Se agrega una migración SQL que actualiza ejercicios sin imagen de niveles Inicial e Intermedio.
+- No se reemplazan imágenes existentes.
+- No se eliminan datos.
+- Queda abierta la posibilidad de cargar imágenes reales por ejercicio en una feature posterior.
+
+## Archivo visual agregado
+
+```txt
+public/images/exercises/gym-master-exercise-fallback.svg
+```
+
+## Migración agregada
+
+```txt
+supabase/migrations/202605202000_rutinas_exercise_images_fallback.sql
+```
+
+## Validación
+
+```txt
+database/scripts/validar_rutinas_exercise_images_fallback.sql
+```
+
+## Flujo de validación recomendado
+
+1. Aplicar la feature con `robocopy`.
+2. Ejecutar Supabase local.
+3. Validar migración local.
+4. Aplicar remoto con Supabase CLI.
+5. Generar una rutina Inicial o Intermedia.
+6. Confirmar que el botón/ícono de imagen aparece.
+7. Confirmar que el PDF de rutina muestra imagen o fallback visual.
+
+## Pendiente futuro
+
+Esta feature no reemplaza la carga de imágenes reales. El backlog futuro debería incluir:
+
+- Mapear ejercicios por grupo muscular.
+- Cargar imágenes/gifs reales por ejercicio.
+- Definir fuente/licencia de recursos visuales.
+- Mejorar fallback por grupo muscular.

--- a/public/images/exercises/gym-master-exercise-fallback.svg
+++ b/public/images/exercises/gym-master-exercise-fallback.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="420" viewBox="0 0 640 420" role="img" aria-labelledby="title desc">
+  <title id="title">Imagen de ejercicio no disponible</title>
+  <desc id="desc">Fallback visual de Gym Master para ejercicios sin imagen específica.</desc>
+  <rect width="640" height="420" rx="32" fill="#f8fafc"/>
+  <rect x="24" y="24" width="592" height="372" rx="28" fill="#ffffff" stroke="#e2e8f0" stroke-width="4"/>
+  <g transform="translate(320 165)">
+    <circle cx="0" cy="-58" r="34" fill="#111827"/>
+    <path d="M-96 8 C-52 -22 -20 -18 0 8 C20 -18 52 -22 96 8" fill="none" stroke="#111827" stroke-width="24" stroke-linecap="round"/>
+    <path d="M0 8 L0 86" fill="none" stroke="#111827" stroke-width="26" stroke-linecap="round"/>
+    <path d="M0 86 L-58 142" fill="none" stroke="#111827" stroke-width="24" stroke-linecap="round"/>
+    <path d="M0 86 L58 142" fill="none" stroke="#111827" stroke-width="24" stroke-linecap="round"/>
+    <circle cx="-118" cy="14" r="18" fill="#0ea5e9"/>
+    <circle cx="118" cy="14" r="18" fill="#0ea5e9"/>
+  </g>
+  <text x="320" y="330" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="700" fill="#111827">Gym Master</text>
+  <text x="320" y="363" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="19" fill="#64748b">Imagen de ejercicio no disponible</text>
+</svg>

--- a/supabase/migrations/202605202000_rutinas_exercise_images_fallback.sql
+++ b/supabase/migrations/202605202000_rutinas_exercise_images_fallback.sql
@@ -1,0 +1,49 @@
+-- =============================================================================
+-- Gym Master
+-- Migration: rutinas exercise images fallback
+-- Fecha: 2026-05-20
+-- Objetivo:
+--   Completar un fallback visual para ejercicios sin imagen, especialmente los
+--   ejercicios seed de niveles Inicial e Intermedio, para que el frontend pueda
+--   mostrar el botón/ícono de visualización y el PDF no quede sin recurso visual.
+--
+-- Notas:
+--   - No reemplaza imágenes existentes.
+--   - No borra datos.
+--   - Usa un asset local versionado en public/images/exercises/.
+--   - Queda preparado para que una futura migración cargue imágenes reales por
+--     ejercicio y reemplace este fallback progresivamente.
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_updated integer := 0;
+BEGIN
+  IF to_regclass('public.ejercicio') IS NULL THEN
+    RAISE NOTICE 'Tabla public.ejercicio no existe. Se omite actualización de fallback de imágenes.';
+    RETURN;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'ejercicio'
+      AND column_name = 'imagen'
+  ) THEN
+    RAISE NOTICE 'Columna public.ejercicio.imagen no existe. Se omite actualización de fallback de imágenes.';
+    RETURN;
+  END IF;
+
+  UPDATE public.ejercicio AS e
+  SET imagen = '/images/exercises/gym-master-exercise-fallback.svg'
+  WHERE (e.imagen IS NULL OR btrim(e.imagen::text) = '')
+    AND (
+      e.id_nivel IN (1, 2)
+      OR e.id_nivel IS NULL
+    );
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  RAISE NOTICE 'Fallback de imágenes aplicado a % ejercicios sin imagen.', v_updated;
+END $$;


### PR DESCRIPTION
# PR: feat: add fallback images for workout exercises

## Resumen

Este PR incorpora una solución de fallback visual para los ejercicios de rutinas que no tenían imagen asociada, especialmente los ejercicios cargados para niveles Inicial e Intermedio. El objetivo es evitar que desaparezca el ícono de visualización de imagen/video en la rutina y asegurar que la exportación PDF tenga siempre un recurso visual disponible.

## Contexto

Durante las pruebas funcionales de generación de rutinas se detectó que las rutinas de nivel Inicial no mostraban el ícono de “ojito” para ver imagen del ejercicio, mientras que en nivel Avanzado sí aparecía. La causa probable era que los ejercicios avanzados ya tenían imagen, pero los ejercicios cargados recientemente para niveles Inicial e Intermedio tenían `imagen` en `NULL`.

## Cambios incluidos

- Se agregó un archivo SVG fallback local en `public/images/exercises/gym-master-exercise-fallback.svg`.
- Se creó la migración `202605202000_rutinas_exercise_images_fallback.sql`.
- La migración completa el campo `imagen` para ejercicios sin imagen de niveles Inicial e Intermedio.
- No se reemplazan imágenes existentes.
- Se agregó script de validación SQL para verificar ejercicios con imagen/fallback.
- Se documentó el cambio en `docs/rutinas/rutinas-exercise-images-fallback.md`.

## Validación local

Se ejecutó Supabase local con migraciones desde cero y se aplicó correctamente la migración:

```bash
npx supabase stop --no-backup
npx supabase start -x storage-api -x imgproxy -x studio -x logflare
docker exec -i supabase_db_gym-master psql -U postgres -d postgres < database/scripts/validar_rutinas_exercise_images_fallback.sql
```

Resultado validado:

| Objetivo | Nivel | Total ejercicios | Con imagen | Con fallback | Sin imagen |
|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 32 | 32 | 32 | 0 |
| 1 | 2 | 32 | 32 | 32 | 0 |

Además, la migración informó que el fallback fue aplicado a 64 ejercicios sin imagen.

## Validación remota

La migración fue aplicada en Supabase remoto mediante Supabase CLI y se validó desde SQL Editor que los ejercicios de Objetivo 1 / Nivel 1 y Objetivo 1 / Nivel 2 quedaron con imagen/fallback y sin registros pendientes sin imagen.

Resultado remoto:

| Objetivo | Nivel | Total ejercicios | Con imagen | Con fallback | Sin imagen |
|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 32 | 32 | 32 | 0 |
| 1 | 2 | 32 | 32 | 32 | 0 |

## Impacto funcional

- Las rutinas Inicial e Intermedia tienen un recurso visual disponible para ejercicios sin imagen real.
- El frontend puede mostrar el ícono de visualización cuando se base en la existencia del campo `imagen`.
- La exportación PDF de rutinas tiene una imagen fallback disponible y evita secciones visuales vacías.
- Se mantiene abierta una futura mejora para cargar imágenes/gifs/videos reales por ejercicio.

## Archivos principales

```txt
supabase/migrations/202605202000_rutinas_exercise_images_fallback.sql
database/scripts/validar_rutinas_exercise_images_fallback.sql
public/images/exercises/gym-master-exercise-fallback.svg
docs/rutinas/rutinas-exercise-images-fallback.md
docs/pr/pr-rutinas-exercise-images-fallback.md
docs/informes/informe-ejecutivo-rutinas-exercise-images-fallback.md
```

## Notas técnicas

Durante la validación se confirmó que la tabla `ejercicio` utiliza las columnas `id_ejercicio` y `nombre_ejercicio`, no `id` ni `nombre`. El script de validación fue ajustado para evitar asumir nombres de columnas incorrectos.

## Checklist

- [x] Migración creada en `supabase/migrations`.
- [x] Validación local con Supabase CLI.
- [x] Aplicación remota con Supabase CLI.
- [x] Validación remota por SQL Editor.
- [x] Fallback SVG agregado al proyecto.
- [x] Documentación agregada.
- [x] No se reemplazan imágenes existentes.

## Próximos pasos sugeridos

- Reemplazar gradualmente el fallback por imágenes/gifs/videos reales por ejercicio.
- Revisar que el botón de “ojito” aparezca en Inicial, Intermedio y Avanzado.
- Probar exportación PDF de rutinas con ejercicios que usan fallback.
