### PR TITLE
feat: add parameterizable catalog foundation

### DIFF
--- a/database/scripts/validar_catalogos_parametrizables_foundation.sql
+++ b/database/scripts/validar_catalogos_parametrizables_foundation.sql
@@ -1,0 +1,74 @@
+-- -----------------------------------------------------------------------------
+-- Gym Master
+-- Validación: catálogos parametrizables foundation
+-- Uso local:
+-- docker exec -i supabase_db_gym-master psql -U postgres -d postgres < database/scripts/validar_catalogos_parametrizables_foundation.sql
+-- -----------------------------------------------------------------------------
+
+\echo '== Validando existencia de tablas catálogo =='
+
+select table_name
+from information_schema.tables
+where table_schema = 'public'
+  and table_name in (
+    'tipo_empleado',
+    'medio_pago',
+    'tipo_gasto',
+    'tipo_ingreso',
+    'categoria_producto',
+    'tipo_equipamiento',
+    'ubicacion_equipamiento',
+    'tipo_mantenimiento'
+  )
+order by table_name;
+
+\echo '== Validando cantidad de seeds por catálogo =='
+
+select 'tipo_empleado' as catalogo, count(*) as total from public.tipo_empleado
+union all
+select 'medio_pago', count(*) from public.medio_pago
+union all
+select 'tipo_gasto', count(*) from public.tipo_gasto
+union all
+select 'tipo_ingreso', count(*) from public.tipo_ingreso
+union all
+select 'categoria_producto', count(*) from public.categoria_producto
+union all
+select 'tipo_equipamiento', count(*) from public.tipo_equipamiento
+union all
+select 'ubicacion_equipamiento', count(*) from public.ubicacion_equipamiento
+union all
+select 'tipo_mantenimiento', count(*) from public.tipo_mantenimiento
+order by catalogo;
+
+\echo '== Validando columnas opcionales en tablas existentes del baseline =='
+
+select table_name, column_name, data_type
+from information_schema.columns
+where table_schema = 'public'
+  and (
+    (table_name = 'entrenadores' and column_name = 'id_tipo_empleado') or
+    (table_name = 'producto' and column_name = 'id_categoria_producto') or
+    (table_name = 'equipamiento' and column_name in ('id_tipo_equipamiento', 'id_ubicacion_equipamiento')) or
+    (table_name = 'mantenimiento' and column_name = 'id_tipo_mantenimiento') or
+    (table_name = 'pago' and column_name = 'id_medio_pago') or
+    (table_name = 'otros_gastos' and column_name = 'id_tipo_gasto')
+  )
+order by table_name, column_name;
+
+\echo '== Validando constraints defensivas creadas solo si existe la tabla =='
+
+select conname, conrelid::regclass as tabla
+from pg_constraint
+where conname in (
+  'entrenadores_id_tipo_empleado_fkey',
+  'producto_id_categoria_producto_fkey',
+  'equipamiento_id_tipo_equipamiento_fkey',
+  'equipamiento_id_ubicacion_equipamiento_fkey',
+  'mantenimiento_id_tipo_mantenimiento_fkey',
+  'pago_id_medio_pago_fkey',
+  'otros_gastos_id_tipo_gasto_fkey'
+)
+order by conname;
+
+\echo '== Validación final OK si las 8 tablas aparecen con seeds y no hubo errores SQL =='

