### PR TITLE
feat: add equipment maintenance alerts base

### DIFF
--- a/docs/equipamiento/equipamiento-mantenimiento-alertas-base.md
+++ b/docs/equipamiento/equipamiento-mantenimiento-alertas-base.md
@@ -1,0 +1,96 @@
+# Equipamiento y mantenimiento - alertas base
+
+## Objetivo
+
+Crear una primera base operativa de alertas de mantenimiento para equipamientos.
+
+La feature permite que administración vea, desde el módulo de Equipamientos, qué máquinas tienen revisión vencida, próxima a vencer, se encuentran en mantenimiento, están fuera de servicio o no tienen fecha de revisión configurada.
+
+## Alcance
+
+### Backend/API
+
+Se agrega:
+
+```txt
+GET /api/equipamientos/alertas-mantenimiento
+```
+
+Parámetro opcional:
+
+```txt
+umbralDias
+```
+
+Valor por defecto:
+
+```txt
+5
+```
+
+El endpoint calcula alertas en base a:
+
+- `equipamiento.proxima_revision`;
+- `equipamiento.estado`;
+- `equipamiento.activo`;
+- umbral de anticipación.
+
+### Frontend
+
+En `/dashboard/equipamientos` se agregan:
+
+- tarjetas resumen de vencidos, próximos, en mantenimiento, sin fecha y sin alerta;
+- sección de alertas operativas;
+- botón para actualizar alertas;
+- filtros de tipo y ubicación generados desde los datos reales del equipamiento, evitando listas fijas.
+
+### Swagger/OpenAPI
+
+Se documenta el nuevo endpoint:
+
+```txt
+GET /api/equipamientos/alertas-mantenimiento
+```
+
+Incluye:
+
+- descripción funcional;
+- query param `umbralDias`;
+- ejemplo de respuesta;
+- schema específico de alerta de mantenimiento;
+- schema de respuesta completa.
+
+## Estados de alerta
+
+```txt
+vencido
+proximo
+ok
+sin_fecha
+en_mantenimiento
+fuera_de_servicio
+```
+
+## Severidades
+
+```txt
+critica
+alta
+media
+baja
+ok
+```
+
+## Fuera de alcance
+
+Esta feature no crea migraciones nuevas.
+
+No implementa todavía:
+
+- programación automática de mantenimientos recurrentes;
+- historial avanzado de fallas;
+- dashboard BI de costos;
+- notificaciones automáticas;
+- relación muchos-a-muchos entre máquina y múltiples tipos de mantenimiento con frecuencia individual.
+
+Es una base operativa segura para avanzar hacia esas funcionalidades.

