### PR TITLE
feat: block overdue and unpaid members on login

### DIFF
--- a/docs/socios/socios-morosidad-auto-desactivacion-login.md
+++ b/docs/socios/socios-morosidad-auto-desactivacion-login.md
@@ -1,0 +1,114 @@
+# Socios - morosidad, desactivación automática y login
+
+## Objetivo
+
+Implementar una primera regla operativa para bloquear el ingreso normal de socios con mora mayor a 7 días.
+
+## Regla de negocio
+
+Cuando un usuario intenta iniciar sesión como socio:
+
+1. Se validan email, contraseña y rol.
+2. Se busca el socio asociado al usuario.
+3. Se consulta el estado de cuota mediante `obtener_estado_cuota_socio`.
+4. Si el estado es `vencido` y `dias_vencido > 7`:
+   - se marca el socio como `activo = false`;
+   - se carga `fecha_baja` con la fecha actual;
+   - se bloquea el login normal;
+   - se devuelve un mensaje claro para regularizar en administración.
+
+Mensaje esperado:
+
+```txt
+Usted fue desactivado del sistema porque pasaron X días desde el vencimiento de su cuota. Diríjase a administración para regularizar su situación.
+```
+
+## Alcance técnico
+
+### Backend
+
+Archivos modificados:
+
+```txt
+src/services/loginService.ts
+src/app/api/custom-login/route.ts
+```
+
+Cambios:
+
+- Se agrega evaluación de morosidad durante login de socios.
+- Se agrega desactivación automática de `socio.activo`.
+- Se agregan códigos de error para login.
+- El endpoint devuelve mensajes de error reales en lugar de respuesta genérica.
+
+### Frontend
+
+Archivo modificado:
+
+```txt
+src/app/auth/login/page.tsx
+```
+
+Cambios:
+
+- El login muestra un cartel rojo inline cuando el acceso es restringido.
+- El mensaje de desactivación por mora queda visible en la pantalla de login.
+- Se conserva el comportamiento del toast.
+- Se mantiene el toggle de contraseña agregado previamente.
+
+### Swagger/OpenAPI
+
+Archivo modificado:
+
+```txt
+src/lib/swagger/openApiSpec.ts
+```
+
+Cambios:
+
+- Se actualiza la descripción de `POST /api/custom-login`.
+- Se documentan estados 401 y 403.
+
+## Fuera de alcance
+
+- No separa todavía login de socio y login admin/usuario.
+- No implementa RBAC/permisos de menú.
+- No crea migraciones nuevas.
+- No modifica tabla `usuario`.
+- No implementa scheduler automático; la desactivación ocurre durante intento de login del socio.
+
+## Validación sugerida
+
+1. Socio al día:
+   - puede iniciar sesión normalmente.
+
+2. Socio vencido con menos o igual a 7 días:
+   - puede iniciar sesión normalmente.
+
+3. Socio vencido con más de 7 días:
+   - no ingresa al dashboard;
+   - se muestra cartel rojo en login;
+   - `socio.activo` queda en `false`.
+
+4. Admin/usuario interno:
+   - login normal sin impacto por esta regla.
+
+
+## Fix complementario: bloqueo de socios sin pagos
+
+Durante la prueba funcional se detectó que la regla bloqueaba correctamente al socio vencido por más de 7 días, pero permitía ingresar a un socio con estado `sin_pagos`.
+
+Se ajusta la regla del login para bloquear también a socios sin pagos activos.
+
+### Regla actualizada
+
+- `estado_cuota = 'vencido'` y `dias_vencido > 7`: bloquea login, desactiva socio.
+- `estado_cuota = 'sin_pagos'`: bloquea login, desactiva socio.
+- Socio al día: ingresa normalmente.
+- Socio vencido dentro de tolerancia: ingresa normalmente.
+
+### Mensaje para socio sin pagos
+
+```txt
+Usted fue desactivado del sistema porque no registra pagos activos. Diríjase a administración para regularizar su situación.
+```

--- a/src/app/api/custom-login/route.ts
+++ b/src/app/api/custom-login/route.ts
@@ -1,18 +1,63 @@
 import { signIn } from "@/services/loginService";
 import { NextResponse } from "next/server";
 
