### PR TITLE
feat: add parameterizable catalog CRUD base

### DIFF
--- a/docs/parametrizacion/catalogos-parametrizables-crud-base.md
+++ b/docs/parametrizacion/catalogos-parametrizables-crud-base.md
@@ -1,0 +1,47 @@
+# Catálogos parametrizables - CRUD base
+
+## Objetivo
+
+Agregar una primera capa de administración CRUD para los catálogos parametrizables de Gym Master desde `/dashboard/parametrizacion`.
+
+## Alcance
+
+Esta feature permite:
+
+- crear registros en catálogos parametrizables;
+- editar registros existentes;
+- activar/desactivar registros sin hard delete;
+- refrescar los datos vivos desde Supabase;
+- mantener la pantalla de parametrización como panel operativo inicial.
+
+## Catálogos alcanzados
+
+El endpoint y la UI soportan los 8 catálogos foundation:
+
+- `tipo_empleado`
+- `medio_pago`
+- `tipo_gasto`
+- `tipo_ingreso`
+- `categoria_producto`
+- `tipo_equipamiento`
+- `ubicacion_equipamiento`
+- `tipo_mantenimiento`
+
+## Decisiones técnicas
+
+- Se mantiene un único endpoint `/api/parametrizacion/catalogos` con métodos `GET`, `POST` y `PATCH`.
+- El endpoint usa una whitelist de tablas permitidas para evitar escrituras dinámicas inseguras.
+- No se implementa hard delete; los registros se desactivan con `activo = false`.
+- El código del catálogo se normaliza en backend a minúsculas, sin acentos, sin espacios y con `_`.
+- Se usa `getSupabaseServerClient()` para operar desde el servidor.
+
+## Fuera de alcance
+
+No se integran todavía estos catálogos en formularios operativos como pagos, productos, equipamiento, mantenimientos o empleados.
+
+## Próximos pasos recomendados
+
+1. Integrar `medio_pago` en formularios de pagos y recibos.
+2. Integrar `tipo_gasto` en otros gastos y futuros sueldos.
+3. Integrar `tipo_empleado` cuando se migre entrenadores a empleados.
+4. Integrar `tipo_equipamiento`, `ubicacion_equipamiento` y `tipo_mantenimiento` en equipamiento/mantenimiento avanzado.

