### PR TITLE
Feature/auth route permission guards

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,9 @@
+import DashboardRouteGuard from '@/components/auth/DashboardRouteGuard';
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <DashboardRouteGuard>{children}</DashboardRouteGuard>;
+}

--- a/src/components/auth/DashboardRouteGuard.tsx
+++ b/src/components/auth/DashboardRouteGuard.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { ReactNode, useEffect } from 'react';
+import { ShieldAlert } from 'lucide-react';
+import { useAuthStore } from '@/stores/authStore';
+import {
+  canAccessDashboardPath,
+  getDashboardRoutePermission,
+} from '@/lib/permissions/menuPermissions';
+
+function DashboardRouteLoading() {
+  return (
+    <div className='flex min-h-screen items-center justify-center bg-background px-4 text-sm text-muted-foreground'>
+      Validando acceso...
+    </div>
+  );
+}
+
+function DashboardRouteUnauthorized({
+  permissionLabel,
+}: {
+  permissionLabel?: string;
+}) {
+  return (
+    <main className='flex min-h-screen items-center justify-center bg-background px-4 py-8'>
+      <section className='w-full max-w-lg rounded-2xl border border-red-200 bg-card p-6 text-center shadow-sm dark:border-red-900/60'>
+        <div className='mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-300'>
+          <ShieldAlert className='h-7 w-7' aria-hidden='true' />
+        </div>
+
+        <h1 className='text-2xl font-semibold tracking-tight text-foreground'>
+          Acceso no autorizado
+        </h1>
+
+        <p className='mt-3 text-sm leading-6 text-muted-foreground'>
+          Tu usuario no tiene permisos para ingresar a esta sección del panel.
+          {permissionLabel
+            ? ` Se requiere el módulo “${permissionLabel}”.`
+            : ' Solicitá a un administrador que revise tus permisos.'}
+        </p>
+
+        <div className='mt-6 flex flex-col justify-center gap-3 sm:flex-row'>
+          <Link
+            href='/dashboard'
+            className='inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90'
+          >
+            Volver al inicio
+          </Link>
+          <Link
+            href='/auth/login'
+            className='inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground'
+          >
+            Cambiar usuario
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function DashboardRouteGuard({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { user, isAuthenticated, isInitialized, initializeAuth } =
+    useAuthStore();
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
+  useEffect(() => {
+    if (isInitialized && !isAuthenticated) {
+      router.replace('/auth/login');
+    }
+  }, [isAuthenticated, isInitialized, router]);
+
+  if (!isInitialized) {
+    return <DashboardRouteLoading />;
+  }
+
+  if (!isAuthenticated || !user) {
+    return null;
+  }
+
+  const canAccess = canAccessDashboardPath(
+    user.rol,
+    user.permisos_menu ?? null,
+    pathname
+  );
+
+  if (!canAccess) {
+    const routePermission = getDashboardRoutePermission(pathname);
+
+    return (
+      <DashboardRouteUnauthorized
+        permissionLabel={routePermission?.permissionKey}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/sidebar/AppSidebar.tsx
+++ b/src/components/sidebar/AppSidebar.tsx
@@ -3,19 +3,17 @@ import React, { useEffect, useState } from "react";
 import { Sidebar } from "../ui/sidebar";
 import { Menu, X } from "lucide-react";
 import { SidebarSection } from "./SidebarSection";
+import { SidebarLogoutButton } from "./SidebarLogoutButton";
 import { useIsMobile } from "@/hooks/use-mobile";
 import "@/app/styles/scrollbar.css";
 import { useAuthStore } from "@/stores/authStore";
 import { useSidebarMenu } from "@/hooks/useSidebarSection";
-import { usePathname } from "next/navigation";
 
 export const AppSidebar = () => {
   const [isOpen, setIsOpen] = useState(false);
   const isMobile = useIsMobile();
   const { user, isAuthenticated, isInitialized, initializeAuth } =
     useAuthStore();
-  const pathname = usePathname();
-
   const userType = user?.rol;
   const menuSections = useSidebarMenu(userType, user?.permisos_menu ?? null);
 
@@ -75,6 +73,11 @@ export const AppSidebar = () => {
             closeSidebar={() => setIsOpen(false)}
           />
         ))}
+
+        <SidebarLogoutButton
+          isMobile={isMobile}
+          closeSidebar={() => setIsOpen(false)}
+        />
       </Sidebar>
     </>
   );

--- a/src/components/sidebar/SidebarLogoutButton.tsx
+++ b/src/components/sidebar/SidebarLogoutButton.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import React from 'react';
+import { LogOut } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '../ui/sidebar';
+import { useAuthStore } from '@/stores/authStore';
+
+interface SidebarLogoutButtonProps {
+  isMobile: boolean;
+  closeSidebar: () => void;
+}
+
+export const SidebarLogoutButton: React.FC<SidebarLogoutButtonProps> = ({
+  isMobile,
+  closeSidebar,
+}) => {
+  const router = useRouter();
+  const { logout } = useAuthStore();
+
+  const handleLogout = () => {
+    logout();
+
+    if (isMobile) {
+      closeSidebar();
+    }
+
+    router.push('/auth/login');
+  };
+
+  return (
+    <div className='mt-auto border-t border-sidebar-border/60 px-2 pb-4 pt-3'>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            type='button'
+            onClick={handleLogout}
+            className='flex w-full items-center gap-2 text-sm text-muted-foreground hover:text-foreground'
+            title='Cerrar sesión'
+            aria-label='Cerrar sesión'
+          >
+            <LogOut className='h-4 w-4' aria-hidden='true' />
+            <span>Cerrar sesión</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </div>
+  );
+};

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -257,6 +257,112 @@ export const DEFAULT_MENU_PERMISSIONS_BY_ROLE: Record<AppRole, string[]> = {
   ],
 };
 
+
+export type DashboardRoutePermission = {
+  path: string;
+  permissionKey: string;
+  roles: AppRole[];
+  exact?: boolean;
+};
+
+const MENU_DASHBOARD_ROUTE_PERMISSIONS: DashboardRoutePermission[] =
+  MENU_PERMISSION_GROUPS.flatMap((group) =>
+    group.items.map((item) => ({
+      path: item.path,
+      permissionKey: item.key,
+      roles: item.roles,
+      exact: true,
+    }))
+  );
+
+export const DASHBOARD_ROUTE_PERMISSIONS: DashboardRoutePermission[] = [
+  ...MENU_DASHBOARD_ROUTE_PERMISSIONS,
+  {
+    path: '/dashboard/admin',
+    permissionKey: 'Inicio',
+    roles: ['admin'],
+    exact: true,
+  },
+  {
+    path: '/dashboard/bi-cuotas-pagos',
+    permissionKey: 'Pagos',
+    roles: ['admin'],
+    exact: true,
+  },
+  {
+    path: '/dashboard/gestion-dietas',
+    permissionKey: 'Gestión de Dietas',
+    roles: ['admin'],
+    exact: true,
+  },
+  {
+    path: '/dashboard/ventas-detalle',
+    permissionKey: 'Ventas',
+    roles: ['admin', 'usuario'],
+    exact: true,
+  },
+];
+
+function normalizeDashboardPath(pathname?: string | null) {
+  if (!pathname) return '/dashboard';
+  const cleanPath = pathname.split('?')[0].split('#')[0];
+  if (cleanPath === '/') return '/';
+  return cleanPath.replace(/\/$/, '') || '/dashboard';
+}
+
+function normalizeAppRole(role?: string | null): AppRole | null {
+  if (role === 'admin' || role === 'usuario' || role === 'socio') {
+    return role;
+  }
+
+  return null;
+}
+
+export function getDashboardRoutePermission(pathname?: string | null) {
+  const normalizedPath = normalizeDashboardPath(pathname);
+
+  const exactMatch = DASHBOARD_ROUTE_PERMISSIONS.find(
+    (route) => normalizeDashboardPath(route.path) === normalizedPath
+  );
+
+  if (exactMatch) return exactMatch;
+
+  return DASHBOARD_ROUTE_PERMISSIONS
+    .filter((route) => route.exact === false)
+    .sort((a, b) => b.path.length - a.path.length)
+    .find((route) => {
+      const normalizedRoutePath = normalizeDashboardPath(route.path);
+      return normalizedPath.startsWith(`${normalizedRoutePath}/`);
+    });
+}
+
+export function canAccessDashboardPath(
+  role?: string | null,
+  permissions?: string[] | null,
+  pathname?: string | null
+) {
+  const normalizedRole = normalizeAppRole(role);
+  if (!normalizedRole) return false;
+
+  const routePermission = getDashboardRoutePermission(pathname);
+
+  if (!routePermission) {
+    return normalizedRole === 'admin';
+  }
+
+  if (!routePermission.roles.includes(normalizedRole)) {
+    return false;
+  }
+
+  if (normalizedRole === 'admin') {
+    return true;
+  }
+
+  return getEffectiveMenuPermissions(normalizedRole, permissions).includes(
+    routePermission.permissionKey
+  );
+}
+
 export function getAvailableMenuPermissionsForRole(role?: string | null) {
   const normalizedRole = (role || 'socio') as AppRole;
   if (!['admin', 'usuario', 'socio'].includes(normalizedRole)) return [];


### PR DESCRIPTION
# PR — feature/auth-route-permission-guards

## Resumen

Esta rama refuerza la seguridad de navegación del dashboard de Gym Master incorporando guards de permisos por ruta y agregando una segunda opción de cierre de sesión desde el menú lateral.

Hasta ahora, el RBAC fase 1 ya filtraba visualmente el sidebar para usuarios internos usando `usuario.permisos_menu`, pero un usuario podía intentar ingresar manualmente por URL a secciones no asignadas. Esta feature agrega una protección centralizada para impedir ese acceso.

También se agrega un botón fijo de logout con ícono de puerta/salida al final del menú lateral para admin, usuario interno y socio, manteniendo dos formas de salir del sistema.

## Rama

```bash
feature/auth-route-permission-guards
```

## Cambios principales

### 1. Guard central de rutas del dashboard

Se agregó un componente de protección para validar el acceso a rutas bajo `/dashboard` según rol y permisos cargados en sesión.

Reglas funcionales:

- `admin`: acceso total al dashboard.
- `usuario`: acceso únicamente a rutas asociadas a los permisos definidos en `usuario.permisos_menu`.
- `socio`: acceso restringido a rutas propias de socio.

### 2. Mapa de permisos por ruta

Se extendió la lógica de permisos del menú para cubrir rutas directas del dashboard, incluyendo rutas que no necesariamente aparecen como ítems principales del sidebar.

Esto permite bloquear intentos de acceso manual por URL a módulos no autorizados.

### 3. Logout fijo al final del sidebar

Se agregó un botón de cierre de sesión al final del menú lateral:

- visible para admin.
- visible para usuario interno.
- visible para socio.
- siempre ubicado al final del listado, incluso si en el futuro se agregan nuevos ítems al menú.

El botón ejecuta logout y redirige al login principal.

## Archivos modificados/agregados

```txt
src/app/dashboard/layout.tsx
src/components/auth/DashboardRouteGuard.tsx
src/components/sidebar/AppSidebar.tsx
src/components/sidebar/SidebarLogoutButton.tsx
src/lib/permissions/menuPermissions.ts
```

## Impacto técnico

- No agrega dependencias.
- No modifica base de datos.
- No requiere migraciones Supabase.
- No modifica endpoints API.
- No requiere actualización Swagger/OpenAPI, porque no se crearon ni modificaron rutas API.
- Mejora la seguridad de navegación del RBAC actual.
- Mantiene compatibilidad con el modelo vigente `usuario.permisos_menu JSONB`.

## Validación sugerida

```bash
npm run build
git status
```

Si `npm run build` modifica archivos PWA sin intención:

```bash
git restore public/sw.js public/workbox-*.js
```

## Casos de prueba funcional

### Admin

Debe poder acceder a cualquier ruta del dashboard.

Rutas de ejemplo:

```txt
/dashboard
/dashboard/socios
/dashboard/usuarios
/dashboard/parametrizacion
/dashboard/equipamientos
/dashboard/bi-cuotas-pagos
```

### Usuario interno QA

Credenciales:

```txt
qa.usuario.interno@gymmaster.local
GymMaster2026!
```

Permisos actuales:

```json
["Inicio", "Socios", "Pagos", "Asistencias"]
```

Debe poder acceder a:

```txt
/dashboard
/dashboard/socios
/dashboard/pagos
/dashboard/asistencias
```

Debe quedar bloqueado al intentar acceder manualmente por URL a módulos no asignados, por ejemplo:

```txt
/dashboard/usuarios
/dashboard/parametrizacion
/dashboard/cuotas
/dashboard/equipamientos
/dashboard/gestor-rutinas
/dashboard/bi-cuotas-pagos
```

### Socio

Debe conservar acceso únicamente a sus rutas propias, por ejemplo:

```txt
/dashboard/control-asistencia
/dashboard/ficha-medica
/dashboard/mi-cuenta/pagar-cuota
/dashboard/mi-cuenta/historial-pagos
```

### Logout del sidebar

Validar que el ítem de salida aparezca al final del menú lateral en:

- admin.
- usuario interno.
- socio.

Al hacer clic debe cerrar sesión y redirigir a:

```txt
/auth/login
```

## Checklist

- [ ] Patch aplicado correctamente.
- [ ] `npm run build` ejecutado sin errores.
- [ ] `git status` revisado.
- [ ] Admin validado con acceso total.
- [ ] Usuario interno validado con rutas permitidas y rutas bloqueadas.
- [ ] Socio validado con rutas propias.
- [ ] Logout del sidebar validado al final del menú.
- [ ] PR mergeado a `main`.
- [ ] `main` actualizado localmente después del merge.

## Commit sugerido

```bash
git add src/app/dashboard/layout.tsx src/components/auth/DashboardRouteGuard.tsx src/components/sidebar/AppSidebar.tsx src/components/sidebar/SidebarLogoutButton.tsx src/lib/permissions/menuPermissions.ts

git commit -m "feat: add dashboard route guards and sidebar logout"
```