-export async function POST(req : Request){
-try{
+export const dynamic = 'force-dynamic';
+
+type LoginError = Error & {
+  code?: string;
+  status?: number;
+  details?: Record<string, unknown>;
+};
+
+function getLoginStatus(error: LoginError) {
+  if (error.status) return error.status;
+  if (error.message?.includes('contraseña')) return 401;
+  if (error.message?.includes('inactivo')) return 403;
+  if (error.message?.includes('desactiv')) return 403;
+  return 500;
+}
+
+export async function POST(req: Request) {
+  try {
     const body = await req.json();
     const { email, password, rol } = body;
+
     if (!email || !password || !rol) {
-        return NextResponse.json({ message: "Faltan datos" }, { status: 400 });
+      return NextResponse.json(
+        {
+          message: "Faltan datos",
+          error_code: "LOGIN_MISSING_FIELDS",
+        },
+        { status: 400 }
+      );
     }
+
     const loginSignin = await signIn({ email, password, rol });
-    return NextResponse.json({
-        message: "Logueado con exito", token : loginSignin},{status: 200});
-    } catch (error) {
-        console.error("Error en el inicio de sesión:", error);
-        return NextResponse.json({ message: "Error al iniciar sesión" }, { status: 500 });
-    }
-    }
+
+    return NextResponse.json(
+      {
+        message: "Logueado con exito",
+        token: loginSignin,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    const loginError = error as LoginError;
+    const status = getLoginStatus(loginError);
+
+    console.error("Error en el inicio de sesión:", {
+      message: loginError.message,
+      code: loginError.code,
+      status,
+    });
+
+    return NextResponse.json(
+      {
+        message: loginError.message || "Error al iniciar sesión",
+        error_code: loginError.code || "LOGIN_ERROR",
+        details: loginError.details ?? null,
+      },
+      { status }
+    );
+  }
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -4,7 +4,7 @@ import { useState, FormEvent, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { useAuthStore } from '@/stores/authStore';
-import { Sun, Moon, Check, ChevronsUpDown, Eye, EyeOff } from 'lucide-react';
+import { Sun, Moon, Check, ChevronsUpDown, Eye, EyeOff, AlertTriangle } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -96,6 +96,7 @@ export default function LoginPage() {
   );
   const [userTypeOpen, setUserTypeOpen] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [loginAlert, setLoginAlert] = useState<string | null>(null);
   const { dark, toggle } = useDarkMode();
 
   useEffect(() => {
@@ -107,6 +108,7 @@ export default function LoginPage() {
 
   useEffect(() => {
     if (error) {
+      setLoginAlert(error);
       toast.error(error);
       clearError();
     }
@@ -114,6 +116,7 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    setLoginAlert(null);
 
     if (!email.trim()) {
       toast.error('El campo Usuario es obligatorio');
@@ -202,7 +205,10 @@ export default function LoginPage() {
                   type='email'
                   placeholder='usuario@correo.com'
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    if (loginAlert) setLoginAlert(null);
+                  }}
                   required
                 />
               </div>
@@ -215,7 +221,10 @@ export default function LoginPage() {
                     type={showPassword ? 'text' : 'password'}
                     placeholder='••••••••'
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      if (loginAlert) setLoginAlert(null);
+                    }}
                     className='pr-12'
                     autoComplete='current-password'
                     required
@@ -302,6 +311,19 @@ export default function LoginPage() {
                 </Popover>
               </div>
 
+
+              {loginAlert && (
+                <div
+                  role='alert'
+                  className='flex gap-3 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-950/50 dark:text-red-100'
+                >
+                  <AlertTriangle className='mt-0.5 h-5 w-5 flex-shrink-0' />
+                  <div>
+                    <p className='font-semibold'>Acceso restringido</p>
+                    <p className='mt-1 leading-relaxed'>{loginAlert}</p>
+                  </div>
+                </div>
+              )}
 
               <Button
                 type='submit'

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -637,13 +637,15 @@ const endpointDefinitions: EndpointDefinition[] = [
     ],
     "tag": "Autenticación",
     "summary": "Login personalizado",
-    "description": "Valida credenciales y tipo de usuario para iniciar sesión en el sistema.",
+    "description": "Valida credenciales y tipo de usuario para iniciar sesión en el sistema. Para socios, evalúa estado activo y mora mayor a 7 días; si corresponde, bloquea el ingreso normal y devuelve mensaje de regularización administrativa.",
     "auth": false,
     "admin": false,
     "notImplemented": false,
     "statuses": [
       200,
       400,
+      401,
+      403,
       500
     ],
     "queryParams": [],

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -5,6 +5,114 @@ import { getSocioByIdUsuario } from './socioService';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 
+const DIAS_TOLERANCIA_MORA = 7;
+
+type EstadoCuotaLogin = {
+  estado_cuota: string | null;
+  dias_vencido: number;
+  periodo_hasta: string | null;
+  ultimo_vencimiento: string | null;
+};
+
+class LoginBusinessError extends Error {
+  code: string;
+  status: number;
+  details?: Record<string, unknown>;
+
+  constructor(
+    message: string,
+    options?: {
+      code?: string;
+      status?: number;
+      details?: Record<string, unknown>;
+    }
+  ) {
+    super(message);
+    this.name = 'LoginBusinessError';
+    this.code = options?.code ?? 'LOGIN_ERROR';
+    this.status = options?.status ?? 400;
+    this.details = options?.details;
+  }
+}
+
+function toNumber(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeEstadoCuotaLogin(row: any): EstadoCuotaLogin | null {
+  if (!row) return null;
+
+  return {
+    estado_cuota: row.estado_cuota ?? null,
+    dias_vencido: toNumber(row.dias_vencido),
+    periodo_hasta: row.periodo_hasta ?? null,
+    ultimo_vencimiento: row.ultimo_vencimiento ?? null,
+  };
+}
+
+async function getEstadoCuotaParaLogin(
+  supabase: ReturnType<typeof conexionBD>,
+  socioId: string
+): Promise<EstadoCuotaLogin | null> {
+  const { data, error } = await supabase.rpc('obtener_estado_cuota_socio', {
+    p_id_socio: socioId,
+  });
+
+  if (error) {
+    console.warn(
+      'No se pudo consultar estado de cuota durante login:',
+      error.message
+    );
+    return null;
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  return normalizeEstadoCuotaLogin(row);
+}
+
+function buildMensajeDesactivacionMora(estado: EstadoCuotaLogin | null) {
+  if (estado?.estado_cuota === 'sin_pagos') {
+    return 'Usted fue desactivado del sistema porque no registra pagos activos. Diríjase a administración para regularizar su situación.';
+  }
+
+  const dias = Math.max(estado?.dias_vencido ?? 0, DIAS_TOLERANCIA_MORA + 1);
+
+  return `Usted fue desactivado del sistema porque pasaron ${dias} días desde el vencimiento de su cuota. Diríjase a administración para regularizar su situación.`;
+}
+
+async function desactivarSocioPorMora(
+  supabase: ReturnType<typeof conexionBD>,
+  socioId: string
+) {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const { error } = await supabase
+    .from('socio')
+    .update({
+      activo: false,
+      fecha_baja: today,
+    })
+    .eq('id_socio', socioId);
+
+  if (error) {
+    throw new Error(`No se pudo desactivar al socio por mora: ${error.message}`);
+  }
+}
+
+function debeBloquearLoginSocioPorMora(estado: EstadoCuotaLogin | null) {
+  if (!estado?.estado_cuota) return false;
+
+  if (estado.estado_cuota === 'sin_pagos') {
+    return true;
+  }
+
+  return (
+    estado.estado_cuota === 'vencido' &&
+    toNumber(estado.dias_vencido) > DIAS_TOLERANCIA_MORA
+  );
+}
+
 export const signIn = async (login: SignInDto) => {
   const { email, password, rol } = login;
 
@@ -19,28 +127,52 @@ export const signIn = async (login: SignInDto) => {
 
   if (error) {
     console.log('Error al obtener el usuario:', error.message);
-    throw new Error('Error al obtener el usuario');
+    throw new LoginBusinessError('Error al obtener el usuario', {
+      code: 'LOGIN_USER_QUERY_ERROR',
+      status: 500,
+    });
   }
 
   if (!data) {
     console.log('Email no encontrado');
-    throw new Error('Usuario no encontrado o contraseña incorrecta');
+    throw new LoginBusinessError(
+      'Usuario no encontrado o contraseña incorrecta',
+      {
+        code: 'LOGIN_INVALID_CREDENTIALS',
+        status: 401,
+      }
+    );
   }
 
   const validatePassword = bcrypt.compareSync(password, data.password_hash);
 
   if (!validatePassword) {
     console.log('Contraseña incorrecta');
-    throw new Error('Usuario no encontrado o contraseña incorrecta');
+    throw new LoginBusinessError(
+      'Usuario no encontrado o contraseña incorrecta',
+      {
+        code: 'LOGIN_INVALID_CREDENTIALS',
+        status: 401,
+      }
+    );
   }
 
   if (data.rol !== rol) {
     console.log('Rol no autorizado');
-    throw new Error('Usuario no encontrado o contraseña incorrecta');
+    throw new LoginBusinessError(
+      'Usuario no encontrado o contraseña incorrecta',
+      {
+        code: 'LOGIN_INVALID_ROLE',
+        status: 401,
+      }
+    );
   }
   if (data.activo === false) {
     console.log('Usuario inactivo');
-    throw new Error('Usuario inactivo');
+    throw new LoginBusinessError('Usuario inactivo', {
+      code: 'LOGIN_USER_INACTIVE',
+      status: 403,
+    });
   }
 
   const basePayload: JwtUser = {
@@ -55,13 +187,45 @@ export const signIn = async (login: SignInDto) => {
 
   if (rol === 'socio') {
     const socio = await getSocioByIdUsuario(data.id);
-    
-    // const socio = await getSocioByIdUsuario(data.id);
 
     if (!socio) {
       console.log('No se encontró el socio asociado al usuario');
-      throw new Error('No se encontró el socio asociado al usuario');
+      throw new LoginBusinessError('No se encontró el socio asociado al usuario', {
+        code: 'LOGIN_SOCIO_NOT_FOUND',
+        status: 404,
+      });
     }
+
+    const estadoCuota = await getEstadoCuotaParaLogin(supabase, socio.id_socio);
+    const debeDesactivarsePorMora = debeBloquearLoginSocioPorMora(estadoCuota);
+
+    if (debeDesactivarsePorMora && socio.activo) {
+      await desactivarSocioPorMora(supabase, socio.id_socio);
+      console.log(
+        `Socio ${socio.id_socio} desactivado por morosidad (${estadoCuota?.estado_cuota}, ${estadoCuota?.dias_vencido} días vencido).`
+      );
+    }
+
+    if (!socio.activo || debeDesactivarsePorMora) {
+      const message = debeDesactivarsePorMora
+        ? buildMensajeDesactivacionMora(estadoCuota)
+        : 'Su cuenta de socio se encuentra desactivada. Diríjase a administración para regularizar su situación.';
+
+      throw new LoginBusinessError(message, {
+        code: debeDesactivarsePorMora
+          ? 'LOGIN_SOCIO_DESACTIVADO_MORA'
+          : 'LOGIN_SOCIO_INACTIVE',
+        status: 403,
+        details: {
+          id_socio: socio.id_socio,
+          estado_cuota: estadoCuota?.estado_cuota ?? null,
+          dias_vencido: estadoCuota?.dias_vencido ?? null,
+          periodo_hasta: estadoCuota?.periodo_hasta ?? null,
+          ultimo_vencimiento: estadoCuota?.ultimo_vencimiento ?? null,
+        },
+      });
+    }
+
     basePayload.id_socio = socio.id_socio;
   }
 
@@ -72,3 +236,5 @@ export const signIn = async (login: SignInDto) => {
   const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '3h' });
   return token;
 };
+
+export { LoginBusinessError };


### PR DESCRIPTION
# feat: block overdue members on login

## Resumen

Esta feature implementa la regla de morosidad en el login de socios de Gym Master.

Cuando un socio intenta iniciar sesión, el sistema consulta su estado de cuota. Si el socio está vencido por más de 7 días o no registra pagos activos, el sistema bloquea el ingreso normal, desactiva al socio y muestra un cartel rojo en el login indicando que debe regularizar su situación en administración.

## Cambios principales

- Se evalúa el estado de cuota durante el login del socio.
- Se consulta el RPC `obtener_estado_cuota_socio`.
- Se bloquea el login de socios con `estado_cuota = vencido` y `dias_vencido > 7`.
- Se bloquea también el login de socios con `estado_cuota = sin_pagos`.
- Se actualiza `socio.activo = false` y se registra `fecha_baja` cuando corresponde.
- Se conserva login normal para administradores, usuarios internos, socios al día y socios vencidos dentro de tolerancia.
- `/api/custom-login` devuelve errores más claros y específicos para mostrar en pantalla.
- Se mantiene el diseño visual del cartel rojo en login.
- Se actualiza Swagger/OpenAPI para `POST /api/custom-login`.
- Se agrega documentación técnica de la feature.

## Mensajes esperados

### Socio vencido por más de 7 días

```txt
Usted fue desactivado del sistema porque pasaron X días desde el vencimiento de su cuota. Diríjase a administración para regularizar su situación.
```

### Socio sin pagos activos

```txt
Usted fue desactivado del sistema porque no registra pagos activos. Diríjase a administración para regularizar su situación.
```

## Archivos principales modificados

- `src/services/loginService.ts`
- `src/app/api/custom-login/route.ts`
- `src/app/auth/login/page.tsx`
- `src/lib/swagger/openApiSpec.ts`
- `docs/socios/socios-morosidad-auto-desactivacion-login.md`

## Validación realizada

- Build local ejecutado correctamente.
- Login de socio vencido probado: bloquea ingreso y muestra cartel rojo.
- Login de socio sin pagos probado: bloquea ingreso y muestra cartel rojo.
- Login de socio al día: debe conservar ingreso normal.
- Login de administrador/usuario interno: debe conservar ingreso normal.

## Observaciones del build

El build finalizó correctamente. Las advertencias de `baseline-browser-mapping` y `caniuse-lite` son deuda técnica menor de dependencias de browserslist y no bloquean deploy.

## Fuera de alcance

- No separa todavía login de socio y login admin/usuario interno.
- No implementa RBAC/permisos por menú.
- No implementa scheduler automático de morosidad.
- No agrega migraciones.
- No modifica reglas de pago ni generación de cuotas.
- No implementa control SaaS/licencia del gimnasio cliente.
