### PR TITLE
fix: adjust attendance QR camera preview and timezone

### DIFF
--- a/docs/asistencias/asistencia-qr-camera-timezone-fix.md
+++ b/docs/asistencias/asistencia-qr-camera-timezone-fix.md
@@ -1,0 +1,48 @@
+# Fix - Asistencia QR: cámara móvil y hora local
+
+## Objetivo
+
+Corregir dos observaciones detectadas durante la prueba deployada en Vercel:
+
+1. Las asistencias se registraban con diferencia de +3 horas por usar hora del servidor/UTC.
+2. En móvil, el lector QR detectaba el código, pero la previsualización de cámara quedaba como cuadro gris.
+
+## Cambios
+
+### Hora local Argentina
+
+Se actualiza `src/services/asistenciaService.ts` para registrar fecha y hora usando la zona horaria:
+
+```txt
+America/Argentina/Buenos_Aires
+```
+
+Esto impacta en:
+
+- fecha del QR diario;
+- validación de fecha del QR;
+- `hora_ingreso` al crear asistencia;
+- expiración diaria del QR en horario local Argentina.
+
+### Preview del lector QR
+
+Se ajusta `src/components/ui/RegistrarAsistenciaQR.tsx` para:
+
+- forzar estilos sobre los elementos internos `section`, `video` y `canvas` del lector;
+- usar `facingMode: { ideal: 'environment' }`;
+- remount del lector al presionar **Reintentar**;
+- separar mensajes de cámara de errores funcionales de asistencia.
+
+## Alcance
+
+No se cambia la librería `react-qr-reader` en esta rama porque el escaneo ya funciona.  
+Si el preview sigue gris en algunos navegadores Android/Chrome, el próximo paso recomendado es una rama específica para reemplazar o encapsular el lector QR con una implementación basada en `getUserMedia` + detector QR.
+
+## Validación sugerida
+
+1. Deploy en Vercel.
+2. Abrir dashboard admin y QR del día.
+3. Escanear desde celular.
+4. Confirmar que la asistencia se registra.
+5. Confirmar que la hora nueva coincide con hora Argentina.
+6. Confirmar si la previsualización de cámara ya se muestra o si continúa gris.

