### PR TITLE
feat: add mobile profile photo upload and camera capture

### DIFF
--- a/docs/perfil/profile-photo-camera-upload.md
+++ b/docs/perfil/profile-photo-camera-upload.md
@@ -1,0 +1,61 @@
+# Feature: profile-photo-camera-upload
+
+## Resumen
+
+Se mejora la actualización de foto de perfil en Gym Master para que el usuario pueda cargar su imagen desde celular con dos opciones:
+
+- Subir una imagen existente desde el dispositivo.
+- Sacar una foto directamente con la cámara del celular.
+
+## Alcance
+
+La mejora aplica al perfil del usuario autenticado y mantiene la integración existente con Cloudinary y la actualización de foto en `usuario`. Cuando el usuario autenticado es socio, también se actualiza la foto vinculada en `socio`.
+
+## Cambios principales
+
+- Se reemplaza el botón único de cambio de imagen por dos acciones:
+  - **Subir foto**
+  - **Sacar foto**
+- Se agrega vista previa antes de guardar.
+- Se permite cancelar la selección antes de subir.
+- Se validan tamaño y formato de imagen en frontend y backend.
+- Se actualiza el estado local de sesión para refrescar el avatar sin reloguear.
+- Se mantiene fallback por inicial del usuario cuando no hay foto.
+
+## Validaciones
+
+Formatos aceptados:
+
+- PNG
+- JPG/JPEG
+- WEBP
+- GIF
+- SVG
+- HEIC/HEIF
+
+Tamaño máximo:
+
+- 5 MB
+
+## Endpoints impactados
+
+```txt
+POST /api/file-upload
+```
+
+No se agregan migraciones ni cambios de base de datos.
+
+## Consideraciones
+
+La captura con cámara utiliza `input type="file"` con `capture="user"`, por lo que en navegadores móviles compatibles se abre la cámara del dispositivo. En escritorio o navegadores sin soporte, el comportamiento puede caer al selector de archivos.
+
+## Pruebas sugeridas
+
+1. Entrar como socio.
+2. Ir a Perfil.
+3. Usar "Subir foto".
+4. Ver vista previa.
+5. Guardar.
+6. Confirmar que se actualiza el avatar.
+7. Repetir desde celular usando "Sacar foto".
+8. Verificar que la foto se refleje en perfil, header y vistas que consuman `foto`.