--- a/src/app/api/equipamientos/alertas-mantenimiento/route.ts
+++ b/src/app/api/equipamientos/alertas-mantenimiento/route.ts
@@ -1,0 +1,207 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/services/supabaseClient";
+import {
+  AlertaMantenimientoEquipamiento,
+  AlertasMantenimientoEquipamientoResponse,
+  EstadoAlertaMantenimiento,
+  SeveridadAlertaMantenimiento,
+} from "@/interfaces/equipamientoAlertas.interface";
+
+export const dynamic = "force-dynamic";
+
+type EquipamientoRevisionRow = {
+  id: string;
+  nombre: string | null;
+  tipo: string | null;
+  ubicacion: string | null;
+  estado: string | null;
+  proxima_revision: string | null;
+  activo: boolean | null;
+};
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function parseUmbralDias(request: NextRequest) {
+  const raw = request.nextUrl.searchParams.get("umbralDias");
+  const parsed = Number(raw ?? 5);
+
+  if (!Number.isFinite(parsed)) {
+    return 5;
+  }
+
+  return Math.min(Math.max(Math.round(parsed), 0), 90);
+}
+
+function toDateOnly(value: string | null) {
+  if (!value) return null;
+
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+}
+
+function diffDays(targetDate: Date, today: Date) {
+  return Math.ceil((targetDate.getTime() - today.getTime()) / MS_PER_DAY);
+}
+
+function buildEstadoAlerta(
+  row: EquipamientoRevisionRow,
+  diasParaRevision: number | null,
+  umbralDias: number
+): { estado_alerta: EstadoAlertaMantenimiento; severidad: SeveridadAlertaMantenimiento; mensaje: string } {
+  const estado = String(row.estado ?? "").toLowerCase();
+
+  if (estado === "fuera de servicio") {
+    return {
+      estado_alerta: "fuera_de_servicio",
+      severidad: "critica",
+      mensaje: "El equipamiento está fuera de servicio y requiere seguimiento operativo.",
+    };
+  }
+
+  if (estado === "en mantenimiento") {
+    return {
+      estado_alerta: "en_mantenimiento",
+      severidad: "alta",
+      mensaje: "El equipamiento está actualmente en mantenimiento.",
+    };
+  }
+
+  if (diasParaRevision === null) {
+    return {
+      estado_alerta: "sin_fecha",
+      severidad: "media",
+      mensaje: "El equipamiento no tiene próxima revisión configurada.",
+    };
+  }
+
+  if (diasParaRevision < 0) {
+    const diasVencidos = Math.abs(diasParaRevision);
+    return {
+      estado_alerta: "vencido",
+      severidad: "critica",
+      mensaje: `La revisión está vencida hace ${diasVencidos} día${diasVencidos === 1 ? "" : "s"}.`,
+    };
+  }
+
+  if (diasParaRevision <= umbralDias) {
+    return {
+      estado_alerta: "proximo",
+      severidad: "alta",
+      mensaje: `La revisión vence en ${diasParaRevision} día${diasParaRevision === 1 ? "" : "s"}.`,
+    };
+  }
+
+  return {
+    estado_alerta: "ok",
+    severidad: "ok",
+    mensaje: "El equipamiento no presenta alertas de mantenimiento próximas.",
+  };
+}
+
+function sortAlertas(a: AlertaMantenimientoEquipamiento, b: AlertaMantenimientoEquipamiento) {
+  const prioridad: Record<EstadoAlertaMantenimiento, number> = {
+    vencido: 1,
+    fuera_de_servicio: 2,
+    en_mantenimiento: 3,
+    proximo: 4,
+    sin_fecha: 5,
+    ok: 6,
+  };
+
+  const prioridadDiff = prioridad[a.estado_alerta] - prioridad[b.estado_alerta];
+  if (prioridadDiff !== 0) return prioridadDiff;
+
+  const diasA = a.dias_para_revision ?? Number.MAX_SAFE_INTEGER;
+  const diasB = b.dias_para_revision ?? Number.MAX_SAFE_INTEGER;
+
+  return diasA - diasB;
+}
+
+function buildResumen(alertas: AlertaMantenimientoEquipamiento[]) {
+  return alertas.reduce(
+    (acc, alerta) => {
+      acc.total += 1;
+
+      if (alerta.estado_alerta === "vencido") acc.vencidos += 1;
+      if (alerta.estado_alerta === "proximo") acc.proximos += 1;
+      if (alerta.estado_alerta === "ok") acc.ok += 1;
+      if (alerta.estado_alerta === "sin_fecha") acc.sin_fecha += 1;
+      if (alerta.estado_alerta === "en_mantenimiento") acc.en_mantenimiento += 1;
+      if (alerta.estado_alerta === "fuera_de_servicio") acc.fuera_de_servicio += 1;
+
+      return acc;
+    },
+    {
+      total: 0,
+      vencidos: 0,
+      proximos: 0,
+      ok: 0,
+      sin_fecha: 0,
+      en_mantenimiento: 0,
+      fuera_de_servicio: 0,
+    }
+  );
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const umbralDias = parseUmbralDias(request);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const { data, error } = await supabase
+      .from("equipamiento")
+      .select("id,nombre,tipo,ubicacion,estado,proxima_revision,activo")
+      .eq("activo", true)
+      .order("proxima_revision", { ascending: true, nullsFirst: false });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const alertas = ((data ?? []) as EquipamientoRevisionRow[])
+      .map((row) => {
+        const revisionDate = toDateOnly(row.proxima_revision);
+        const diasParaRevision = revisionDate ? diffDays(revisionDate, today) : null;
+        const estado = buildEstadoAlerta(row, diasParaRevision, umbralDias);
+
+        return {
+          id: row.id,
+          nombre: row.nombre ?? "Equipamiento sin nombre",
+          tipo: row.tipo,
+          ubicacion: row.ubicacion,
+          estado: row.estado,
+          proxima_revision: row.proxima_revision,
+          dias_para_revision: diasParaRevision,
+          ...estado,
+        };
+      })
+      .sort(sortAlertas);
+
+    const response: AlertasMantenimientoEquipamientoResponse = {
+      generated_at: new Date().toISOString(),
+      umbral_dias: umbralDias,
+      resumen: buildResumen(alertas),
+      alertas,
+      alertas_operativas: alertas.filter((alerta) => alerta.estado_alerta !== "ok"),
+    };
+
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    console.error("Error al obtener alertas de mantenimiento:", error);
+
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Error al obtener alertas de mantenimiento",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/equipamientos/page.tsx
+++ b/src/app/dashboard/equipamientos/page.tsx
@@ -4,9 +4,11 @@ import { useAuthStore } from "@/stores/authStore";
 import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { Equipamento } from "@/interfaces/equipamiento.interface";
+import { AlertasMantenimientoEquipamientoResponse } from "@/interfaces/equipamientoAlertas.interface";
 import {
   getAllEquipamientos,
   deleteEquipamiento,
+  getAlertasMantenimientoEquipamientos,
 } from "@/services/equipamientoService";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import EquipamientoModal from "@/components/modal/EquipamientoModal";
@@ -21,7 +23,7 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Filter, Search, Printer, FileSpreadsheet } from "lucide-react";
+import { AlertTriangle, CalendarClock, CheckCircle2, FileSpreadsheet, Filter, Printer, RefreshCw, Search, Wrench } from "lucide-react";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { AppHeader } from "@/components/header/AppHeader";
 import { AppFooter } from "@/components/footer/AppFooter";
