### PR TITLE
feat: add password visibility toggle on login

### DIFF
--- a/docs/ux/login-password-visibility-toggle.md
+++ b/docs/ux/login-password-visibility-toggle.md
@@ -1,0 +1,33 @@
+# Login - Password visibility toggle
+
+## Objetivo
+
+Mejorar la experiencia de usuario del login principal agregando un botón con ícono de ojo para mostrar u ocultar la contraseña ingresada.
+
+## Alcance
+
+Archivo modificado:
+
+```txt
+src/app/auth/login/page.tsx
+```
+
+## Cambios
+
+- Se agrega estado local `showPassword`.
+- El input de contraseña alterna entre:
+  - `type="password"`
+  - `type="text"`
+- Se agregan íconos `Eye` y `EyeOff` desde `lucide-react`.
+- El botón mantiene accesibilidad mediante:
+  - `aria-label`
+  - `title`
+  - `type="button"` para evitar submit accidental.
+- Se agrega `autoComplete="current-password"`.
+
+## Fuera de alcance
+
+- No se modifican endpoints.
+- No se modifica autenticación.
+- No se modifica Swagger/OpenAPI porque no hay cambios de API.
+- No se agregan migraciones.

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -4,7 +4,7 @@ import { useState, FormEvent, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { useAuthStore } from '@/stores/authStore';
-import { Sun, Moon, Check, ChevronsUpDown } from 'lucide-react';
+import { Sun, Moon, Check, ChevronsUpDown, Eye, EyeOff } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -95,6 +95,7 @@ export default function LoginPage() {
     ''
   );
   const [userTypeOpen, setUserTypeOpen] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const { dark, toggle } = useDarkMode();
 
   useEffect(() => {
@@ -208,14 +209,34 @@ export default function LoginPage() {
 
               <div className='grid gap-2'>
                 <Label htmlFor='password'>Contraseña</Label>
-                <Input
-                  id='password'
-                  type='password'
-                  placeholder='••••••••'
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                />
+                <div className='relative'>
+                  <Input
+                    id='password'
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder='••••••••'
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className='pr-12'
+                    autoComplete='current-password'
+                    required
+                  />
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='icon'
+                    className='absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground'
+                    onClick={() => setShowPassword((value) => !value)}
+                    aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                    title={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                    tabIndex={0}
+                  >
+                    {showPassword ? (
+                      <EyeOff className='h-4 w-4' aria-hidden='true' />
+                    ) : (
+                      <Eye className='h-4 w-4' aria-hidden='true' />
+                    )}
+                  </Button>
+                </div>
               </div>
 
               <div className='grid gap-2'>


### PR DESCRIPTION
# feat: add password visibility toggle on login

## Resumen

Esta feature mejora la experiencia de usuario del login de Gym Master agregando un botón con ícono de ojo en el campo de contraseña.

El usuario puede alternar entre contraseña oculta y visible para verificar lo que escribió antes de iniciar sesión, evitando errores comunes cuando solo se visualizan puntos.

## Cambios principales

- Se agrega estado local para controlar si la contraseña se muestra u oculta.
- Se agrega botón dentro del input de contraseña.
- Se utilizan íconos `Eye` y `EyeOff` de `lucide-react`.
- El input alterna entre `type="password"` y `type="text"`.
- Se mantiene accesibilidad mediante `aria-label` y `title`.
- Se conserva el flujo actual de autenticación sin modificar lógica de login.
- Se agrega documentación técnica de la mejora.

## Archivos modificados

- `src/app/auth/login/page.tsx`
- `docs/ux/login-password-visibility-toggle.md`

## Validación realizada

- Se probó visualmente el login.
- Se verificó que el botón de ojo permite mostrar la contraseña.
- Se verificó que al volver a presionar el botón la contraseña vuelve a ocultarse.
- No se modificaron endpoints, base de datos ni variables de entorno.

## Impacto técnico

- Mejora UX del login.
- No afecta autenticación ni seguridad de backend.
- No requiere migraciones.
- No requiere actualización de Swagger/OpenAPI porque no se tocaron APIs.

## Fuera de alcance

- No se modifican roles ni permisos.
- No se alteran tokens ni lógica de sesión.
- No se agregan nuevas pantallas.
- No se modifican formularios internos fuera del login principal.