--- a/docs/parametrizacion/catalogos-parametrizables-foundation.md
+++ b/docs/parametrizacion/catalogos-parametrizables-foundation.md
@@ -1,0 +1,200 @@
+# Catálogos parametrizables foundation
+
+## Objetivo
+
+Esta rama crea la base real de catálogos parametrizables para Gym Master.
+
+La intención es dejar preparada la base de datos para futuras pantallas CRUD y para eliminar progresivamente valores hardcodeados o dependientes de seeds manuales.
+
+## Alcance de la fase
+
+Incluye migraciones SQL para crear catálogos base y columnas de integración opcionales.
+
+No incluye todavía:
+
+- formularios nuevos de CRUD;
+- reemplazo de selects existentes;
+- migración completa de `entrenadores` hacia `empleados`;
+- módulo de sueldos;
+- módulo de mantenimiento avanzado;
+- módulo de notificaciones.
+
+## Tablas nuevas
+
+- `public.tipo_empleado`
+- `public.medio_pago`
+- `public.tipo_gasto`
+- `public.tipo_ingreso`
+- `public.categoria_producto`
+- `public.tipo_equipamiento`
+- `public.ubicacion_equipamiento`
+- `public.tipo_mantenimiento`
+
+## Columnas opcionales agregadas
+
+Las columnas se agregan defensivamente y no eliminan campos legacy existentes.
+
+- `public.entrenadores.id_tipo_empleado`
+- `public.producto.id_categoria_producto`
+- `public.equipamiento.id_tipo_equipamiento`
+- `public.equipamiento.id_ubicacion_equipamiento`
+- `public.mantenimiento.id_tipo_mantenimiento`
+- `public.pago.id_medio_pago`
+- `public.otros_gastos.id_tipo_gasto`
+
+## Seed mínimo
+
+### Tipo empleado
+
+- Administrativo
+- Entrenador
+- Mantenimiento de equipamientos
+- Limpieza
+- Mayordomía / bar-snack
+
+### Medio pago
+
+- Efectivo
+- Stripe
+- Transferencia
+- Tarjeta de débito
+- Tarjeta de crédito
+- Otro
+
+### Tipo gasto
+
+- Sueldos
+- Mantenimiento
+- Servicios
+- Insumos
+- Alquiler
+- Impuestos
+- Limpieza
+- Marketing
+- Otros
+
+### Tipo ingreso
+
+- Cuotas
+- Ventas
+- Servicios
+- Clases especiales
+- Promociones
+- Otros
+
+### Categoría producto
+
+- Bebidas
+- Snacks
+- Suplementos
+- Indumentaria
+- Accesorios
+- Higiene
+- Otros
+
+### Tipo equipamiento
+
+- Cardio
+- Fuerza
+- Funcional
+- Peso libre
+- Accesorio
+- Otro
+
+### Ubicación equipamiento
+
+- Zona A
+- Zona B
+- Zona C
+- Zona D
+- Sala de musculación
+- Sala de cardio
+- Depósito
+- Bar / snack
+- Recepción
+
+### Tipo mantenimiento
+
+- Preventivo
+- Correctivo
+- Lubricación
+- Cableado / correas
+- Seguridad
+- Limpieza técnica
+- Ajuste / calibración
+- Revisión general
+
+## Validación local sugerida
+
+Antes de aplicar en remoto:
+
+```bash
+npx supabase stop --no-backup
+npx supabase start
+npx supabase db reset
+```
+
+Si el baseline local ya está preparado, validar las migraciones nuevas con:
+
+```bash
+npx supabase migration up
+```
+
+Luego ejecutar diagnóstico SQL:
+
+```sql
+select 'tipo_empleado' tabla, count(*) cantidad from public.tipo_empleado
+union all select 'medio_pago', count(*) from public.medio_pago
+union all select 'tipo_gasto', count(*) from public.tipo_gasto
+union all select 'tipo_ingreso', count(*) from public.tipo_ingreso
+union all select 'categoria_producto', count(*) from public.categoria_producto
+union all select 'tipo_equipamiento', count(*) from public.tipo_equipamiento
+union all select 'ubicacion_equipamiento', count(*) from public.ubicacion_equipamiento
+union all select 'tipo_mantenimiento', count(*) from public.tipo_mantenimiento;
+```
+
+Validar columnas opcionales:
+
+```sql
+select table_name, column_name
+from information_schema.columns
+where table_schema = 'public'
+  and column_name in (
+    'id_tipo_empleado',
+    'id_categoria_producto',
+    'id_tipo_equipamiento',
+    'id_ubicacion_equipamiento',
+    'id_tipo_mantenimiento',
+    'id_medio_pago',
+    'id_tipo_gasto'
+  )
+order by table_name, column_name;
+```
+
+## Próximas fases
+
+1. Crear APIs/servicios para leer catálogos activos.
+2. Integrar selects en formularios existentes.
+3. Crear CRUD administrativo desde `/dashboard/parametrizacion`.
+4. Migrar gradualmente `entrenadores` hacia `empleados`.
+5. Construir módulo de sueldos y recibos.
+6. Construir mantenimiento avanzado por máquina/tipo/frecuencia.
+
+
+## Fix de validación local
+
+Durante la validación con Supabase local, el baseline mínimo puede no contener algunas tablas legacy como `entrenadores`, `producto`, `equipamiento`, `mantenimiento` u `otros_gastos`.
+
+Por eso el bloque de foreign keys debe ser defensivo:
+
+- resolver cada tabla con `to_regclass`;
+- evitar casteos directos como `'public.entrenadores'::regclass` si la tabla podría no existir;
+- ejecutar `ALTER TABLE` con SQL dinámico solo cuando la tabla existe.
+
+Se agregó el script:
+
+```bash
+database/scripts/validar_catalogos_parametrizables_foundation.sql
+```
+
+para validar tablas catálogo, seeds, columnas opcionales y constraints creadas.