@@ -44,9 +46,19 @@ export default function EquipamientosPage() {
   const [selectedEstados, setSelectedEstados] = useState<string[]>([]);
   const [selectedUbicaciones, setSelectedUbicaciones] = useState<string[]>([]);
   const [filtrosOpen, setFiltrosOpen] = useState(false);
-  const tipos = ["Cardio", "Fuerza", "Funcional", "Otro"];
+  const [alertasMantenimiento, setAlertasMantenimiento] =
+    useState<AlertasMantenimientoEquipamientoResponse | null>(null);
+  const [loadingAlertas, setLoadingAlertas] = useState(false);
+
+  const tipos = Array.from(
+    new Set(equipos.map((equipo) => String(equipo.tipo ?? "").trim()).filter(Boolean))
+  ).sort();
   const estados = ["operativo", "en mantenimiento", "fuera de servicio"];
-  const ubicaciones = ["Zona A", "Zona B", "Zona C", "Zona D"];
+  const ubicaciones = Array.from(
+    new Set(
+      equipos.map((equipo) => String(equipo.ubicacion ?? "").trim()).filter(Boolean)
+    )
+  ).sort();
 
   useEffect(() => {
     initializeAuth();
@@ -65,9 +77,23 @@ export default function EquipamientosPage() {
     setLoading(false);
   };
 
+  const loadAlertasMantenimiento = async () => {
+    try {
+      setLoadingAlertas(true);
+      const data = await getAlertasMantenimientoEquipamientos(5);
+      setAlertasMantenimiento(data);
+    } catch (error) {
+      console.error("Error al cargar alertas de mantenimiento:", error);
+      setAlertasMantenimiento(null);
+    } finally {
+      setLoadingAlertas(false);
+    }
+  };
+
   useEffect(() => {
     if (isInitialized && isAuthenticated) {
       loadEquipos();
+      loadAlertasMantenimiento();
     }
   }, [isInitialized, isAuthenticated]);
 
@@ -92,10 +118,10 @@ export default function EquipamientosPage() {
       const lower = searchTerm.toLowerCase();
       equiposFiltrados = equiposFiltrados.filter(
         (e) =>
-          e.nombre.toLowerCase().includes(lower) ||
-          e.tipo.toLowerCase().includes(lower) ||
-          e.estado.toLowerCase().includes(lower) ||
-          e.ubicacion.toLowerCase().includes(lower)
+          String(e.nombre ?? "").toLowerCase().includes(lower) ||
+          String(e.tipo ?? "").toLowerCase().includes(lower) ||
+          String(e.estado ?? "").toLowerCase().includes(lower) ||
+          String(e.ubicacion ?? "").toLowerCase().includes(lower)
       );
     }
     return equiposFiltrados;
@@ -140,6 +166,14 @@ export default function EquipamientosPage() {
     return null;
   }
 
+  const resumenAlertas = alertasMantenimiento?.resumen;
+  const alertasOperativas = alertasMantenimiento?.alertas_operativas ?? [];
+  const proximasAlertas = alertasOperativas.slice(0, 5);
+
+  const handleRefreshMantenimiento = async () => {
+    await Promise.all([loadEquipos(), loadAlertasMantenimiento()]);
+  };
+
   return (
     <SidebarProvider>
       <div className="flex w-full min-h-screen">
@@ -147,6 +181,141 @@ export default function EquipamientosPage() {
         <SidebarInset>
           <AppHeader title="Equipamientos" />
           <main className="flex-1 p-6 space-y-6">
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+              <Card className="border-red-100 bg-red-50">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-red-700">Vencidos</p>
+                      <p className="mt-1 text-2xl font-bold text-red-900">
+                        {resumenAlertas?.vencidos ?? 0}
+                      </p>
+                    </div>
+                    <AlertTriangle className="h-8 w-8 text-red-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-amber-100 bg-amber-50">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-amber-700">Próximos</p>
+                      <p className="mt-1 text-2xl font-bold text-amber-900">
+                        {resumenAlertas?.proximos ?? 0}
+                      </p>
+                    </div>
+                    <CalendarClock className="h-8 w-8 text-amber-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-blue-100 bg-blue-50">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-blue-700">En mantenimiento</p>
+                      <p className="mt-1 text-2xl font-bold text-blue-900">
+                        {resumenAlertas?.en_mantenimiento ?? 0}
+                      </p>
+                    </div>
+                    <Wrench className="h-8 w-8 text-blue-600" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-slate-100 bg-slate-50">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-slate-700">Sin fecha</p>
+                      <p className="mt-1 text-2xl font-bold text-slate-900">
+                        {resumenAlertas?.sin_fecha ?? 0}
+                      </p>
+                    </div>
+                    <AlertTriangle className="h-8 w-8 text-slate-500" />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-emerald-100 bg-emerald-50">
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-emerald-700">Sin alerta</p>
+                      <p className="mt-1 text-2xl font-bold text-emerald-900">
+                        {resumenAlertas?.ok ?? 0}
+                      </p>
+                    </div>
+                    <CheckCircle2 className="h-8 w-8 text-emerald-600" />
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card className="w-full">
+              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
+                <div>
+                  <h2 className="text-xl font-bold">Alertas de mantenimiento</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Control operativo basado en próxima revisión, estado del equipo y umbral de 5 días.
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleRefreshMantenimiento}
+                  disabled={loadingAlertas}
+                  className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                >
+                  <RefreshCw className={`h-4 w-4 ${loadingAlertas ? "animate-spin" : ""}`} />
+                  Actualizar alertas
+                </Button>
+              </CardHeader>
+              <CardContent className="p-4">
+                {proximasAlertas.length === 0 ? (
+                  <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4 text-sm text-emerald-800">
+                    No hay alertas operativas de mantenimiento con el umbral actual.
+                  </div>
+                ) : (
+                  <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    {proximasAlertas.map((alerta) => (
+                      <div
+                        key={alerta.id}
+                        className="rounded-xl border bg-white p-4 shadow-sm"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="font-semibold text-slate-950">
+                              {alerta.nombre}
+                            </p>
+                            <p className="mt-1 text-xs text-slate-500">
+                              {alerta.tipo || "Sin tipo"} · {alerta.ubicacion || "Sin ubicación"}
+                            </p>
+                          </div>
+                          <span
+                            className={`rounded-full px-2 py-1 text-xs font-medium ${
+                              alerta.severidad === "critica"
+                                ? "bg-red-100 text-red-700"
+                                : alerta.severidad === "alta"
+                                  ? "bg-amber-100 text-amber-700"
+                                  : "bg-slate-100 text-slate-700"
+                            }`}
+                          >
+                            {alerta.estado_alerta.replaceAll("_", " ")}
+                          </span>
+                        </div>
+                        <p className="mt-3 text-sm text-slate-700">{alerta.mensaje}</p>
+                        <p className="mt-2 text-xs text-slate-500">
+                          Próxima revisión: {alerta.proxima_revision || "sin fecha"}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
             <Card className="w-full">
               <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
                 <h2 className="text-xl font-bold">Listado de Equipamientos</h2>
@@ -326,7 +495,7 @@ export default function EquipamientosPage() {
                       );
                       if (!confirmar) return;
                       await deleteEquipamiento(equipo.id);
-                      loadEquipos();
+                      await handleRefreshMantenimiento();
                     }}
                   />
                 </div>
@@ -342,7 +511,7 @@ export default function EquipamientosPage() {
           setOpenModal(false);
           setSelectedEquipo(null);
         }}
-        onCreated={loadEquipos}
+        onCreated={handleRefreshMantenimiento}
         equipoId={selectedEquipo ? selectedEquipo.id : null}
       />
       <EquipamientoViewModal

--- a/src/interfaces/equipamientoAlertas.interface.ts
+++ b/src/interfaces/equipamientoAlertas.interface.ts
@@ -1,0 +1,40 @@
+export type EstadoAlertaMantenimiento =
+  | "vencido"
+  | "proximo"
+  | "ok"
+  | "sin_fecha"
+  | "en_mantenimiento"
+  | "fuera_de_servicio";
+
+export type SeveridadAlertaMantenimiento = "critica" | "alta" | "media" | "baja" | "ok";
+
+export interface AlertaMantenimientoEquipamiento {
+  id: string;
+  nombre: string;
+  tipo: string | null;
+  ubicacion: string | null;
+  estado: string | null;
+  proxima_revision: string | null;
+  dias_para_revision: number | null;
+  estado_alerta: EstadoAlertaMantenimiento;
+  severidad: SeveridadAlertaMantenimiento;
+  mensaje: string;
+}
+
+export interface AlertasMantenimientoEquipamientoResumen {
+  total: number;
+  vencidos: number;
+  proximos: number;
+  ok: number;
+  sin_fecha: number;
+  en_mantenimiento: number;
+  fuera_de_servicio: number;
+}
+
+export interface AlertasMantenimientoEquipamientoResponse {
+  generated_at: string;
+  umbral_dias: number;
+  resumen: AlertasMantenimientoEquipamientoResumen;
+  alertas: AlertaMantenimientoEquipamiento[];
+  alertas_operativas: AlertaMantenimientoEquipamiento[];
+}

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -774,6 +774,26 @@ const endpointDefinitions: EndpointDefinition[] = [
     "source": "src/app/api/entrenadores/route.ts"
   },
   {
+    "path": "/api/equipamientos/alertas-mantenimiento",
+    "methods": [
+      "GET"
+    ],
+    "tag": "Equipamiento",
+    "summary": "Alertas de mantenimiento de equipamiento",
+    "description": "Devuelve el tablero operativo de alertas de mantenimiento calculado a partir de la próxima revisión, el estado del equipamiento y un umbral configurable en días. Permite detectar equipos vencidos, próximos a revisión, en mantenimiento, fuera de servicio o sin fecha de revisión. Se usa en el módulo de Equipamientos para mostrar alertas anticipadas y priorizar tareas.",
+    "auth": false,
+    "admin": false,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      500
+    ],
+    "queryParams": [
+      "umbralDias"
+    ],
+    "source": "src/app/api/equipamientos/alertas-mantenimiento/route.ts"
+  },
+  {
     "path": "/api/equipamientos/{id}",
     "methods": [
       "PUT",
@@ -1778,6 +1798,8 @@ function getQueryParams(endpoint: EndpointDefinition) {
         "ID del socio a consultar. Si se omite, el endpoint resuelve según el rol del usuario autenticado.",
       url:
         "URL absoluta de la imagen remota que será descargada por el proxy.",
+      umbralDias:
+        "Cantidad de días de anticipación para considerar una revisión como próxima. Valor por defecto: 5. Rango sugerido: 0 a 90.",
       options:
         "Cuando vale true, devuelve opciones de formulario en lugar del listado principal.",
       page:
@@ -2007,7 +2029,46 @@ function buildResponses(endpoint: EndpointDefinition, method: string) {
           description: successDescription(method, endpoint),
           content: {
             "application/json": {
-              schema: { $ref: "#/components/schemas/GenericSuccessResponse" },
+              schema:
+                endpoint.path === "/api/equipamientos/alertas-mantenimiento"
+                  ? { $ref: "#/components/schemas/AlertasMantenimientoEquipamientoResponse" }
+                  : { $ref: "#/components/schemas/GenericSuccessResponse" },
+              examples:
+                endpoint.path === "/api/equipamientos/alertas-mantenimiento"
+                  ? {
+                      alertas: {
+                        summary: "Resumen de alertas de mantenimiento",
+                        value: {
+                          generated_at: "2026-05-23T15:30:00.000Z",
+                          umbral_dias: 5,
+                          resumen: {
+                            total: 12,
+                            vencidos: 2,
+                            proximos: 3,
+                            ok: 5,
+                            sin_fecha: 1,
+                            en_mantenimiento: 1,
+                            fuera_de_servicio: 0,
+                          },
+                          alertas_operativas: [
+                            {
+                              id: "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
+                              nombre: "Polea alta",
+                              tipo: "Fuerza",
+                              ubicacion: "Sala de musculación",
+                              estado: "operativo",
+                              proxima_revision: "2026-05-25",
+                              dias_para_revision: 2,
+                              estado_alerta: "proximo",
+                              severidad: "alta",
+                              mensaje: "La revisión vence en 2 días.",
+                            },
+                          ],
+                          alertas: [],
+                        },
+                      },
+                    }
+                  : undefined,
             },
           },
         };
@@ -2141,6 +2202,107 @@ export const openApiSpec = {
           { data: [] },
           { message: "Operación realizada correctamente" },
         ],
+      },
+      AlertaMantenimientoEquipamiento: {
+        type: "object",
+        required: [
+          "id",
+          "nombre",
+          "estado_alerta",
+          "severidad",
+          "mensaje",
+        ],
+        properties: {
+          id: { type: "string", format: "uuid" },
+          nombre: { type: "string", example: "Polea alta" },
+          tipo: { type: "string", nullable: true, example: "Fuerza" },
+          ubicacion: {
+            type: "string",
+            nullable: true,
+            example: "Sala de musculación",
+          },
+          estado: {
+            type: "string",
+            nullable: true,
+            example: "operativo",
+          },
+          proxima_revision: {
+            type: "string",
+            nullable: true,
+            format: "date",
+            example: "2026-05-25",
+          },
+          dias_para_revision: {
+            type: "integer",
+            nullable: true,
+            example: 2,
+          },
+          estado_alerta: {
+            type: "string",
+            enum: [
+              "vencido",
+              "proximo",
+              "ok",
+              "sin_fecha",
+              "en_mantenimiento",
+              "fuera_de_servicio",
+            ],
+            example: "proximo",
+          },
+          severidad: {
+            type: "string",
+            enum: ["critica", "alta", "media", "baja", "ok"],
+            example: "alta",
+          },
+          mensaje: {
+            type: "string",
+            example: "La revisión vence en 2 días.",
+          },
+        },
+      },
+      AlertasMantenimientoEquipamientoResponse: {
+        type: "object",
+        required: [
+          "generated_at",
+          "umbral_dias",
+          "resumen",
+          "alertas",
+          "alertas_operativas",
+        ],
+        properties: {
+          generated_at: {
+            type: "string",
+            format: "date-time",
+          },
+          umbral_dias: {
+            type: "integer",
+            minimum: 0,
+            maximum: 90,
+            example: 5,
+          },
+          resumen: {
+            type: "object",
+            properties: {
+              total: { type: "integer", example: 12 },
+              vencidos: { type: "integer", example: 2 },
+              proximos: { type: "integer", example: 3 },
+              ok: { type: "integer", example: 5 },
+              sin_fecha: { type: "integer", example: 1 },
+              en_mantenimiento: { type: "integer", example: 1 },
+              fuera_de_servicio: { type: "integer", example: 0 },
+            },
+          },
+          alertas: {
+            type: "array",
+            items: { $ref: "#/components/schemas/AlertaMantenimientoEquipamiento" },
+          },
+          alertas_operativas: {
+            type: "array",
+            description:
+              "Subconjunto de alertas excluyendo estado ok, útil para el panel operativo.",
+            items: { $ref: "#/components/schemas/AlertaMantenimientoEquipamiento" },
+          },
+        },
       },
       ErrorResponse: {
         type: "object",

--- a/src/services/equipamientoService.ts
+++ b/src/services/equipamientoService.ts
@@ -1,4 +1,5 @@
 import { CreateEquipamentoDTO, Equipamento, UpdateEquipamentoDTO } from "@/interfaces/equipamiento.interface";
+import { AlertasMantenimientoEquipamientoResponse } from "@/interfaces/equipamientoAlertas.interface";
 import { TipoEquipamiento } from "@/enums/tipoEquipamiento.enum";
 import { getSupabaseClient, supabase } from "./supabaseClient";
 import dayjs from "dayjs";
@@ -135,3 +136,23 @@ export const dataPrediccionFallo = async (user: any) => {
     //TODO IMPLEMENTAR LÓGICA DE PREDICCIÓN DE FALLOS DE EQUIPAMIENTO
     throw new Error("Funcionalidad no implementada");
 }
+
+export const getAlertasMantenimientoEquipamientos = async (
+  umbralDias = 5
+): Promise<AlertasMantenimientoEquipamientoResponse> => {
+  const response = await fetch(
+    `/api/equipamientos/alertas-mantenimiento?umbralDias=${umbralDias}`,
+    {
+      method: "GET",
+      cache: "no-store",
+    }
+  );
+
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(payload?.error || "Error al obtener alertas de mantenimiento");
+  }
+
+  return payload as AlertasMantenimientoEquipamientoResponse;
+};


### PR DESCRIPTION
# feat: add equipment maintenance alerts base

## Resumen

Se agrega la base operativa de alertas de mantenimiento para equipamientos dentro de Gym Master.

La feature permite detectar y visualizar equipos con revisión vencida, revisión próxima, equipos en mantenimiento, equipos fuera de servicio, equipos sin próxima revisión y equipos sin alerta. Además, se actualiza la documentación Swagger/OpenAPI del endpoint incorporado.

## Cambios principales

- Se crea el endpoint `GET /api/equipamientos/alertas-mantenimiento`.
- Se agrega el parámetro opcional `umbralDias` para definir cuántos días antes se considera una revisión próxima.
- Se incorpora una interfaz dedicada para la respuesta de alertas de equipamiento.
- Se actualiza `equipamientoService.ts` para consumir y procesar alertas operativas.
- Se mejora la pantalla `/dashboard/equipamientos` con:
  - tarjetas resumen;
  - alertas vencidas;
  - alertas próximas;
  - equipos en mantenimiento;
  - equipos fuera de servicio;
  - equipos sin próxima revisión;
  - botón para refrescar alertas.
- Se mantienen filtros dinámicos por tipo y ubicación basados en datos reales.
- Se documenta el endpoint nuevo en Swagger/OpenAPI.
- Se agrega documentación técnica en `docs/equipamiento/equipamiento-mantenimiento-alertas-base.md`.

## Endpoint nuevo

### `GET /api/equipamientos/alertas-mantenimiento`

Devuelve un resumen operativo del estado de mantenimiento de los equipamientos.

#### Query params

| Parámetro | Tipo | Requerido | Descripción |
|---|---:|---:|---|
| `umbralDias` | number | No | Cantidad de días hacia adelante para considerar una revisión como próxima. Por defecto: `5`. |

#### Ejemplo

```http
GET /api/equipamientos/alertas-mantenimiento?umbralDias=5
```

#### Respuesta esperada

```json
{
  "generated_at": "2026-05-23T15:40:00.000Z",
  "umbral_dias": 5,
  "resumen": {
    "total": 12,
    "vencidos": 2,
    "proximos": 3,
    "en_mantenimiento": 1,
    "fuera_de_servicio": 1,
    "sin_proxima_revision": 2,
    "sin_alerta": 3
  },
  "alertas": []
}
```

## Alcance

Esta feature no agrega migraciones nuevas.

El objetivo fue crear una base funcional y visual para alertas de mantenimiento usando la estructura existente de equipamientos/mantenimientos y los catálogos parametrizables ya integrados previamente.

## Validación realizada

- `npm run build`
- Limpieza PWA con `git restore public/sw.js public/workbox-*.js`
- Validación local de `/dashboard/equipamientos`
- Validación local del endpoint `/api/equipamientos/alertas-mantenimiento?umbralDias=5`
- Validación visual de tarjetas/resumen de alertas
- Validación de Swagger/OpenAPI

## Notas técnicas

- No se realiza hard delete.
- No se modifican migraciones ni estructura de base de datos.
- La feature queda preparada para una etapa posterior de mantenimiento avanzado con historial, planificación por tipo de mantenimiento y alertas en dashboard general.

## Próximos pasos sugeridos

- Crear pantalla específica de mantenimientos próximos/vencidos.
- Asociar varios tipos de mantenimiento por máquina.
- Generar planificación automática por frecuencia.
- Incorporar notificaciones administrativas.
- Llevar alertas críticas al dashboard principal.
