### PR TITLE
feat: integrate parameterizable catalogs UI

### DIFF
--- a/docs/parametrizacion/integrar-catalogos-parametrizacion-ui.md
+++ b/docs/parametrizacion/integrar-catalogos-parametrizacion-ui.md
@@ -1,0 +1,50 @@
+# Integración de catálogos parametrizables en UI
+
+## Objetivo
+
+Conectar la pantalla `/dashboard/parametrizacion` con los catálogos reales creados en la base de datos.
+
+## Alcance
+
+Esta fase agrega lectura real de datos, sin modificar formularios existentes ni crear CRUD todavía.
+
+## Cambios incluidos
+
+- Nueva API interna `GET /api/parametrizacion/catalogos`.
+- Nuevo servicio frontend `parametrizacionService.ts`.
+- Nueva interfaz `parametrizacion.interface.ts`.
+- Pantalla `/dashboard/parametrizacion` con conteos reales por catálogo.
+- Botón para actualizar datos.
+- Cards con totales, activos, inactivos y ejemplos reales.
+- Ajuste de navegación para mostrar `Parametrización` en el menú de administradores.
+
+## Catálogos leídos
+
+- `tipo_empleado`
+- `medio_pago`
+- `tipo_gasto`
+- `tipo_ingreso`
+- `categoria_producto`
+- `tipo_equipamiento`
+- `ubicacion_equipamiento`
+- `tipo_mantenimiento`
+
+## Decisión técnica
+
+La API utiliza `getSupabaseServerClient()` para leer catálogos desde servidor y evitar problemas con RLS o exposición innecesaria de lógica de acceso en el navegador.
+
+La ruta se marca con:
+
+```ts
+export const dynamic = "force-dynamic";
+```
+
+para evitar errores de prerender estático en Next.js.
+
+## Fuera de alcance
+
+- CRUD de catálogos.
+- Integración de selects en formularios.
+- Migración de entrenadores a empleados.
+- Módulo de sueldos.
+- Módulo de notificaciones.