--- a/src/components/ui/RegistrarAsistenciaQR.tsx
+++ b/src/components/ui/RegistrarAsistenciaQR.tsx
@@ -39,6 +39,8 @@ export function RegistrarAsistenciaQR() {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [cameraKey, setCameraKey] = useState(0);
+  const [cameraHint, setCameraHint] = useState('');
   const lastScanRef = useRef<{ value: string; at: number } | null>(null);
 
   const [showWelcome, setShowWelcome] = useState(false);
@@ -64,6 +66,7 @@ export function RegistrarAsistenciaQR() {
     setLoading(true);
     setError('');
     setMessage('');
+    setCameraHint('');
 
     const res = await registrarAsistenciaQR(data);
 
@@ -132,9 +135,10 @@ export function RegistrarAsistenciaQR() {
         <CardTitle>Escanear QR para registrar asistencia</CardTitle>
       </CardHeader>
       <CardContent className='flex flex-col items-center gap-6'>
-        <div className='flex items-center justify-center w-full max-w-xs overflow-hidden bg-gray-100 border rounded-lg aspect-square'>
+        <div className='flex items-center justify-center w-full max-w-xs overflow-hidden bg-gray-100 border rounded-lg aspect-square [&_section]:!static [&_section]:!h-full [&_section]:!w-full [&_section]:!p-0 [&_video]:!static [&_video]:!h-full [&_video]:!w-full [&_video]:!object-cover [&_video]:!opacity-100 [&_canvas]:!hidden'>
           <QrReader
-            constraints={{ facingMode: 'environment' }}
+            key={cameraKey}
+            constraints={{ facingMode: { ideal: 'environment' } }}
             onResult={(result, scanError) => {
               if (result && typeof result.getText === 'function') {
                 const text = result.getText();
@@ -142,25 +146,32 @@ export function RegistrarAsistenciaQR() {
               }
 
               const cameraError = scanError as { name?: string; message?: string } | null;
+
               if (cameraError?.name === 'NotAllowedError') {
-                setError('No se pudo acceder a la cámara. Revisá los permisos del navegador.');
+                setCameraHint('No se pudo acceder a la cámara. Revisá los permisos del navegador.');
               }
 
               if (cameraError?.name === 'NotFoundError') {
-                setError('No se encontró una cámara disponible para escanear.');
+                setCameraHint('No se encontró una cámara disponible para escanear.');
               }
 
               if (cameraError?.name === 'NotReadableError') {
-                setError('La cámara está ocupada por otra aplicación o el navegador no pudo iniciarla.');
+                setCameraHint('La cámara está ocupada por otra aplicación o el navegador no pudo iniciarla.');
               }
             }}
           />
         </div>
 
         <p className='max-w-sm text-xs text-center text-muted-foreground'>
-          Si ves un cuadro gris, revisá permisos de cámara, que el sitio esté en
-          HTTPS o localhost, y que ninguna otra aplicación esté usando la cámara.
+          Si ves un cuadro gris pero el QR se detecta, el permiso está activo y el problema
+          puede ser solo de previsualización del lector. Reintentá o actualizá la página.
         </p>
+
+        {cameraHint && (
+          <div className='max-w-sm text-sm font-medium text-center text-amber-700'>
+            {cameraHint}
+          </div>
+        )}
 
         {loading && <div className='text-blue-600'>Registrando...</div>}
         {message && (
@@ -178,6 +189,8 @@ export function RegistrarAsistenciaQR() {
             setError('');
             setMessage('');
             setShowWelcome(false);
+            setCameraHint('');
+            setCameraKey((value) => value + 1);
             lastScanRef.current = null;
           }}
         >

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -476,7 +476,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     ],
     "tag": "Asistencias",
     "summary": "Registro de asistencia por QR",
-    "description": "Valida el token del QR diario y registra la asistencia del socio autenticado. Mantiene el caso normal con bienvenida, informa deuda con alerta roja si la cuota está vencida o sin pagos, y bloquea el ingreso con alerta amarillo/naranja si el socio está desactivado.",
+    "description": "Valida el token del QR diario y registra la asistencia del socio autenticado usando fecha y hora local de Argentina. Mantiene el caso normal con bienvenida, informa deuda con alerta roja si la cuota está vencida o sin pagos, y bloquea el ingreso con alerta amarillo/naranja si el socio está desactivado.",
     "auth": true,
     "admin": false,
     "notImplemented": false,

--- a/src/services/asistenciaService.ts
+++ b/src/services/asistenciaService.ts
@@ -11,6 +11,54 @@ import { JwtUser } from '@/interfaces/jwtUser.interface';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 import { getSocioByIdUsuario } from './socioService';
 
+const ARGENTINA_TIME_ZONE = 'America/Argentina/Buenos_Aires';
+
+function getArgentinaDateTimeParts(date = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: ARGENTINA_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const values = Object.fromEntries(
+    parts
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, part.value])
+  ) as Record<string, string>;
+
+  const hour = values.hour === '24' ? '00' : values.hour;
+
+  return {
+    year: Number(values.year),
+    month: Number(values.month),
+    day: Number(values.day),
+    fecha: `${values.year}-${values.month}-${values.day}`,
+    hora: `${hour}:${values.minute}:${values.second}`,
+  };
+}
+
+function getArgentinaEndOfDayUnix(date = new Date()) {
+  const argentinaNow = getArgentinaDateTimeParts(date);
+
+  // Argentina opera en UTC-03. El final del día local 23:59:59
+  // equivale a 02:59:59 UTC del día siguiente.
+  return Math.floor(
+    Date.UTC(
+      argentinaNow.year,
+      argentinaNow.month - 1,
+      argentinaNow.day + 1,
+      2,
+      59,
+      59
+    ) / 1000
+  );
+}
+
 export const getAllAsistencias = async (
   user: JwtUser
 ): Promise<Asistencia[]> => {
@@ -83,8 +131,9 @@ export const deleteAsistencia = async (
 };
 
 export const createQRDiario = async () => {
-  const hoy = dayjs().format('YYYY-MM-DD');
-  const expiracion = dayjs().endOf('day').unix();
+  const hoyArgentina = getArgentinaDateTimeParts();
+  const hoy = hoyArgentina.fecha;
+  const expiracion = getArgentinaEndOfDayUnix();
 
   //guardo la fecha de hoy
   const payload = { fecha: hoy };
@@ -189,7 +238,7 @@ export const registrarAsistenciaDesdeQR = async (
   const fechaAsistencia = payload.fecha;
 
   //VERIFICO QUE LA FECHA DEL TOKEN SEA LA DE HOY
-  const hoy = dayjs().format('YYYY-MM-DD');
+  const hoy = getArgentinaDateTimeParts().fecha;
   if (fechaAsistencia !== hoy) {
     return {
       valido: false,
@@ -273,7 +322,7 @@ export const registrarAsistenciaDesdeQR = async (
     .insert({
       socio_id: socio.id_socio,
       fecha: hoy,
-      hora_ingreso: dayjs().format('HH:mm:ss'),
+      hora_ingreso: getArgentinaDateTimeParts().hora,
     })
     .select(
       `


### PR DESCRIPTION
# fix: adjust attendance QR camera preview and timezone

## Resumen

Este fix ajusta dos problemas detectados durante la prueba deployada en Vercel del flujo de asistencia por QR:

1. La hora de asistencia se mostraba con diferencia de +3 horas.
2. En móvil, el lector QR mostraba un cuadro gris aunque el escaneo funcionaba correctamente.

El objetivo es corregir el manejo horario y mejorar el render del lector QR en celular, manteniendo intacto el flujo que ya funciona.

## Cambios principales

- Se ajusta el manejo de fecha/hora en el registro de asistencia.
- Se corrige la visualización horaria para evitar desfase UTC vs hora local Argentina.
- Se mejora el comportamiento del lector QR en móvil.
- Se agregan ajustes visuales/estilos para intentar evitar el cuadro gris del preview.
- El botón “Reintentar” reinicializa el lector QR.
- Se mantiene la detección del QR que ya funcionaba correctamente.
- Se conserva el flujo de control de acceso:
  - socio al día: acceso permitido;
  - socio con deuda: alerta roja;
  - socio sin pagos activos: alerta roja;
  - socio válido: splash de bienvenida.
- Se actualiza Swagger/OpenAPI.
- Se agrega documentación técnica del fix.

## Archivos principales modificados

- `src/components/ui/RegistrarAsistenciaQR.tsx`
- `src/services/asistenciaService.ts`
- `src/lib/swagger/openApiSpec.ts`
- `docs/asistencias/asistencia-qr-camera-timezone-fix.md`

## Validación realizada

- La rama anterior fue probada en deploy de Vercel desde celular.
- El QR escaneaba correctamente.
- Los carteles según estado del socio funcionaban:
  - acceso permitido;
  - cuota pendiente;
  - sin pagos activos.
- Se confirmó que el problema de cámara no era de permisos, porque Chrome tenía la cámara habilitada y el QR era detectado.

## Validación requerida post-merge/deploy

Luego del merge y deploy en Vercel, probar nuevamente desde celular:

1. Abrir el dashboard admin con QR del día.
2. Iniciar sesión como socio desde celular.
3. Escanear el QR.
4. Confirmar que la asistencia siga registrándose.
5. Confirmar que la hora se muestre correctamente.
6. Verificar si el preview de cámara deja de verse gris.
7. Probar socio al día y socio con deuda/sin pagos.

## Observaciones

Si el preview de cámara continúa gris pero el QR sigue escaneando, el siguiente paso recomendado será una rama específica para reemplazar o encapsular mejor la librería de lectura QR.

## Fuera de alcance

- No se implementa todavía desactivación automática por 7 días de mora.
- No se modifica todavía el login de socio desactivado.
- No se implementa biometría ni reconocimiento facial.
- No se cambia la regla completa de morosidad.