--- a/src/app/api/parametrizacion/catalogos/route.ts
+++ b/src/app/api/parametrizacion/catalogos/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
 import {
   CatalogoParametrizableKey,
@@ -15,6 +15,8 @@ type CatalogDefinition = {
   description: string;
   status: CatalogoParametrizableStatus;
   priority: CatalogoParametrizablePrioridad;
+  editable: boolean;
+  extraFields?: string[];
 };
 
 const catalogDefinitions: CatalogDefinition[] = [
@@ -26,6 +28,7 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Base para evolucionar entrenadores hacia empleados, sueldos, recibos y reportes por rol.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
   },
   {
     key: "medio_pago",
@@ -35,6 +38,8 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Medios disponibles para cuotas, ventas, transferencias, Stripe y futuros recibos verificables.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
+    extraFields: ["requiere_comprobante", "es_online"],
   },
   {
     key: "tipo_gasto",
@@ -44,6 +49,7 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Clasificación de egresos operativos: sueldos, mantenimiento, servicios, insumos e impuestos.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
   },
   {
     key: "tipo_ingreso",
@@ -53,6 +59,7 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Clasificación de ingresos por cuotas, ventas, servicios, clases especiales y promociones.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
   },
   {
     key: "categoria_producto",
@@ -62,15 +69,16 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Categorías para ordenar productos, ventas adicionales, stock y reportes comerciales.",
     status: "Disponible",
     priority: "Media",
+    editable: true,
   },
   {
     key: "tipo_equipamiento",
     table: "tipo_equipamiento",
     title: "Tipos de equipamiento",
-    description:
-      "Catálogo base para clasificar máquinas y equipamiento del gimnasio.",
+    description: "Catálogo base para clasificar máquinas y equipamiento del gimnasio.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
   },
   {
     key: "ubicacion_equipamiento",
@@ -80,6 +88,7 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Sectores físicos donde se ubican máquinas, accesorios y espacios operativos del gimnasio.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
   },
   {
     key: "tipo_mantenimiento",
@@ -89,8 +98,14 @@ const catalogDefinitions: CatalogDefinition[] = [
       "Verificaciones configurables por frecuencia, alerta anticipada e impacto operativo.",
     status: "Disponible",
     priority: "Alta",
+    editable: true,
+    extraFields: ["frecuencia_dias", "alerta_dias_anticipacion"],
   },
 ];
+
+function getCatalogDefinition(key: unknown) {
+  return catalogDefinitions.find((definition) => definition.key === key);
+}
 
 function normalizeCatalogRow(row: Record<string, unknown>) {
   return {
@@ -114,6 +129,105 @@ function normalizeCatalogRow(row: Record<string, unknown>) {
         ? null
         : Number(row.alerta_dias_anticipacion),
   };
+}
+
+function sanitizeCodigo(codigo: string) {
+  return codigo
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80);
+}
+
+function parseString(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseNullableString(value: unknown) {
+  const text = parseString(value);
+  return text.length ? text : null;
+}
+
+function parseNullablePositiveInteger(value: unknown) {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return Math.round(parsed);
+}
+
+function parseNonNegativeInteger(value: unknown, fallback = 0) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.round(parsed);
+}
+
+function buildCatalogPayload(
+  definition: CatalogDefinition,
+  body: Record<string, unknown>,
+  mode: "create" | "update"
+) {
+  const payload: Record<string, unknown> = {};
+
+  const nombre = parseString(body.nombre);
+  if (mode === "create" && !nombre) {
+    throw new Error("El nombre es obligatorio");
+  }
+  if (nombre || mode === "create") {
+    payload.nombre = nombre;
+  }
+
+  const rawCodigo = parseString(body.codigo);
+  if (mode === "create" && !rawCodigo) {
+    throw new Error("El código es obligatorio");
+  }
+  if (rawCodigo || mode === "create") {
+    const codigo = sanitizeCodigo(rawCodigo);
+    if (!codigo) {
+      throw new Error("El código no tiene un formato válido");
+    }
+    payload.codigo = codigo;
+  }
+
+  if ("descripcion" in body || mode === "create") {
+    payload.descripcion = parseNullableString(body.descripcion);
+  }
+
+  if ("activo" in body || mode === "create") {
+    payload.activo = body.activo !== false;
+  }
+
+  if ("orden" in body || mode === "create") {
+    payload.orden = parseNonNegativeInteger(body.orden, 0);
+  }
+
+  if (definition.extraFields?.includes("requiere_comprobante") && "requiere_comprobante" in body) {
+    payload.requiere_comprobante = body.requiere_comprobante === true;
+  }
+
+  if (definition.extraFields?.includes("es_online") && "es_online" in body) {
+    payload.es_online = body.es_online === true;
+  }
+
+  if (definition.extraFields?.includes("frecuencia_dias") && "frecuencia_dias" in body) {
+    payload.frecuencia_dias = parseNullablePositiveInteger(body.frecuencia_dias);
+  }
+
+  if (
+    definition.extraFields?.includes("alerta_dias_anticipacion") &&
+    "alerta_dias_anticipacion" in body
+  ) {
+    payload.alerta_dias_anticipacion = parseNonNegativeInteger(
+      body.alerta_dias_anticipacion,
+      0
+    );
+  }
+
+  payload.actualizado_en = new Date().toISOString();
+
+  return payload;
 }
 
 export async function GET() {
@@ -155,6 +269,89 @@ export async function GET() {
 
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Error al obtener catálogos" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    const definition = getCatalogDefinition(body.catalogo);
+
+    if (!definition || !definition.editable) {
+      return NextResponse.json({ error: "Catálogo no editable o inexistente" }, { status: 400 });
+    }
+
+    const supabase = getSupabaseServerClient();
+    const payload = buildCatalogPayload(definition, body, "create");
+
+    const { data, error } = await supabase
+      .from(definition.table)
+      .insert(payload)
+      .select("*")
+      .single();
+
+    if (error) {
+      const status = error.code === "23505" ? 409 : 500;
+      return NextResponse.json({ error: error.message }, { status });
+    }
+
+    return NextResponse.json(
+      {
+        item: normalizeCatalogRow(data as Record<string, unknown>),
+        message: "Registro creado correctamente",
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error al crear catálogo de parametrización:", error);
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error al crear registro" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Record<string, unknown>;
+    const definition = getCatalogDefinition(body.catalogo);
+    const id = parseString(body.id);
+
+    if (!definition || !definition.editable) {
+      return NextResponse.json({ error: "Catálogo no editable o inexistente" }, { status: 400 });
+    }
+
+    if (!id) {
+      return NextResponse.json({ error: "El id es obligatorio" }, { status: 400 });
+    }
+
+    const supabase = getSupabaseServerClient();
+    const payload = buildCatalogPayload(definition, body, "update");
+
+    const { data, error } = await supabase
+      .from(definition.table)
+      .update(payload)
+      .eq("id", id)
+      .select("*")
+      .single();
+
+    if (error) {
+      const status = error.code === "23505" ? 409 : 500;
+      return NextResponse.json({ error: error.message }, { status });
+    }
+
+    return NextResponse.json({
+      item: normalizeCatalogRow(data as Record<string, unknown>),
+      message: "Registro actualizado correctamente",
+    });
+  } catch (error) {
+    console.error("Error al actualizar catálogo de parametrización:", error);
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Error al actualizar registro" },
       { status: 500 }
     );
   }

--- a/src/app/dashboard/parametrizacion/page.tsx
+++ b/src/app/dashboard/parametrizacion/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   AlertTriangle,
@@ -10,13 +10,17 @@ import {
   CreditCard,
   Database,
   Dumbbell,
+  Edit3,
   Loader2,
   Package,
+  Plus,
   ReceiptText,
   RefreshCcw,
   Settings,
   ShieldCheck,
   Tags,
+  ToggleLeft,
+  ToggleRight,
   UserCog,
   Wrench,
 } from "lucide-react";
@@ -25,19 +29,49 @@ import { AppHeader } from "@/components/header/AppHeader";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import {
+  CatalogoParametrizableItem,
   CatalogoParametrizableKey,
+  CatalogoParametrizablePayload,
   CatalogoParametrizableSummary,
   ParametrizacionCatalogosResponse,
 } from "@/interfaces/parametrizacion.interface";
-import { getParametrizacionCatalogos } from "@/services/parametrizacionService";
+import {
+  createParametrizacionCatalogoItem,
+  getParametrizacionCatalogos,
+  toggleParametrizacionCatalogoItem,
+  updateParametrizacionCatalogoItem,
+} from "@/services/parametrizacionService";
 import { useAuthStore } from "@/stores/authStore";
 
 type CatalogUiDefinition = {
   icon: React.ElementType;
   href?: string;
   tags: string[];
+};
+
+type CatalogFormState = {
+  codigo: string;
+  nombre: string;
+  descripcion: string;
+  orden: string;
+  activo: boolean;
+  requiere_comprobante: boolean;
+  es_online: boolean;
+  frecuencia_dias: string;
+  alerta_dias_anticipacion: string;
 };
 
 const catalogUiDefinitions: Record<CatalogoParametrizableKey, CatalogUiDefinition> = {
@@ -101,12 +135,53 @@ function formatDateTime(value?: string) {
   return Number.isNaN(date.getTime()) ? "-" : date.toLocaleString("es-AR");
 }
 
+function emptyFormState(): CatalogFormState {
+  return {
+    codigo: "",
+    nombre: "",
+    descripcion: "",
+    orden: "0",
+    activo: true,
+    requiere_comprobante: false,
+    es_online: false,
+    frecuencia_dias: "",
+    alerta_dias_anticipacion: "5",
+  };
+}
+
+function formFromItem(item: CatalogoParametrizableItem): CatalogFormState {
+  return {
+    codigo: item.codigo,
+    nombre: item.nombre,
+    descripcion: item.descripcion ?? "",
+    orden: String(item.orden ?? 0),
+    activo: item.activo,
+    requiere_comprobante: item.requiere_comprobante === true,
+    es_online: item.es_online === true,
+    frecuencia_dias: item.frecuencia_dias == null ? "" : String(item.frecuencia_dias),
+    alerta_dias_anticipacion:
+      item.alerta_dias_anticipacion == null ? "0" : String(item.alerta_dias_anticipacion),
+  };
+}
+
+function parseOptionalNumber(value: string) {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export default function ParametrizacionPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
   const [catalogosData, setCatalogosData] = useState<ParametrizacionCatalogosResponse | null>(null);
   const [loadingCatalogos, setLoadingCatalogos] = useState(false);
   const [catalogosError, setCatalogosError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedCatalog, setSelectedCatalog] = useState<CatalogoParametrizableSummary | null>(null);
+  const [selectedItem, setSelectedItem] = useState<CatalogoParametrizableItem | null>(null);
+  const [formState, setFormState] = useState<CatalogFormState>(emptyFormState());
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     initializeAuth();
@@ -149,6 +224,92 @@ export default function ParametrizacionPage() {
     };
   }, [catalogosData]);
 
+  const openCreateDialog = (catalogo: CatalogoParametrizableSummary) => {
+    setSelectedCatalog(catalogo);
+    setSelectedItem(null);
+    setFormState(emptyFormState());
+    setActionMessage(null);
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (
+    catalogo: CatalogoParametrizableSummary,
+    item: CatalogoParametrizableItem
+  ) => {
+    setSelectedCatalog(catalogo);
+    setSelectedItem(item);
+    setFormState(formFromItem(item));
+    setActionMessage(null);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!selectedCatalog) return;
+
+    setSaving(true);
+    setCatalogosError(null);
+    setActionMessage(null);
+
+    const payload: CatalogoParametrizablePayload = {
+      catalogo: selectedCatalog.key,
+      id: selectedItem?.id,
+      codigo: formState.codigo,
+      nombre: formState.nombre,
+      descripcion: formState.descripcion || null,
+      orden: Number(formState.orden || 0),
+      activo: formState.activo,
+    };
+
+    if (selectedCatalog.key === "medio_pago") {
+      payload.requiere_comprobante = formState.requiere_comprobante;
+      payload.es_online = formState.es_online;
+    }
+
+    if (selectedCatalog.key === "tipo_mantenimiento") {
+      payload.frecuencia_dias = parseOptionalNumber(formState.frecuencia_dias);
+      payload.alerta_dias_anticipacion = Number(formState.alerta_dias_anticipacion || 0);
+    }
+
+    try {
+      if (selectedItem) {
+        await updateParametrizacionCatalogoItem(payload);
+        setActionMessage("Registro actualizado correctamente.");
+      } else {
+        await createParametrizacionCatalogoItem(payload);
+        setActionMessage("Registro creado correctamente.");
+      }
+
+      setDialogOpen(false);
+      await loadCatalogos();
+    } catch (error) {
+      setCatalogosError(error instanceof Error ? error.message : "No se pudo guardar el registro");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleItem = async (
+    catalogo: CatalogoParametrizableSummary,
+    item: CatalogoParametrizableItem
+  ) => {
+    setCatalogosError(null);
+    setActionMessage(null);
+
+    try {
+      await toggleParametrizacionCatalogoItem({
+        catalogo: catalogo.key,
+        id: item.id,
+        activo: !item.activo,
+      });
+      setActionMessage(item.activo ? "Registro desactivado." : "Registro activado.");
+      await loadCatalogos();
+    } catch (error) {
+      setCatalogosError(error instanceof Error ? error.message : "No se pudo cambiar el estado");
+    }
+  };
+
   if (!isInitialized) {
     return <div>Cargando...</div>;
   }
@@ -159,6 +320,8 @@ export default function ParametrizacionPage() {
 
   const isAdmin = user?.rol === "admin";
   const catalogos = catalogosData?.catalogos ?? [];
+  const isMedioPago = selectedCatalog?.key === "medio_pago";
+  const isTipoMantenimiento = selectedCatalog?.key === "tipo_mantenimiento";
 
   return (
     <SidebarProvider>
@@ -191,14 +354,12 @@ export default function ParametrizacionPage() {
                         </div>
                         <h1 className="mt-2 text-2xl font-bold">Parametrización de catálogos</h1>
                         <p className="mt-2 max-w-3xl text-sm leading-relaxed text-slate-200">
-                          Consulta en vivo de los catálogos reales creados en base de datos para eliminar progresivamente valores hardcodeados en formularios, reportes y procesos administrativos.
+                          Consulta y administración base de catálogos reales para eliminar progresivamente valores hardcodeados en formularios, reportes y procesos administrativos.
                         </p>
                       </div>
                       <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm backdrop-blur">
                         <p className="font-semibold">Última lectura</p>
-                        <p className="mt-1 text-cyan-100">
-                          {formatDateTime(catalogosData?.generated_at)}
-                        </p>
+                        <p className="mt-1 text-cyan-100">{formatDateTime(catalogosData?.generated_at)}</p>
                       </div>
                     </div>
                   </div>
@@ -216,7 +377,7 @@ export default function ParametrizacionPage() {
                     <CardContent className="p-4">
                       <p className="text-sm text-gray-500">Registros parametrizables</p>
                       <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.registros}</p>
-                      <p className="mt-1 text-xs text-gray-500">Seeds y valores activos para próximas integraciones.</p>
+                      <p className="mt-1 text-xs text-gray-500">Seeds y valores vivos para próximas integraciones.</p>
                     </CardContent>
                   </Card>
                   <Card>
@@ -233,28 +394,27 @@ export default function ParametrizacionPage() {
                     <div>
                       <h2 className="text-xl font-bold">Catálogos disponibles</h2>
                       <p className="text-sm text-gray-500">
-                        Datos vivos de la base. Esta fase todavía no reemplaza formularios existentes.
+                        Datos vivos de la base. Esta fase habilita creación, edición y activación/desactivación sin hard delete.
                       </p>
                     </div>
-                    <Button
-                      onClick={loadCatalogos}
-                      disabled={loadingCatalogos}
-                      className="bg-[#02a8e1] hover:bg-[#0288b1]"
-                    >
-                      {loadingCatalogos ? (
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      ) : (
-                        <RefreshCcw className="mr-2 h-4 w-4" />
-                      )}
+                    <Button onClick={loadCatalogos} disabled={loadingCatalogos} className="bg-[#02a8e1] hover:bg-[#0288b1]">
+                      {loadingCatalogos ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCcw className="mr-2 h-4 w-4" />}
                       Actualizar catálogos
                     </Button>
                   </CardHeader>
-                  <CardContent className="p-4">
-                    {catalogosError ? (
+                  <CardContent className="p-4 space-y-4">
+                    {catalogosError && (
                       <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
                         {catalogosError}
                       </div>
-                    ) : loadingCatalogos && !catalogos.length ? (
+                    )}
+                    {actionMessage && (
+                      <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+                        {actionMessage}
+                      </div>
+                    )}
+
+                    {loadingCatalogos && !catalogos.length ? (
                       <div className="flex items-center justify-center gap-2 rounded-xl border border-dashed p-8 text-sm text-gray-500">
                         <Loader2 className="h-4 w-4 animate-spin" />
                         Cargando catálogos parametrizables...
@@ -267,47 +427,77 @@ export default function ParametrizacionPage() {
                           const examples = catalogo.examples.length ? catalogo.examples : ui?.tags ?? [];
 
                           return (
-                            <div
-                              key={catalogo.key}
-                              className="flex flex-col rounded-2xl border bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
-                            >
+                            <div key={catalogo.key} className="flex flex-col rounded-2xl border bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
                               <div className="flex items-start justify-between gap-3">
                                 <div className="rounded-xl bg-[#02a8e1]/10 p-2 text-[#02a8e1]">
                                   <Icon className="h-5 w-5" />
                                 </div>
                                 <div className="flex flex-wrap justify-end gap-2">
-                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${statusStyles[catalogo.status]}`}>
-                                    {catalogo.status}
-                                  </span>
-                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${priorityStyles[catalogo.priority]}`}>
-                                    {catalogo.priority}
-                                  </span>
+                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${statusStyles[catalogo.status]}`}>{catalogo.status}</span>
+                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${priorityStyles[catalogo.priority]}`}>{catalogo.priority}</span>
                                 </div>
                               </div>
 
                               <h3 className="mt-4 text-lg font-bold text-gray-950">{catalogo.title}</h3>
                               <p className="mt-2 text-sm leading-relaxed text-gray-500">{catalogo.description}</p>
 
-                              <div className="mt-4 grid grid-cols-3 gap-2">
-                                <div className="rounded-xl bg-slate-50 p-2 text-center">
-                                  <p className="text-[11px] text-slate-500">Total</p>
-                                  <p className="text-lg font-bold text-slate-950">{catalogo.total}</p>
+                              <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs">
+                                <div className="rounded-xl bg-slate-50 p-2">
+                                  <p className="text-gray-500">Total</p>
+                                  <p className="text-lg font-bold text-gray-950">{catalogo.total}</p>
                                 </div>
-                                <div className="rounded-xl bg-emerald-50 p-2 text-center">
-                                  <p className="text-[11px] text-emerald-700">Activos</p>
+                                <div className="rounded-xl bg-emerald-50 p-2">
+                                  <p className="text-emerald-600">Activos</p>
                                   <p className="text-lg font-bold text-emerald-700">{catalogo.activos}</p>
                                 </div>
-                                <div className="rounded-xl bg-slate-50 p-2 text-center">
-                                  <p className="text-[11px] text-slate-500">Inactivos</p>
-                                  <p className="text-lg font-bold text-slate-950">{catalogo.inactivos}</p>
+                                <div className="rounded-xl bg-amber-50 p-2">
+                                  <p className="text-amber-600">Inactivos</p>
+                                  <p className="text-lg font-bold text-amber-700">{catalogo.inactivos}</p>
+                                </div>
+                              </div>
+
+                              <div className="mt-4 space-y-2">
+                                <div className="flex items-center justify-between gap-2">
+                                  <p className="text-xs font-semibold uppercase text-gray-500">Registros</p>
+                                  {catalogo.editable && (
+                                    <Button size="sm" onClick={() => openCreateDialog(catalogo)} className="h-8 bg-[#02a8e1] hover:bg-[#0288b1]">
+                                      <Plus className="mr-1 h-3.5 w-3.5" /> Nuevo
+                                    </Button>
+                                  )}
+                                </div>
+
+                                <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+                                  {catalogo.items.map((item) => (
+                                    <div key={item.id} className="rounded-xl border bg-slate-50 p-3">
+                                      <div className="flex items-start justify-between gap-2">
+                                        <div>
+                                          <p className="text-sm font-semibold text-gray-950">{item.nombre}</p>
+                                          <p className="text-xs text-gray-500">{item.codigo}</p>
+                                        </div>
+                                        <span className={`rounded-full px-2 py-1 text-[11px] font-medium ${item.activo ? "bg-emerald-100 text-emerald-700" : "bg-gray-200 text-gray-600"}`}>
+                                          {item.activo ? "Activo" : "Inactivo"}
+                                        </span>
+                                      </div>
+
+                                      {item.descripcion && <p className="mt-2 line-clamp-2 text-xs text-gray-500">{item.descripcion}</p>}
+
+                                      <div className="mt-3 flex flex-wrap gap-2">
+                                        <Button size="sm" variant="outline" onClick={() => openEditDialog(catalogo, item)} className="h-8">
+                                          <Edit3 className="mr-1 h-3.5 w-3.5" /> Editar
+                                        </Button>
+                                        <Button size="sm" variant="outline" onClick={() => handleToggleItem(catalogo, item)} className="h-8">
+                                          {item.activo ? <ToggleRight className="mr-1 h-3.5 w-3.5" /> : <ToggleLeft className="mr-1 h-3.5 w-3.5" />}
+                                          {item.activo ? "Desactivar" : "Activar"}
+                                        </Button>
+                                      </div>
+                                    </div>
+                                  ))}
                                 </div>
                               </div>
 
                               <div className="mt-4 flex flex-wrap gap-2">
-                                {examples.slice(0, 6).map((item) => (
-                                  <span key={item} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-600">
-                                    {item}
-                                  </span>
+                                {examples.slice(0, 4).map((example) => (
+                                  <span key={example} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-600">{example}</span>
                                 ))}
                               </div>
 
@@ -321,8 +511,7 @@ export default function ParametrizacionPage() {
                                   </Button>
                                 ) : (
                                   <div className="flex items-center gap-2 rounded-xl bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
-                                    <CheckCircle2 className="h-4 w-4" />
-                                    Catálogo disponible para integración
+                                    <CheckCircle2 className="h-4 w-4" /> Disponible para integración
                                   </div>
                                 )}
                               </div>
@@ -339,6 +528,95 @@ export default function ParametrizacionPage() {
           <AppFooter />
         </SidebarInset>
       </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{selectedItem ? "Editar registro" : "Nuevo registro"}</DialogTitle>
+            <DialogDescription>
+              {selectedCatalog?.title}. El sistema no elimina registros físicamente; se activan o desactivan.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSave} className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="catalogo-nombre">Nombre</Label>
+                <Input id="catalogo-nombre" value={formState.nombre} onChange={(event) => setFormState((prev) => ({ ...prev, nombre: event.target.value }))} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="catalogo-codigo">Código</Label>
+                <Input id="catalogo-codigo" value={formState.codigo} onChange={(event) => setFormState((prev) => ({ ...prev, codigo: event.target.value }))} required />
+                <p className="text-xs text-gray-500">Se normaliza a minúsculas, sin espacios ni acentos.</p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="catalogo-descripcion">Descripción</Label>
+              <textarea
+                id="catalogo-descripcion"
+                value={formState.descripcion}
+                onChange={(event) => setFormState((prev) => ({ ...prev, descripcion: event.target.value }))}
+                className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="catalogo-orden">Orden</Label>
+                <Input id="catalogo-orden" type="number" min="0" value={formState.orden} onChange={(event) => setFormState((prev) => ({ ...prev, orden: event.target.value }))} />
+              </div>
+              <div className="flex items-center gap-2 rounded-xl border p-3">
+                <Checkbox checked={formState.activo} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, activo: checked === true }))} />
+                <div>
+                  <p className="text-sm font-medium">Activo</p>
+                  <p className="text-xs text-gray-500">Disponible para futuras integraciones.</p>
+                </div>
+              </div>
+            </div>
+
+            {isMedioPago && (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="flex items-center gap-2 rounded-xl border p-3">
+                  <Checkbox checked={formState.requiere_comprobante} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, requiere_comprobante: checked === true }))} />
+                  <div>
+                    <p className="text-sm font-medium">Requiere comprobante</p>
+                    <p className="text-xs text-gray-500">Útil para transferencias, Stripe o tarjetas.</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 rounded-xl border p-3">
+                  <Checkbox checked={formState.es_online} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, es_online: checked === true }))} />
+                  <div>
+                    <p className="text-sm font-medium">Es online</p>
+                    <p className="text-xs text-gray-500">Identifica medios digitales.</p>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {isTipoMantenimiento && (
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="catalogo-frecuencia">Frecuencia en días</Label>
+                  <Input id="catalogo-frecuencia" type="number" min="1" value={formState.frecuencia_dias} onChange={(event) => setFormState((prev) => ({ ...prev, frecuencia_dias: event.target.value }))} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="catalogo-alerta">Alerta anticipada en días</Label>
+                  <Input id="catalogo-alerta" type="number" min="0" value={formState.alerta_dias_anticipacion} onChange={(event) => setFormState((prev) => ({ ...prev, alerta_dias_anticipacion: event.target.value }))} />
+                </div>
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>Cancelar</Button>
+              <Button type="submit" disabled={saving} className="bg-[#02a8e1] hover:bg-[#0288b1]">
+                {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {selectedItem ? "Guardar cambios" : "Crear registro"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </SidebarProvider>
   );
 }

--- a/src/interfaces/parametrizacion.interface.ts
+++ b/src/interfaces/parametrizacion.interface.ts
@@ -38,9 +38,29 @@ export interface CatalogoParametrizableSummary {
   inactivos: number;
   items: CatalogoParametrizableItem[];
   examples: string[];
+  editable: boolean;
 }
 
 export interface ParametrizacionCatalogosResponse {
   generated_at: string;
   catalogos: CatalogoParametrizableSummary[];
+}
+
+export interface CatalogoParametrizablePayload {
+  catalogo: CatalogoParametrizableKey;
+  id?: string;
+  codigo?: string;
+  nombre?: string;
+  descripcion?: string | null;
+  activo?: boolean;
+  orden?: number;
+  requiere_comprobante?: boolean | null;
+  es_online?: boolean | null;
+  frecuencia_dias?: number | null;
+  alerta_dias_anticipacion?: number | null;
+}
+
+export interface CatalogoParametrizableMutationResponse {
+  item: CatalogoParametrizableItem;
+  message: string;
 }

--- a/src/services/parametrizacionService.ts
+++ b/src/services/parametrizacionService.ts
@@ -1,4 +1,18 @@
-import { ParametrizacionCatalogosResponse } from "@/interfaces/parametrizacion.interface";
+import {
+  CatalogoParametrizableMutationResponse,
+  CatalogoParametrizablePayload,
+  ParametrizacionCatalogosResponse,
+} from "@/interfaces/parametrizacion.interface";
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(payload?.error || "Error en operación de parametrización");
+  }
+
+  return payload as T;
+}
 
 export async function getParametrizacionCatalogos(): Promise<ParametrizacionCatalogosResponse> {
   const response = await fetch("/api/parametrizacion/catalogos", {
@@ -6,11 +20,35 @@ export async function getParametrizacionCatalogos(): Promise<ParametrizacionCata
     cache: "no-store",
   });
 
-  const payload = await response.json();
+  return parseJsonResponse<ParametrizacionCatalogosResponse>(response);
+}
 
-  if (!response.ok) {
-    throw new Error(payload?.error || "Error al obtener catálogos de parametrización");
-  }
+export async function createParametrizacionCatalogoItem(
+  payload: CatalogoParametrizablePayload
+): Promise<CatalogoParametrizableMutationResponse> {
+  const response = await fetch("/api/parametrizacion/catalogos", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
 
-  return payload as ParametrizacionCatalogosResponse;
+  return parseJsonResponse<CatalogoParametrizableMutationResponse>(response);
+}
+
+export async function updateParametrizacionCatalogoItem(
+  payload: CatalogoParametrizablePayload
+): Promise<CatalogoParametrizableMutationResponse> {
+  const response = await fetch("/api/parametrizacion/catalogos", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  return parseJsonResponse<CatalogoParametrizableMutationResponse>(response);
+}
+
+export async function toggleParametrizacionCatalogoItem(
+  payload: Pick<CatalogoParametrizablePayload, "catalogo" | "id" | "activo">
+): Promise<CatalogoParametrizableMutationResponse> {
+  return updateParametrizacionCatalogoItem(payload);
 }


### PR DESCRIPTION
# feat: add parameterizable catalogs CRUD base

## Resumen

Se implementa la base CRUD administrativa para los catálogos parametrizables de Gym Master desde la pantalla `/dashboard/parametrizacion`.

Esta feature evoluciona la fase anterior, que solo mostraba lectura y conteos reales, incorporando acciones administrativas para crear, editar, activar y desactivar registros de catálogo sin realizar hard delete.

## Cambios principales

- Se amplía la API `/api/parametrizacion/catalogos` con operaciones `GET`, `POST` y `PATCH`.
- Se agrega creación de registros para catálogos parametrizables.
- Se agrega edición de registros existentes.
- Se agrega activación/desactivación lógica mediante campo `activo`.
- Se mantiene la restricción de no eliminar físicamente registros de catálogo.
- Se actualiza la pantalla `/dashboard/parametrizacion` con acciones administrativas.
- Se agrega modal de creación/edición.
- Se actualizan conteos de total, activos e inactivos luego de las acciones.
- Se mantiene compatibilidad con los 8 catálogos foundation:
  - `tipo_empleado`
  - `medio_pago`
  - `tipo_gasto`
  - `tipo_ingreso`
  - `categoria_producto`
  - `tipo_equipamiento`
  - `ubicacion_equipamiento`
  - `tipo_mantenimiento`

## Alcance técnico

### Incluido

- CRUD base para catálogos parametrizables.
- Acciones de alta, edición y cambio de estado.
- Servicio frontend para consumir la API de parametrización.
- Interfaces TypeScript para catálogo, resumen y payloads.
- Documentación técnica de la feature.

### Fuera de alcance

- No se agregan nuevas migraciones.
- No se modifica estructura de base de datos.
- No se integran todavía estos catálogos en formularios de pagos, productos, equipamientos o empleados.
- No se implementa eliminación física.
- No se implementa todavía documentación Swagger/OpenAPI; queda planificada para la siguiente rama.

## Validación realizada

- Build de producción ejecutado correctamente con `npm run build`.
- Limpieza de artefactos PWA con `git restore public/sw.js public/workbox-*.js`.
- Validación funcional local como usuario administrador.
- Pruebas manuales en `/dashboard/parametrizacion`:
  - creación de registro de prueba;
  - edición de registro;
  - desactivación;
  - reactivación;
  - actualización de conteos.

## Notas

Esta feature deja preparada la base administrativa para que futuras ramas conecten los catálogos reales con formularios operativos del sistema.

A partir de la próxima rama se incorporará Swagger/OpenAPI como estándar para documentar cada endpoint nuevo o modificado.