--- a/supabase/migrations/202605222300_catalogos_parametrizables_foundation.sql
+++ b/supabase/migrations/202605222300_catalogos_parametrizables_foundation.sql
@@ -1,0 +1,369 @@
+-- -----------------------------------------------------------------------------
+-- Gym Master
+-- Feature: catalogos-parametrizables-foundation
+-- Migration: 202605222300_catalogos_parametrizables_foundation.sql
+--
+-- Objetivo:
+-- Crear la base de catálogos parametrizables para el sistema sin integrar todavía
+-- todos los formularios del frontend.
+--
+-- Alcance:
+-- - Crea tablas de catálogos base.
+-- - Agrega columnas FK opcionales a tablas existentes cuando corresponda.
+-- - No elimina columnas legacy de texto.
+-- - No renombra entrenadores a empleados todavía.
+-- - Mantiene compatibilidad hacia atrás.
+-- -----------------------------------------------------------------------------
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- -----------------------------------------------------------------------------
+-- 1. Función común para actualizado_en en catálogos
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.set_catalogo_actualizado_en()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.actualizado_en = now();
+  RETURN NEW;
+END;
+$$;
+
+-- -----------------------------------------------------------------------------
+-- 2. Catálogos base
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.tipo_empleado (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.medio_pago (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  requiere_comprobante boolean NOT NULL DEFAULT false,
+  es_online boolean NOT NULL DEFAULT false,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.tipo_gasto (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.tipo_ingreso (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.categoria_producto (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.tipo_equipamiento (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.ubicacion_equipamiento (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.tipo_mantenimiento (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  codigo varchar(80) NOT NULL UNIQUE,
+  nombre varchar(120) NOT NULL,
+  descripcion text NULL,
+  frecuencia_dias integer NULL,
+  alerta_dias_anticipacion integer NOT NULL DEFAULT 5,
+  activo boolean NOT NULL DEFAULT true,
+  orden integer NOT NULL DEFAULT 0,
+  creado_en timestamp without time zone NOT NULL DEFAULT now(),
+  actualizado_en timestamp without time zone NOT NULL DEFAULT now(),
+  CONSTRAINT tipo_mantenimiento_frecuencia_check
+    CHECK (frecuencia_dias IS NULL OR frecuencia_dias > 0),
+  CONSTRAINT tipo_mantenimiento_alerta_check
+    CHECK (alerta_dias_anticipacion >= 0)
+);
+
+-- -----------------------------------------------------------------------------
+-- 3. Triggers de actualizado_en para catálogos
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+  catalog_table text;
+  trigger_name text;
+BEGIN
+  FOREACH catalog_table IN ARRAY ARRAY[
+    'tipo_empleado',
+    'medio_pago',
+    'tipo_gasto',
+    'tipo_ingreso',
+    'categoria_producto',
+    'tipo_equipamiento',
+    'ubicacion_equipamiento',
+    'tipo_mantenimiento'
+  ] LOOP
+    trigger_name := 'trg_' || catalog_table || '_actualizado_en';
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_trigger
+      WHERE tgname = trigger_name
+        AND tgrelid = ('public.' || catalog_table)::regclass
+    ) THEN
+      EXECUTE format(
+        'CREATE TRIGGER %I BEFORE UPDATE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.set_catalogo_actualizado_en()',
+        trigger_name,
+        catalog_table
+      );
+    END IF;
+  END LOOP;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 4. Columnas FK opcionales en tablas existentes
+--    No reemplazan columnas legacy; preparan integración futura.
+-- -----------------------------------------------------------------------------
+ALTER TABLE IF EXISTS public.entrenadores
+  ADD COLUMN IF NOT EXISTS id_tipo_empleado uuid NULL;
+
+ALTER TABLE IF EXISTS public.producto
+  ADD COLUMN IF NOT EXISTS id_categoria_producto uuid NULL;
+
+ALTER TABLE IF EXISTS public.equipamiento
+  ADD COLUMN IF NOT EXISTS id_tipo_equipamiento uuid NULL,
+  ADD COLUMN IF NOT EXISTS id_ubicacion_equipamiento uuid NULL;
+
+ALTER TABLE IF EXISTS public.mantenimiento
+  ADD COLUMN IF NOT EXISTS id_tipo_mantenimiento uuid NULL;
+
+ALTER TABLE IF EXISTS public.pago
+  ADD COLUMN IF NOT EXISTS id_medio_pago uuid NULL;
+
+ALTER TABLE IF EXISTS public.otros_gastos
+  ADD COLUMN IF NOT EXISTS id_tipo_gasto uuid NULL;
+
+-- -----------------------------------------------------------------------------
+-- 5. Foreign keys defensivas
+--    Importante: no usar 'tabla'::regclass sobre tablas opcionales inexistentes.
+--    En baselines locales mínimos algunas tablas todavía no existen, por eso
+--    se resuelve cada tabla con to_regclass() y se ejecuta DDL dinámico.
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+  target_table regclass;
+BEGIN
+  target_table := to_regclass('public.entrenadores');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'entrenadores_id_tipo_empleado_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.entrenadores
+      ADD CONSTRAINT entrenadores_id_tipo_empleado_fkey
+      FOREIGN KEY (id_tipo_empleado)
+      REFERENCES public.tipo_empleado(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+
+  target_table := to_regclass('public.producto');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'producto_id_categoria_producto_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.producto
+      ADD CONSTRAINT producto_id_categoria_producto_fkey
+      FOREIGN KEY (id_categoria_producto)
+      REFERENCES public.categoria_producto(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+
+  target_table := to_regclass('public.equipamiento');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'equipamiento_id_tipo_equipamiento_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.equipamiento
+      ADD CONSTRAINT equipamiento_id_tipo_equipamiento_fkey
+      FOREIGN KEY (id_tipo_equipamiento)
+      REFERENCES public.tipo_equipamiento(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+
+  target_table := to_regclass('public.equipamiento');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'equipamiento_id_ubicacion_equipamiento_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.equipamiento
+      ADD CONSTRAINT equipamiento_id_ubicacion_equipamiento_fkey
+      FOREIGN KEY (id_ubicacion_equipamiento)
+      REFERENCES public.ubicacion_equipamiento(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+
+  target_table := to_regclass('public.mantenimiento');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'mantenimiento_id_tipo_mantenimiento_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.mantenimiento
+      ADD CONSTRAINT mantenimiento_id_tipo_mantenimiento_fkey
+      FOREIGN KEY (id_tipo_mantenimiento)
+      REFERENCES public.tipo_mantenimiento(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+
+  target_table := to_regclass('public.pago');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'pago_id_medio_pago_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.pago
+      ADD CONSTRAINT pago_id_medio_pago_fkey
+      FOREIGN KEY (id_medio_pago)
+      REFERENCES public.medio_pago(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+
+  target_table := to_regclass('public.otros_gastos');
+  IF target_table IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1 FROM pg_constraint
+       WHERE conname = 'otros_gastos_id_tipo_gasto_fkey'
+         AND conrelid = target_table
+     ) THEN
+    EXECUTE '
+      ALTER TABLE public.otros_gastos
+      ADD CONSTRAINT otros_gastos_id_tipo_gasto_fkey
+      FOREIGN KEY (id_tipo_gasto)
+      REFERENCES public.tipo_gasto(id)
+      ON UPDATE CASCADE
+      ON DELETE SET NULL';
+  END IF;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 6. Índices para integración futura
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF to_regclass('public.entrenadores') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_entrenadores_id_tipo_empleado
+      ON public.entrenadores(id_tipo_empleado);
+  END IF;
+
+  IF to_regclass('public.producto') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_producto_id_categoria_producto
+      ON public.producto(id_categoria_producto);
+  END IF;
+
+  IF to_regclass('public.equipamiento') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_equipamiento_id_tipo_equipamiento
+      ON public.equipamiento(id_tipo_equipamiento);
+    CREATE INDEX IF NOT EXISTS idx_equipamiento_id_ubicacion_equipamiento
+      ON public.equipamiento(id_ubicacion_equipamiento);
+  END IF;
+
+  IF to_regclass('public.mantenimiento') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_mantenimiento_id_tipo_mantenimiento
+      ON public.mantenimiento(id_tipo_mantenimiento);
+  END IF;
+
+  IF to_regclass('public.pago') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_pago_id_medio_pago
+      ON public.pago(id_medio_pago);
+  END IF;
+
+  IF to_regclass('public.otros_gastos') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_otros_gastos_id_tipo_gasto
+      ON public.otros_gastos(id_tipo_gasto);
+  END IF;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 7. Comentarios técnicos
+-- -----------------------------------------------------------------------------
+COMMENT ON TABLE public.tipo_empleado IS
+  'Catálogo parametrizable de tipos de empleado. Base futura para migrar entrenadores hacia empleados, sueldos, recibos y reportes.';
+COMMENT ON TABLE public.medio_pago IS
+  'Catálogo parametrizable de medios de pago para cuotas, ventas, recibos y conciliación.';
+COMMENT ON TABLE public.tipo_gasto IS
+  'Catálogo parametrizable de egresos operativos: sueldos, mantenimiento, servicios, insumos, etc.';
+COMMENT ON TABLE public.tipo_ingreso IS
+  'Catálogo parametrizable de ingresos: cuotas, ventas, servicios, clases especiales, etc.';
+COMMENT ON TABLE public.categoria_producto IS
+  'Catálogo parametrizable de categorías para productos y ventas adicionales.';
+COMMENT ON TABLE public.tipo_equipamiento IS
+  'Catálogo parametrizable de tipos de equipamiento del gimnasio.';
+COMMENT ON TABLE public.ubicacion_equipamiento IS
+  'Catálogo parametrizable de ubicaciones físicas del equipamiento.';
+COMMENT ON TABLE public.tipo_mantenimiento IS
+  'Catálogo parametrizable de tipos de mantenimiento con frecuencia y alerta anticipada.';

--- a/supabase/migrations/202605222301_catalogos_parametrizables_seed.sql
+++ b/supabase/migrations/202605222301_catalogos_parametrizables_seed.sql
@@ -1,0 +1,236 @@
+-- -----------------------------------------------------------------------------
+-- Gym Master
+-- Feature: catalogos-parametrizables-foundation
+-- Migration: 202605222301_catalogos_parametrizables_seed.sql
+--
+-- Objetivo:
+-- Cargar seed mínimo de catálogos parametrizables y backfill defensivo de
+-- columnas FK opcionales creadas por la migración anterior.
+-- -----------------------------------------------------------------------------
+
+-- -----------------------------------------------------------------------------
+-- 1. Seed tipo_empleado
+-- -----------------------------------------------------------------------------
+INSERT INTO public.tipo_empleado (codigo, nombre, descripcion, orden)
+VALUES
+  ('administrativo', 'Administrativo', 'Empleado administrativo del gimnasio.', 10),
+  ('entrenador', 'Entrenador', 'Empleado responsable de entrenamiento, rutinas y seguimiento físico.', 20),
+  ('mantenimiento', 'Mantenimiento de equipamientos', 'Empleado responsable de mantenimiento y control operativo de máquinas.', 30),
+  ('limpieza', 'Limpieza', 'Empleado responsable de limpieza e higiene general.', 40),
+  ('mayordomia_bar_snack', 'Mayordomía / bar-snack', 'Empleado responsable de cafetería, bebidas, snack bar o atención auxiliar.', 50)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 2. Seed medio_pago
+-- -----------------------------------------------------------------------------
+INSERT INTO public.medio_pago (codigo, nombre, descripcion, requiere_comprobante, es_online, orden)
+VALUES
+  ('efectivo', 'Efectivo', 'Pago manual registrado por administración.', false, false, 10),
+  ('stripe', 'Stripe', 'Pago online procesado por Stripe.', true, true, 20),
+  ('transferencia', 'Transferencia', 'Pago por transferencia bancaria o billetera.', true, false, 30),
+  ('tarjeta_debito', 'Tarjeta de débito', 'Pago presencial con tarjeta de débito.', true, false, 40),
+  ('tarjeta_credito', 'Tarjeta de crédito', 'Pago presencial con tarjeta de crédito.', true, false, 50),
+  ('otro', 'Otro', 'Medio de pago no clasificado.', false, false, 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  requiere_comprobante = EXCLUDED.requiere_comprobante,
+  es_online = EXCLUDED.es_online,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 3. Seed tipo_gasto
+-- -----------------------------------------------------------------------------
+INSERT INTO public.tipo_gasto (codigo, nombre, descripcion, orden)
+VALUES
+  ('sueldos', 'Sueldos', 'Pagos mensuales a empleados.', 10),
+  ('mantenimiento', 'Mantenimiento', 'Gastos asociados a mantenimiento de equipamiento o infraestructura.', 20),
+  ('servicios', 'Servicios', 'Luz, agua, internet, software u otros servicios.', 30),
+  ('insumos', 'Insumos', 'Insumos operativos del gimnasio.', 40),
+  ('alquiler', 'Alquiler', 'Alquiler del local o espacios asociados.', 50),
+  ('impuestos', 'Impuestos', 'Impuestos, tasas y obligaciones fiscales.', 60),
+  ('limpieza', 'Limpieza', 'Productos, personal o servicios de limpieza.', 70),
+  ('marketing', 'Marketing', 'Publicidad, promociones y comunicación.', 80),
+  ('otros', 'Otros', 'Gastos no clasificados.', 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 4. Seed tipo_ingreso
+-- -----------------------------------------------------------------------------
+INSERT INTO public.tipo_ingreso (codigo, nombre, descripcion, orden)
+VALUES
+  ('cuotas', 'Cuotas', 'Ingresos por pago de cuotas de socios.', 10),
+  ('ventas', 'Ventas', 'Ingresos por venta de productos.', 20),
+  ('servicios', 'Servicios', 'Ingresos por servicios adicionales.', 30),
+  ('clases_especiales', 'Clases especiales', 'Ingresos por clases, eventos o actividades especiales.', 40),
+  ('promociones', 'Promociones', 'Ingresos asociados a promociones o paquetes.', 50),
+  ('otros', 'Otros', 'Ingresos no clasificados.', 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 5. Seed categoria_producto
+-- -----------------------------------------------------------------------------
+INSERT INTO public.categoria_producto (codigo, nombre, descripcion, orden)
+VALUES
+  ('bebidas', 'Bebidas', 'Agua, bebidas isotónicas, café u otras bebidas.', 10),
+  ('snacks', 'Snacks', 'Snacks y alimentos rápidos.', 20),
+  ('suplementos', 'Suplementos', 'Suplementos deportivos y nutricionales.', 30),
+  ('indumentaria', 'Indumentaria', 'Ropa y accesorios de vestir.', 40),
+  ('accesorios', 'Accesorios', 'Accesorios de entrenamiento o uso del gimnasio.', 50),
+  ('higiene', 'Higiene', 'Productos de higiene o cuidado personal.', 60),
+  ('otros', 'Otros', 'Productos no clasificados.', 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 6. Seed tipo_equipamiento
+-- -----------------------------------------------------------------------------
+INSERT INTO public.tipo_equipamiento (codigo, nombre, descripcion, orden)
+VALUES
+  ('cardio', 'Cardio', 'Equipamiento cardiovascular.', 10),
+  ('fuerza', 'Fuerza', 'Máquinas y equipamiento de fuerza.', 20),
+  ('funcional', 'Funcional', 'Equipamiento para entrenamiento funcional.', 30),
+  ('peso_libre', 'Peso libre', 'Mancuernas, barras, discos y accesorios de peso libre.', 40),
+  ('accesorio', 'Accesorio', 'Accesorios generales de entrenamiento.', 50),
+  ('otro', 'Otro', 'Equipamiento no clasificado.', 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 7. Seed ubicacion_equipamiento
+-- -----------------------------------------------------------------------------
+INSERT INTO public.ubicacion_equipamiento (codigo, nombre, descripcion, orden)
+VALUES
+  ('zona_a', 'Zona A', 'Zona operativa A del gimnasio.', 10),
+  ('zona_b', 'Zona B', 'Zona operativa B del gimnasio.', 20),
+  ('zona_c', 'Zona C', 'Zona operativa C del gimnasio.', 30),
+  ('zona_d', 'Zona D', 'Zona operativa D del gimnasio.', 40),
+  ('sala_musculacion', 'Sala de musculación', 'Área principal de musculación.', 50),
+  ('sala_cardio', 'Sala de cardio', 'Área de entrenamiento cardiovascular.', 60),
+  ('deposito', 'Depósito', 'Espacio de almacenamiento.', 70),
+  ('bar_snack', 'Bar / snack', 'Área de bar, snack o cafetería.', 80),
+  ('recepcion', 'Recepción', 'Área de recepción y atención.', 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 8. Seed tipo_mantenimiento
+-- -----------------------------------------------------------------------------
+INSERT INTO public.tipo_mantenimiento (codigo, nombre, descripcion, frecuencia_dias, alerta_dias_anticipacion, orden)
+VALUES
+  ('preventivo', 'Preventivo', 'Mantenimiento preventivo general.', 30, 5, 10),
+  ('correctivo', 'Correctivo', 'Mantenimiento correctivo por falla o rotura.', NULL, 0, 20),
+  ('lubricacion', 'Lubricación', 'Verificación y lubricación de guías, poleas o partes móviles.', 30, 5, 30),
+  ('cableado', 'Cableado / correas', 'Revisión de cables, correas, poleas y tensores.', 7, 5, 40),
+  ('seguridad', 'Seguridad', 'Control de tornillos, seguros, estructura y estabilidad.', 15, 5, 50),
+  ('limpieza', 'Limpieza técnica', 'Limpieza técnica del equipamiento.', 7, 3, 60),
+  ('ajuste_calibracion', 'Ajuste / calibración', 'Ajuste de piezas, calibración o nivelación.', 30, 5, 70),
+  ('revision_general', 'Revisión general', 'Revisión general no clasificada.', 30, 5, 90)
+ON CONFLICT (codigo) DO UPDATE SET
+  nombre = EXCLUDED.nombre,
+  descripcion = EXCLUDED.descripcion,
+  frecuencia_dias = EXCLUDED.frecuencia_dias,
+  alerta_dias_anticipacion = EXCLUDED.alerta_dias_anticipacion,
+  orden = EXCLUDED.orden,
+  actualizado_en = now();
+
+-- -----------------------------------------------------------------------------
+-- 9. Backfill defensivo de columnas FK opcionales
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF to_regclass('public.entrenadores') IS NOT NULL THEN
+    UPDATE public.entrenadores e
+       SET id_tipo_empleado = te.id
+      FROM public.tipo_empleado te
+     WHERE te.codigo = 'entrenador'
+       AND e.id_tipo_empleado IS NULL;
+  END IF;
+
+  IF to_regclass('public.equipamiento') IS NOT NULL THEN
+    UPDATE public.equipamiento e
+       SET id_tipo_equipamiento = te.id
+      FROM public.tipo_equipamiento te
+     WHERE e.id_tipo_equipamiento IS NULL
+       AND (
+         lower(trim(e.tipo)) = lower(trim(te.nombre))
+         OR lower(trim(e.tipo)) = lower(trim(te.codigo))
+       );
+
+    UPDATE public.equipamiento e
+       SET id_ubicacion_equipamiento = ue.id
+      FROM public.ubicacion_equipamiento ue
+     WHERE e.id_ubicacion_equipamiento IS NULL
+       AND (
+         lower(trim(e.ubicacion)) = lower(trim(ue.nombre))
+         OR lower(trim(e.ubicacion)) = lower(trim(ue.codigo))
+       );
+  END IF;
+
+  IF to_regclass('public.mantenimiento') IS NOT NULL THEN
+    UPDATE public.mantenimiento m
+       SET id_tipo_mantenimiento = tm.id
+      FROM public.tipo_mantenimiento tm
+     WHERE m.id_tipo_mantenimiento IS NULL
+       AND tm.codigo = CASE
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%prevent%' THEN 'preventivo'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%correct%' THEN 'correctivo'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%lubric%' THEN 'lubricacion'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%cable%' THEN 'cableado'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%correa%' THEN 'cableado'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%segur%' THEN 'seguridad'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%limp%' THEN 'limpieza'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%calibr%' THEN 'ajuste_calibracion'
+         WHEN lower(coalesce(m.tipo_mantenimiento, '')) LIKE '%ajust%' THEN 'ajuste_calibracion'
+         ELSE 'revision_general'
+       END;
+  END IF;
+
+  IF to_regclass('public.pago') IS NOT NULL THEN
+    UPDATE public.pago p
+       SET id_medio_pago = mp.id
+      FROM public.medio_pago mp
+     WHERE p.id_medio_pago IS NULL
+       AND mp.codigo = CASE
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%stripe%' THEN 'stripe'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%efect%' THEN 'efectivo'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%transfer%' THEN 'transferencia'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%debito%' THEN 'tarjeta_debito'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%débito%' THEN 'tarjeta_debito'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%credito%' THEN 'tarjeta_credito'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%crédito%' THEN 'tarjeta_credito'
+         WHEN lower(coalesce(p.metodo_pago, '')) LIKE '%tarjeta%' THEN 'tarjeta_credito'
+         ELSE 'otro'
+       END;
+  END IF;
+
+  IF to_regclass('public.otros_gastos') IS NOT NULL THEN
+    UPDATE public.otros_gastos g
+       SET id_tipo_gasto = tg.id
+      FROM public.tipo_gasto tg
+     WHERE tg.codigo = 'otros'
+       AND g.id_tipo_gasto IS NULL;
+  END IF;
+END $$;


### PR DESCRIPTION
# feat: add parameterizable catalog foundation

## Resumen

Se agrega la base de catálogos parametrizables para Gym Master, orientada a eliminar dependencias progresivas de seeds y valores hardcodeados en formularios, pagos, equipamiento, empleados, gastos, ingresos y productos.

Esta feature incorpora nuevas tablas catálogo, seeds mínimos, columnas FK opcionales de integración futura y un script SQL de validación local. La implementación fue validada primero en Supabase local y luego aplicada en Supabase remoto.

## Cambios principales

- Se crea la migración `202605222300_catalogos_parametrizables_foundation.sql`.
- Se crea la migración `202605222301_catalogos_parametrizables_seed.sql`.
- Se agrega el script `database/scripts/validar_catalogos_parametrizables_foundation.sql`.
- Se agrega documentación técnica en `docs/parametrizacion/catalogos-parametrizables-foundation.md`.
- Se corrige la lógica de foreign keys defensivas para evitar fallos cuando el baseline local mínimo no contiene algunas tablas legacy.

## Catálogos creados

- `tipo_empleado`
- `medio_pago`
- `tipo_gasto`
- `tipo_ingreso`
- `categoria_producto`
- `tipo_equipamiento`
- `ubicacion_equipamiento`
- `tipo_mantenimiento`

## Seeds mínimos validados

| Catálogo | Total |
|---|---:|
| `categoria_producto` | 7 |
| `medio_pago` | 6 |
| `tipo_empleado` | 5 |
| `tipo_equipamiento` | 6 |
| `tipo_gasto` | 9 |
| `tipo_ingreso` | 6 |
| `tipo_mantenimiento` | 8 |
| `ubicacion_equipamiento` | 9 |

## Columnas opcionales preparadas para integración futura

La migración prepara columnas FK opcionales en tablas existentes cuando están presentes en el entorno:

- `entrenadores.id_tipo_empleado`
- `producto.id_categoria_producto`
- `equipamiento.id_tipo_equipamiento`
- `equipamiento.id_ubicacion_equipamiento`
- `mantenimiento.id_tipo_mantenimiento`
- `pago.id_medio_pago`
- `otros_gastos.id_tipo_gasto`

Estas columnas no reemplazan todavía columnas legacy ni obligan integración inmediata en formularios. Quedan como base para futuras features.

## Validación realizada

### Supabase local

Se validó con el flujo operativo definido para Gym Master:

```bash
npx supabase stop --no-backup
npx supabase start -x storage-api -x imgproxy -x studio -x logflare
docker exec -i supabase_db_gym-master psql -U postgres -d postgres < database/scripts/validar_catalogos_parametrizables_foundation.sql
```

Resultado local:

- 8 tablas catálogo creadas correctamente.
- Seeds mínimos cargados correctamente.
- Script de validación ejecutado sin errores SQL.
- En el baseline local mínimo solo se creó la FK de `pago.id_medio_pago`, porque las demás tablas legacy no existen en ese baseline.

### Supabase remoto

Se aplicaron las migraciones remotas con:

```bash
npx supabase db push
npx supabase migration list
```

Resultado remoto:

- `202605222300` sincronizada local/remoto.
- `202605222301` sincronizada local/remoto.
- Conteos de seeds remotos coinciden con local.

## Alcance

Esta feature se limita a la foundation de base de datos y documentación. No integra todavía los catálogos en formularios existentes.

## Fuera de alcance

- Migrar `entrenadores` a `empleados`.
- Crear CRUD frontend para cada catálogo.
- Reemplazar selects hardcodeados por catálogos reales.
- Implementar sueldos, recibos o reportes por tipo de empleado.
- Implementar equipamiento/mantenimiento avanzado.

## Próximos pasos recomendados

1. Crear endpoints/servicios para lectura de catálogos.
2. Crear pantallas CRUD para catálogos simples desde Parametrización.
3. Integrar `tipo_empleado` en la futura migración de Entrenadores a Empleados.
4. Integrar `medio_pago` en pagos y recibos.
5. Integrar `tipo_equipamiento`, `ubicacion_equipamiento` y `tipo_mantenimiento` en la feature de equipamiento/mantenimiento avanzado.