--- a/src/app/api/file-upload/route.ts
+++ b/src/app/api/file-upload/route.ts
@@ -1,47 +1,88 @@
-import { FileUploadDTO } from "@/interfaces/fileUpload.interface";
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { uploadFile } from "@/services/fileUploadService";
-import { updateFotoUsuarioById } from "@/services/usuarioService";
-import { NextResponse } from "next/server";
-
+import { FileUploadDTO } from '@/interfaces/fileUpload.interface';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { uploadFile } from '@/services/fileUploadService';
+import { updateFotoUsuarioById } from '@/services/usuarioService';
+import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const VALID_IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|svg\+xml|heic|heif)$/i;
+
 export async function POST(request: Request) {
-    try {
-        const { user } = await authMiddleware(request);
-        if(!user){
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
+  try {
+    const { user } = await authMiddleware(request);
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     const formData = await request.formData();
-    const file = formData.get("file") as File;
+    const file = formData.get('file') as File;
 
     if (!file) {
-        return NextResponse.json({ error: "No file uploaded"}, { status: 400 });
+      return NextResponse.json(
+        { error: 'No se recibió ninguna imagen.' },
+        { status: 400 }
+      );
     }
-    // Convierto el archivo en un ArrayBuffer y desp en un Buffer
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json(
+        { error: 'La imagen debe ser menor a 5MB.' },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_IMAGE_TYPES.test(file.type)) {
+      return NextResponse.json(
+        {
+          error:
+            'Formato no válido. Usá PNG, JPG, WEBP, GIF, HEIC o HEIF.',
+        },
+        { status: 400 }
+      );
+    }
+
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
 
-const fileDto : FileUploadDTO = {
-    fieldName: file.name,
-    originalName: file.name,
-    mimeType: file.type,
-    size: file.size,
-    buffer: buffer
-};
+    const fileDto: FileUploadDTO = {
+      fieldName: file.name,
+      originalName: file.name,
+      mimeType: file.type,
+      size: file.size,
+      buffer,
+    };
 
     const folder = `${user.rol}/profile`;
-    const result = await uploadFile(fileDto, folder);
-    if (!result) {
-        return NextResponse.json({ error: "Error al subir el archivo" }, { status: 500 });
-    }
-    await updateFotoUsuarioById(user, result);
-    return NextResponse.json({message: "Foto de usuario actualizada", url: result}, { status: 200 });
+    const uploadedUrl = await uploadFile(fileDto, folder);
 
-}catch (error:any) {
-    console.error("error file:", error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
-}
+    if (!uploadedUrl) {
+      return NextResponse.json(
+        { error: 'Error al subir la imagen.' },
+        { status: 500 }
+      );
+    }
+
+    await updateFotoUsuarioById(user, uploadedUrl);
+
+    return NextResponse.json(
+      {
+        message: 'Foto de perfil actualizada.',
+        url: uploadedUrl,
+        foto: uploadedUrl,
+      },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    console.error('error file:', error);
+    const message = error?.message || 'Error al subir la imagen.';
+    const status =
+      message.includes('Token no proporcionado') || message.includes('Token inválido')
+        ? 401
+        : 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
 }

--- a/src/components/perfil/ProfileCard.tsx
+++ b/src/components/perfil/ProfileCard.tsx
@@ -3,6 +3,7 @@
 import ProfileImage from './ProfileImage';
 import ProfileDetails from './ProfileDetails';
 import type { Usuario } from '@/interfaces/usuario.interface';
+import { useAuthStore } from '@/stores/authStore';
 
 export default function ProfileCard({
   user,
@@ -11,16 +12,26 @@ export default function ProfileCard({
   user?: Partial<Usuario> | null;
   size?: number;
 }) {
+  const updateUser = useAuthStore((state) => state.updateUser);
+
+  const handlePhotoUpload = (data: any) => {
+    const url = data?.url || data?.foto || data?.path || null;
+    if (url) {
+      updateUser({ foto: url });
+    }
+  };
+
   return (
-    <div className='w-full max-w-3xl mx-auto p-6 rounded-lg bg-card border-border shadow-sm'>
-      <div className='flex items-center gap-6'>
+    <div className='w-full max-w-3xl p-6 mx-auto border rounded-lg bg-card border-border shadow-sm'>
+      <div className='flex flex-col items-center gap-6 md:flex-row md:items-start'>
         <ProfileImage
           src={user?.foto ?? null}
           alt={user?.nombre ?? 'Avatar'}
           size={size}
+          onUpload={handlePhotoUpload}
         />
-        <div className='flex-1'>
-          <div className='flex items-center justify-between gap-4'>
+        <div className='flex-1 w-full text-center md:text-left'>
+          <div className='flex flex-col justify-between gap-4 md:flex-row md:items-center'>
             <div>
               <div className='text-2xl font-bold text-foreground'>
                 Bienvenido, {user?.nombre ?? 'Usuario'}

--- a/src/components/perfil/ProfileImage.tsx
+++ b/src/components/perfil/ProfileImage.tsx
@@ -1,7 +1,11 @@
 'use client';
-import Image from 'next/image';
-import { useState, useRef } from 'react';
+
+import { useEffect, useRef, useState } from 'react';
+import { Camera, ImagePlus, RotateCcw, Save, X } from 'lucide-react';
 import { uploadFile } from '@/services/apiClient';
+
+const MAX_FILE_SIZE_MB = 5;
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
 export default function ProfileImage({
   foto,
@@ -23,66 +27,126 @@ export default function ProfileImage({
   const [currentSrc, setCurrentSrc] = useState<string | null>(
     foto ?? src ?? null
   );
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<{
     type: 'error' | 'success';
     text: string;
   } | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const galleryInputRef = useRef<HTMLInputElement | null>(null);
+  const cameraInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    setCurrentSrc(foto ?? src ?? null);
+  }, [foto, src]);
+
+  useEffect(() => {
+    return () => {
+      if (previewSrc) {
+        URL.revokeObjectURL(previewSrc);
+      }
+    };
+  }, [previewSrc]);
 
   const validateFile = (file: File | null) => {
-    if (!file) return 'No se seleccionó archivo';
-    if (file.size > 5 * 1024 * 1024) return 'El archivo debe ser menor a 5MB';
-    const validTypes = /^image\/(png|jpe?g|webp|gif|svg\+xml)$/;
-    if (!validTypes.test(file.type)) return 'Tipo de archivo no válido';
+    if (!file) return 'No se seleccionó archivo.';
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return `La imagen debe ser menor a ${MAX_FILE_SIZE_MB}MB.`;
+    }
+
+    const validTypes = /^image\/(png|jpe?g|webp|gif|svg\+xml|heic|heif)$/i;
+    if (!validTypes.test(file.type)) {
+      return 'Formato no válido. Usá PNG, JPG, WEBP, GIF, HEIC o HEIF.';
+    }
+
     return null;
   };
 
-  const handleFile = async (f: File | null) => {
+  const resetInputs = () => {
+    if (galleryInputRef.current) galleryInputRef.current.value = '';
+    if (cameraInputRef.current) cameraInputRef.current.value = '';
+  };
+
+  const clearPreview = () => {
+    if (previewSrc) {
+      URL.revokeObjectURL(previewSrc);
+    }
+    setPreviewSrc(null);
+    setSelectedFile(null);
+    resetInputs();
+  };
+
+  const handleSelectedFile = (file: File | null) => {
     setMessage(null);
-    if (!f) return;
-    const validationError = validateFile(f);
+
+    const validationError = validateFile(file);
+    if (validationError) {
+      clearPreview();
+      setMessage({ type: 'error', text: validationError });
+      return;
+    }
+
+    if (!file) return;
+
+    if (previewSrc) {
+      URL.revokeObjectURL(previewSrc);
+    }
+
+    setSelectedFile(file);
+    setPreviewSrc(URL.createObjectURL(file));
+  };
+
+  const uploadSelectedFile = async () => {
+    setMessage(null);
+
+    if (!selectedFile) {
+      setMessage({
+        type: 'error',
+        text: 'Seleccioná o sacá una foto antes de guardar.',
+      });
+      return;
+    }
+
+    const validationError = validateFile(selectedFile);
     if (validationError) {
       setMessage({ type: 'error', text: validationError });
       return;
     }
+
     setLoading(true);
+
     try {
-      const res = await uploadFile(f, 'file', '/api/file-upload');
+      const res = await uploadFile(selectedFile, 'file', '/api/file-upload');
+
       if (res.ok) {
-        const url = res.data?.url || res.data?.path || res.data?.key || null;
+        const url = res.data?.url || res.data?.foto || res.data?.path || null;
+
         if (url) {
           setCurrentSrc(url);
         }
-        setMessage({ type: 'success', text: 'Imagen subida correctamente' });
-        if (onUpload) onUpload(res.data);
+
+        clearPreview();
+        setMessage({ type: 'success', text: 'Foto de perfil actualizada.' });
+        onUpload?.(res.data);
       } else {
         setMessage({
           type: 'error',
-          text: res.data?.message || 'Error al subir archivo',
+          text: res.data?.message || res.data?.error || 'Error al subir la foto.',
         });
       }
     } catch (error: unknown) {
-      const errObj =
-        error && typeof error === 'object'
-          ? (error as Record<string, unknown>)
-          : null;
       const text =
-        (errObj && typeof errObj.message === 'string' && errObj.message) ||
-        'Error al subir archivo';
-      setMessage({
-        type: 'error',
-        text,
-      });
+        error instanceof Error ? error.message : 'Error al subir la foto.';
+      setMessage({ type: 'error', text });
     } finally {
       setLoading(false);
-      if (inputRef.current) inputRef.current.value = '';
+      resetInputs();
     }
   };
 
-  const imageSrc = currentSrc;
-  const isExternal =
-    typeof imageSrc === 'string' && /^https?:\/\//i.test(imageSrc ?? '');
+  const imageSrc = previewSrc || currentSrc;
 
   const getInitial = () => {
     const name = alt || '';
@@ -92,48 +156,124 @@ export default function ProfileImage({
   };
 
   return (
-    <div className='flex flex-col items-center gap-2' onClick={onClick}>
+    <div className='flex flex-col items-center gap-3' onClick={onClick}>
       <div
-        className='relative flex items-center justify-center flex-shrink-0 overflow-hidden rounded-full ring-1 ring-border/60 dark:ring-border/40'
+        className='relative flex items-center justify-center flex-shrink-0 overflow-hidden rounded-full ring-1 ring-border/60 dark:ring-border/40 bg-muted'
         style={{ width: size, height: size }}
       >
         {imageSrc ? (
-          <Image
+          // Se usa img para soportar previews locales tipo blob: en móviles.
+          <img
             src={imageSrc}
             alt={alt ?? 'Avatar'}
             width={size}
             height={size}
-            className='object-cover w-full h-full rounded-full bg-muted'
-            unoptimized={isExternal}
+            className='object-cover w-full h-full rounded-full'
           />
         ) : (
           <div className='flex items-center justify-center w-full h-full text-xl font-semibold text-white bg-indigo-600 rounded-full'>
             {getInitial()}
           </div>
         )}
+
+        {previewSrc && (
+          <div className='absolute inset-x-0 bottom-0 px-2 py-1 text-[10px] font-semibold text-center text-white bg-black/65'>
+            Vista previa
+          </div>
+        )}
       </div>
+
       <input
-        ref={inputRef}
+        ref={galleryInputRef}
+        type='file'
+        accept='image/png,image/jpeg,image/webp,image/gif,image/svg+xml,image/heic,image/heif'
+        className='hidden'
+        onChange={(e) => handleSelectedFile(e.target.files?.[0] ?? null)}
+      />
+
+      <input
+        ref={cameraInputRef}
         type='file'
         accept='image/*'
+        capture='user'
         className='hidden'
-        onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
+        onChange={(e) => handleSelectedFile(e.target.files?.[0] ?? null)}
       />
+
       {showButton && (
-        <button
-          type='button'
-          onClick={() => inputRef.current?.click()}
-          className='px-3 py-1 text-sm border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60'
-          aria-label='Cambiar imagen'
-          disabled={loading}
-        >
-          {loading ? '...' : 'Cambiar imagen'}
-        </button>
+        <div className='flex flex-col items-center w-full gap-2'>
+          {!selectedFile ? (
+            <div className='flex flex-wrap items-center justify-center gap-2'>
+              <button
+                type='button'
+                onClick={() => galleryInputRef.current?.click()}
+                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60'
+                aria-label='Subir foto desde el dispositivo'
+                disabled={loading}
+              >
+                <ImagePlus className='w-4 h-4' />
+                Subir foto
+              </button>
+
+              <button
+                type='button'
+                onClick={() => cameraInputRef.current?.click()}
+                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-sky-600 rounded-md hover:bg-sky-700 disabled:opacity-60'
+                aria-label='Sacar foto con la cámara'
+                disabled={loading}
+              >
+                <Camera className='w-4 h-4' />
+                Sacar foto
+              </button>
+            </div>
+          ) : (
+            <div className='flex flex-wrap items-center justify-center gap-2'>
+              <button
+                type='button'
+                onClick={uploadSelectedFile}
+                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold text-white bg-emerald-600 rounded-md hover:bg-emerald-700 disabled:opacity-60'
+                aria-label='Guardar foto de perfil'
+                disabled={loading}
+              >
+                <Save className='w-4 h-4' />
+                {loading ? 'Guardando...' : 'Guardar foto'}
+              </button>
+
+              <button
+                type='button'
+                onClick={() => galleryInputRef.current?.click()}
+                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60'
+                aria-label='Elegir otra foto'
+                disabled={loading}
+              >
+                <RotateCcw className='w-4 h-4' />
+                Cambiar
+              </button>
+
+              <button
+                type='button'
+                onClick={clearPreview}
+                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-700 border border-red-200 rounded-md bg-red-50 hover:bg-red-100 disabled:opacity-60 dark:text-red-200 dark:border-red-800 dark:bg-red-950/40'
+                aria-label='Cancelar cambio de foto'
+                disabled={loading}
+              >
+                <X className='w-4 h-4' />
+                Cancelar
+              </button>
+            </div>
+          )}
+
+          <p className='max-w-xs text-xs text-center text-muted-foreground'>
+            Desde el celular podés subir una imagen o sacar una foto con la cámara.
+            Revisá la vista previa antes de guardar.
+          </p>
+        </div>
       )}
+
       {message && (
         <div
-          className={`text-xs ${
-            message.type === 'error' ? 'text-red-500' : 'text-green-500'
+          className={`max-w-xs text-xs text-center ${
+            message.type === 'error' ? 'text-red-500' : 'text-green-600'
           }`}
         >
           {message.text}

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -881,7 +881,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     ],
     "tag": "Archivos",
     "summary": "Subida de archivo",
-    "description": "Sube archivos/fotos mediante servicio de almacenamiento y puede actualizar la foto del usuario.",
+    "description": "Sube imágenes de perfil desde archivo o captura de cámara móvil mediante Cloudinary y actualiza la foto del usuario/socio autenticado.",
     "auth": true,
     "admin": false,
     "notImplemented": false,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -32,6 +32,7 @@ interface AuthState {
   }) => Promise<boolean>;
   logout: () => void;
   initializeAuth: () => void;
+  updateUser: (patch: Partial<StoreUser>) => void;
   clearError: () => void;
 }
 
@@ -104,6 +105,12 @@ export const useAuthStore = create<AuthState>()(
             isInitialized: true,
           });
         }
+      },
+      updateUser: (patch) => {
+        const currentUser = get().user;
+        set({
+          user: currentUser ? { ...currentUser, ...patch } : currentUser,
+        });
       },
       clearError: () => {
         set({ error: null });


### PR DESCRIPTION
# feat: add mobile profile photo upload and camera capture

## Resumen

Esta PR incorpora una mejora en la gestión de foto de perfil, permitiendo que el usuario pueda actualizar su imagen desde el perfil con dos opciones:

- subir una imagen desde el dispositivo;
- capturar una foto directamente con la cámara del celular.

La mejora está pensada especialmente para la experiencia mobile/PWA de socios, permitiendo que cada socio pueda mantener actualizada su foto de perfil. Esto también mejora la identificación visual en módulos como asistencia, terminal de ingreso, dashboard y futuras experiencias mobile.

## Objetivo

Permitir que el usuario actualice su foto de perfil de forma simple, visual y compatible con dispositivos móviles.

## Cambios principales

Se actualizan los componentes de perfil para soportar:

- preview local de la imagen antes de guardar;
- opción “Subir foto”;
- opción “Sacar foto” desde cámara del celular;
- opción “Guardar foto”;
- opción “Cancelar”;
- actualización visual inmediata del avatar;
- validación de archivo antes de subir.

## Archivos principales modificados

```txt
src/components/perfil/ProfileImage.tsx
src/components/perfil/ProfileCard.tsx
src/app/api/file-upload/route.ts
src/stores/authStore.ts
src/lib/swagger/openApiSpec.ts
docs/perfil/profile-photo-camera-upload.md