--- a/src/app/api/parametrizacion/catalogos/route.ts
+++ b/src/app/api/parametrizacion/catalogos/route.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from "next/server";
+import { getSupabaseServerClient } from "@/services/supabaseServerClient";
+import {
+  CatalogoParametrizableKey,
+  CatalogoParametrizablePrioridad,
+  CatalogoParametrizableStatus,
+} from "@/interfaces/parametrizacion.interface";
+
+export const dynamic = "force-dynamic";
+
+type CatalogDefinition = {
+  key: CatalogoParametrizableKey;
+  table: string;
+  title: string;
+  description: string;
+  status: CatalogoParametrizableStatus;
+  priority: CatalogoParametrizablePrioridad;
+};
+
+const catalogDefinitions: CatalogDefinition[] = [
+  {
+    key: "tipo_empleado",
+    table: "tipo_empleado",
+    title: "Tipos de empleado",
+    description:
+      "Base para evolucionar entrenadores hacia empleados, sueldos, recibos y reportes por rol.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+  {
+    key: "medio_pago",
+    table: "medio_pago",
+    title: "Medios de pago",
+    description:
+      "Medios disponibles para cuotas, ventas, transferencias, Stripe y futuros recibos verificables.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+  {
+    key: "tipo_gasto",
+    table: "tipo_gasto",
+    title: "Tipos de gasto",
+    description:
+      "Clasificación de egresos operativos: sueldos, mantenimiento, servicios, insumos e impuestos.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+  {
+    key: "tipo_ingreso",
+    table: "tipo_ingreso",
+    title: "Tipos de ingreso",
+    description:
+      "Clasificación de ingresos por cuotas, ventas, servicios, clases especiales y promociones.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+  {
+    key: "categoria_producto",
+    table: "categoria_producto",
+    title: "Categorías de producto",
+    description:
+      "Categorías para ordenar productos, ventas adicionales, stock y reportes comerciales.",
+    status: "Disponible",
+    priority: "Media",
+  },
+  {
+    key: "tipo_equipamiento",
+    table: "tipo_equipamiento",
+    title: "Tipos de equipamiento",
+    description:
+      "Catálogo base para clasificar máquinas y equipamiento del gimnasio.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+  {
+    key: "ubicacion_equipamiento",
+    table: "ubicacion_equipamiento",
+    title: "Ubicaciones de equipamiento",
+    description:
+      "Sectores físicos donde se ubican máquinas, accesorios y espacios operativos del gimnasio.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+  {
+    key: "tipo_mantenimiento",
+    table: "tipo_mantenimiento",
+    title: "Tipos de mantenimiento",
+    description:
+      "Verificaciones configurables por frecuencia, alerta anticipada e impacto operativo.",
+    status: "Disponible",
+    priority: "Alta",
+  },
+];
+
+function normalizeCatalogRow(row: Record<string, unknown>) {
+  return {
+    id: String(row.id),
+    codigo: String(row.codigo ?? ""),
+    nombre: String(row.nombre ?? ""),
+    descripcion: row.descripcion ? String(row.descripcion) : null,
+    activo: row.activo !== false,
+    orden: Number(row.orden ?? 0),
+    creado_en: row.creado_en ? String(row.creado_en) : null,
+    actualizado_en: row.actualizado_en ? String(row.actualizado_en) : null,
+    requiere_comprobante:
+      typeof row.requiere_comprobante === "boolean" ? row.requiere_comprobante : null,
+    es_online: typeof row.es_online === "boolean" ? row.es_online : null,
+    frecuencia_dias:
+      row.frecuencia_dias === null || row.frecuencia_dias === undefined
+        ? null
+        : Number(row.frecuencia_dias),
+    alerta_dias_anticipacion:
+      row.alerta_dias_anticipacion === null || row.alerta_dias_anticipacion === undefined
+        ? null
+        : Number(row.alerta_dias_anticipacion),
+  };
+}
+
+export async function GET() {
+  try {
+    const supabase = getSupabaseServerClient();
+
+    const catalogos = await Promise.all(
+      catalogDefinitions.map(async (definition) => {
+        const { data, error, count } = await supabase
+          .from(definition.table)
+          .select("*", { count: "exact" })
+          .order("orden", { ascending: true })
+          .order("nombre", { ascending: true });
+
+        if (error) {
+          throw new Error(`${definition.table}: ${error.message}`);
+        }
+
+        const items = ((data ?? []) as Record<string, unknown>[]).map(normalizeCatalogRow);
+        const activos = items.filter((item) => item.activo).length;
+
+        return {
+          ...definition,
+          total: count ?? items.length,
+          activos,
+          inactivos: items.length - activos,
+          items,
+          examples: items.slice(0, 5).map((item) => item.nombre),
+        };
+      })
+    );
+
+    return NextResponse.json({
+      generated_at: new Date().toISOString(),
+      catalogos,
+    });
+  } catch (error) {
+    console.error("Error al obtener catálogos de parametrización:", error);
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error al obtener catálogos" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/parametrizacion/page.tsx
+++ b/src/app/dashboard/parametrizacion/page.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  CreditCard,
+  Database,
+  Dumbbell,
+  Loader2,
+  Package,
+  ReceiptText,
+  RefreshCcw,
+  Settings,
+  ShieldCheck,
+  Tags,
+  UserCog,
+  Wrench,
+} from "lucide-react";
+import { AppFooter } from "@/components/footer/AppFooter";
+import { AppHeader } from "@/components/header/AppHeader";
+import { AppSidebar } from "@/components/sidebar/AppSidebar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import {
+  CatalogoParametrizableKey,
+  CatalogoParametrizableSummary,
+  ParametrizacionCatalogosResponse,
+} from "@/interfaces/parametrizacion.interface";
+import { getParametrizacionCatalogos } from "@/services/parametrizacionService";
+import { useAuthStore } from "@/stores/authStore";
+
+type CatalogUiDefinition = {
+  icon: React.ElementType;
+  href?: string;
+  tags: string[];
+};
+
+const catalogUiDefinitions: Record<CatalogoParametrizableKey, CatalogUiDefinition> = {
+  tipo_empleado: {
+    icon: UserCog,
+    href: "/dashboard/entrenadores",
+    tags: ["administrativo", "entrenador", "mantenimiento", "limpieza", "mayordomía/bar-snack"],
+  },
+  medio_pago: {
+    icon: CreditCard,
+    href: "/dashboard/pagos",
+    tags: ["cuotas", "ventas", "recibos", "Stripe"],
+  },
+  tipo_gasto: {
+    icon: ReceiptText,
+    href: "/dashboard/otros-gastos",
+    tags: ["sueldos", "mantenimiento", "servicios", "insumos"],
+  },
+  tipo_ingreso: {
+    icon: Tags,
+    href: "/dashboard/ventas",
+    tags: ["cuotas", "ventas", "servicios", "promociones"],
+  },
+  categoria_producto: {
+    icon: Package,
+    href: "/dashboard/productos",
+    tags: ["bebidas", "snacks", "suplementos", "stock"],
+  },
+  tipo_equipamiento: {
+    icon: Dumbbell,
+    href: "/dashboard/equipamientos",
+    tags: ["cardio", "fuerza", "funcional", "peso libre"],
+  },
+  ubicacion_equipamiento: {
+    icon: Database,
+    href: "/dashboard/equipamientos",
+    tags: ["zonas", "sala", "depósito", "bar/snack"],
+  },
+  tipo_mantenimiento: {
+    icon: Wrench,
+    href: "/dashboard/equipamientos",
+    tags: ["lubricación", "cableado", "seguridad", "alertas"],
+  },
+};
+
+const statusStyles: Record<string, string> = {
+  Disponible: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  "Base existente": "bg-[#e6f7fd] text-[#027aa3] border-[#b8e8f7]",
+  Planificado: "bg-amber-50 text-amber-700 border-amber-200",
+};
+
+const priorityStyles: Record<string, string> = {
+  Alta: "bg-red-50 text-red-700 border-red-200",
+  Media: "bg-blue-50 text-blue-700 border-blue-200",
+  Futura: "bg-slate-50 text-slate-700 border-slate-200",
+};
+
+function formatDateTime(value?: string) {
+  if (!value) return "-";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "-" : date.toLocaleString("es-AR");
+}
+
+export default function ParametrizacionPage() {
+  const { user, isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const router = useRouter();
+  const [catalogosData, setCatalogosData] = useState<ParametrizacionCatalogosResponse | null>(null);
+  const [loadingCatalogos, setLoadingCatalogos] = useState(false);
+  const [catalogosError, setCatalogosError] = useState<string | null>(null);
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
+  useEffect(() => {
+    if (isInitialized && !isAuthenticated) {
+      router.push("/auth/login");
+    }
+  }, [isAuthenticated, isInitialized, router]);
+
+  const loadCatalogos = useCallback(async () => {
+    setLoadingCatalogos(true);
+    setCatalogosError(null);
+
+    try {
+      const data = await getParametrizacionCatalogos();
+      setCatalogosData(data);
+    } catch (error) {
+      setCatalogosError(
+        error instanceof Error ? error.message : "No se pudieron cargar los catálogos"
+      );
+    } finally {
+      setLoadingCatalogos(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isInitialized && isAuthenticated && user?.rol === "admin") {
+      loadCatalogos();
+    }
+  }, [isAuthenticated, isInitialized, loadCatalogos, user?.rol]);
+
+  const resumen = useMemo(() => {
+    const catalogos = catalogosData?.catalogos ?? [];
+    return {
+      catalogos: catalogos.length,
+      registros: catalogos.reduce((acc, catalogo) => acc + catalogo.total, 0),
+      activos: catalogos.reduce((acc, catalogo) => acc + catalogo.activos, 0),
+    };
+  }, [catalogosData]);
+
+  if (!isInitialized) {
+    return <div>Cargando...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  const isAdmin = user?.rol === "admin";
+  const catalogos = catalogosData?.catalogos ?? [];
+
+  return (
+    <SidebarProvider>
+      <div className="flex w-full min-h-screen">
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader title="Parametrización" />
+          <main className="flex-1 p-6 space-y-6">
+            {!isAdmin ? (
+              <Card className="border-amber-200 bg-amber-50">
+                <CardContent className="flex items-start gap-3 p-5 text-amber-800">
+                  <AlertTriangle className="mt-0.5 h-5 w-5" />
+                  <div>
+                    <h2 className="text-lg font-semibold">Acceso restringido</h2>
+                    <p className="mt-1 text-sm">
+                      La parametrización del sistema está disponible para usuarios administradores.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <>
+                <Card className="overflow-hidden border-0 shadow-sm">
+                  <div className="bg-gradient-to-r from-slate-950 via-slate-900 to-[#025f80] p-6 text-white">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                      <div>
+                        <div className="flex items-center gap-2 text-sm text-cyan-100">
+                          <ShieldCheck className="h-4 w-4" />
+                          Configuración administrativa
+                        </div>
+                        <h1 className="mt-2 text-2xl font-bold">Parametrización de catálogos</h1>
+                        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-slate-200">
+                          Consulta en vivo de los catálogos reales creados en base de datos para eliminar progresivamente valores hardcodeados en formularios, reportes y procesos administrativos.
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm backdrop-blur">
+                        <p className="font-semibold">Última lectura</p>
+                        <p className="mt-1 text-cyan-100">
+                          {formatDateTime(catalogosData?.generated_at)}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+
+                <div className="grid gap-4 md:grid-cols-3">
+                  <Card>
+                    <CardContent className="p-4">
+                      <p className="text-sm text-gray-500">Catálogos reales</p>
+                      <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.catalogos}</p>
+                      <p className="mt-1 text-xs text-gray-500">Leídos desde Supabase vía API interna.</p>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardContent className="p-4">
+                      <p className="text-sm text-gray-500">Registros parametrizables</p>
+                      <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.registros}</p>
+                      <p className="mt-1 text-xs text-gray-500">Seeds y valores activos para próximas integraciones.</p>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardContent className="p-4">
+                      <p className="text-sm text-gray-500">Activos</p>
+                      <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.activos}</p>
+                      <p className="mt-1 text-xs text-gray-500">Base para futuros selectores y CRUD administrativo.</p>
+                    </CardContent>
+                  </Card>
+                </div>
+
+                <Card>
+                  <CardHeader className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h2 className="text-xl font-bold">Catálogos disponibles</h2>
+                      <p className="text-sm text-gray-500">
+                        Datos vivos de la base. Esta fase todavía no reemplaza formularios existentes.
+                      </p>
+                    </div>
+                    <Button
+                      onClick={loadCatalogos}
+                      disabled={loadingCatalogos}
+                      className="bg-[#02a8e1] hover:bg-[#0288b1]"
+                    >
+                      {loadingCatalogos ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <RefreshCcw className="mr-2 h-4 w-4" />
+                      )}
+                      Actualizar catálogos
+                    </Button>
+                  </CardHeader>
+                  <CardContent className="p-4">
+                    {catalogosError ? (
+                      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                        {catalogosError}
+                      </div>
+                    ) : loadingCatalogos && !catalogos.length ? (
+                      <div className="flex items-center justify-center gap-2 rounded-xl border border-dashed p-8 text-sm text-gray-500">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Cargando catálogos parametrizables...
+                      </div>
+                    ) : (
+                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        {catalogos.map((catalogo: CatalogoParametrizableSummary) => {
+                          const ui = catalogUiDefinitions[catalogo.key];
+                          const Icon = ui?.icon ?? Database;
+                          const examples = catalogo.examples.length ? catalogo.examples : ui?.tags ?? [];
+
+                          return (
+                            <div
+                              key={catalogo.key}
+                              className="flex flex-col rounded-2xl border bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                            >
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="rounded-xl bg-[#02a8e1]/10 p-2 text-[#02a8e1]">
+                                  <Icon className="h-5 w-5" />
+                                </div>
+                                <div className="flex flex-wrap justify-end gap-2">
+                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${statusStyles[catalogo.status]}`}>
+                                    {catalogo.status}
+                                  </span>
+                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${priorityStyles[catalogo.priority]}`}>
+                                    {catalogo.priority}
+                                  </span>
+                                </div>
+                              </div>
+
+                              <h3 className="mt-4 text-lg font-bold text-gray-950">{catalogo.title}</h3>
+                              <p className="mt-2 text-sm leading-relaxed text-gray-500">{catalogo.description}</p>
+
+                              <div className="mt-4 grid grid-cols-3 gap-2">
+                                <div className="rounded-xl bg-slate-50 p-2 text-center">
+                                  <p className="text-[11px] text-slate-500">Total</p>
+                                  <p className="text-lg font-bold text-slate-950">{catalogo.total}</p>
+                                </div>
+                                <div className="rounded-xl bg-emerald-50 p-2 text-center">
+                                  <p className="text-[11px] text-emerald-700">Activos</p>
+                                  <p className="text-lg font-bold text-emerald-700">{catalogo.activos}</p>
+                                </div>
+                                <div className="rounded-xl bg-slate-50 p-2 text-center">
+                                  <p className="text-[11px] text-slate-500">Inactivos</p>
+                                  <p className="text-lg font-bold text-slate-950">{catalogo.inactivos}</p>
+                                </div>
+                              </div>
+
+                              <div className="mt-4 flex flex-wrap gap-2">
+                                {examples.slice(0, 6).map((item) => (
+                                  <span key={item} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-600">
+                                    {item}
+                                  </span>
+                                ))}
+                              </div>
+
+                              <div className="mt-auto pt-4">
+                                {ui?.href ? (
+                                  <Button asChild variant="outline" className="w-full justify-between border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]">
+                                    <Link href={ui.href}>
+                                      Ver módulo relacionado
+                                      <ArrowRight className="h-4 w-4" />
+                                    </Link>
+                                  </Button>
+                                ) : (
+                                  <div className="flex items-center gap-2 rounded-xl bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                                    <CheckCircle2 className="h-4 w-4" />
+                                    Catálogo disponible para integración
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </>
+            )}
+          </main>
+          <AppFooter />
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -97,13 +97,18 @@ export const sections: SidebarSectionType[] = [
     ],
   },
   {
-    title: 'Configuración Personal',
+    title: 'Configuración',
     icon: Settings,
     items: [
       { title: 'Perfil', link: '/dashboard/perfil', level: 2 },
       {
         title: 'Preferencias',
         link: '/dashboard/settings/preferences',
+        level: 2,
+      },
+      {
+        title: 'Parametrización',
+        link: '/dashboard/parametrizacion',
         level: 2,
       },
     ],

--- a/src/hooks/useSidebarSection.ts
+++ b/src/hooks/useSidebarSection.ts
@@ -96,6 +96,7 @@ export const useSidebarMenu = (
       'Productos',
       'Servicios',
       'Otros gastos',
+      'Parametrización',
       'Perfil',
       'Preferencias',
     ];

--- a/src/interfaces/parametrizacion.interface.ts
+++ b/src/interfaces/parametrizacion.interface.ts
@@ -1,0 +1,46 @@
+export type CatalogoParametrizableKey =
+  | "tipo_empleado"
+  | "medio_pago"
+  | "tipo_gasto"
+  | "tipo_ingreso"
+  | "categoria_producto"
+  | "tipo_equipamiento"
+  | "ubicacion_equipamiento"
+  | "tipo_mantenimiento";
+
+export type CatalogoParametrizableStatus = "Disponible" | "Planificado" | "Base existente";
+export type CatalogoParametrizablePrioridad = "Alta" | "Media" | "Futura";
+
+export interface CatalogoParametrizableItem {
+  id: string;
+  codigo: string;
+  nombre: string;
+  descripcion: string | null;
+  activo: boolean;
+  orden: number;
+  creado_en?: string | null;
+  actualizado_en?: string | null;
+  requiere_comprobante?: boolean | null;
+  es_online?: boolean | null;
+  frecuencia_dias?: number | null;
+  alerta_dias_anticipacion?: number | null;
+}
+
+export interface CatalogoParametrizableSummary {
+  key: CatalogoParametrizableKey;
+  table: string;
+  title: string;
+  description: string;
+  status: CatalogoParametrizableStatus;
+  priority: CatalogoParametrizablePrioridad;
+  total: number;
+  activos: number;
+  inactivos: number;
+  items: CatalogoParametrizableItem[];
+  examples: string[];
+}
+
+export interface ParametrizacionCatalogosResponse {
+  generated_at: string;
+  catalogos: CatalogoParametrizableSummary[];
+}

--- a/src/services/parametrizacionService.ts
+++ b/src/services/parametrizacionService.ts
@@ -1,0 +1,16 @@
+import { ParametrizacionCatalogosResponse } from "@/interfaces/parametrizacion.interface";
+
+export async function getParametrizacionCatalogos(): Promise<ParametrizacionCatalogosResponse> {
+  const response = await fetch("/api/parametrizacion/catalogos", {
+    method: "GET",
+    cache: "no-store",
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(payload?.error || "Error al obtener catálogos de parametrización");
+  }
+
+  return payload as ParametrizacionCatalogosResponse;
+}


### PR DESCRIPTION
# PR: Integrar catálogos parametrizables en la UI de Parametrización

## Resumen

Se integra la pantalla administrativa de **Parametrización** con los catálogos reales creados previamente en base de datos, permitiendo visualizar información viva desde Supabase en lugar de mantener únicamente cards estáticas o planificadas.

Esta feature conecta el frontend con una API interna para consultar los catálogos parametrizables, mostrar conteos reales, estados activos/inactivos y ejemplos de registros por cada catálogo.

## Rama

`feature/integrar-catalogos-parametrizacion-ui`

## Cambios principales

- Se agrega el endpoint `GET /api/parametrizacion/catalogos`.
- Se crea la interfaz TypeScript para representar catálogos parametrizables.
- Se agrega un servicio frontend para consumir la API de parametrización.
- Se actualiza la pantalla `/dashboard/parametrizacion` para mostrar datos reales.
- Se muestran conteos por catálogo: total, activos e inactivos.
- Se agregan ejemplos visibles de registros reales por catálogo.
- Se incorpora botón de actualización manual de catálogos.
- Se asegura el acceso desde el menú lateral para usuarios administradores.
- Se documenta la integración UI de catálogos parametrizables.

## Catálogos integrados

- `tipo_empleado`
- `medio_pago`
- `tipo_gasto`
- `tipo_ingreso`
- `categoria_producto`
- `tipo_equipamiento`
- `ubicacion_equipamiento`
- `tipo_mantenimiento`

## Archivos principales

- `src/app/api/parametrizacion/catalogos/route.ts`
- `src/app/dashboard/parametrizacion/page.tsx`
- `src/interfaces/parametrizacion.interface.ts`
- `src/services/parametrizacionService.ts`
- `src/components/sidebar/sidebarConfig.ts`
- `src/hooks/useSidebarSection.ts`
- `docs/parametrizacion/integrar-catalogos-parametrizacion-ui.md`

## Alcance

Esta feature **no modifica base de datos**, **no agrega migraciones** y **no cambia formularios operativos existentes**.

La integración queda enfocada en lectura y visualización administrativa de catálogos reales desde la pantalla de Parametrización.

## Fuera de alcance

- CRUD completo de catálogos.
- Edición de registros desde la pantalla de Parametrización.
- Integración de catálogos en formularios de productos, pagos, equipamientos, mantenimientos o empleados.
- Migración de `entrenadores` hacia `empleados`.
- Módulo de notificaciones administrativas.

## Validación

- Rama probada exitosamente en entorno local.
- Validación funcional de `/dashboard/parametrizacion` como usuario administrador.
- Visualización correcta de catálogos reales creados en la feature anterior.
- Confirmación de acceso desde el menú lateral.
- Sin cambios en base de datos.

## Próximos pasos recomendados

1. Crear CRUD administrativo para catálogos simples.
2. Integrar catálogos reales en formularios existentes.
3. Avanzar con `tipo_empleado` y evolución de Entrenadores hacia Empleados.
4. Preparar módulo de Equipamiento/Mantenimiento avanzado.
5. Diseñar módulo de Notificaciones administrativas.
