### PR TITLE
feat: import external exercise media into Cloudinary

### DIFF
--- a/docs/rutinas/rutinas-exercise-media-cloudinary-import.md
+++ b/docs/rutinas/rutinas-exercise-media-cloudinary-import.md
@@ -1,0 +1,59 @@
+# Feature: Importación de media remota a Cloudinary
+
+## Rama
+
+`feature/rutinas-exercise-media-cloudinary-import`
+
+## Objetivo
+
+Automatizar la migración de imágenes/GIFs externos de ejercicios hacia Cloudinary sin descargar archivos manualmente.
+
+La mejora permite tomar una URL existente de `ejercicio.imagen` o una URL externa ingresada por el administrador, importarla desde backend a Cloudinary y actualizar los campos del ejercicio con la URL segura final.
+
+## Alcance implementado
+
+- Nuevo endpoint: `POST /api/rutinas/ejercicios-media/import`.
+- Nueva acción en `/dashboard/rutinas/media`: `Importar URL a Cloudinary`.
+- Importación remota de imagen/GIF usando Cloudinary.
+- Actualización de:
+  - `ejercicio.imagen`
+  - `ejercicio.imagen_origen = cloudinary`
+  - `ejercicio.cloudinary_public_id`
+  - `ejercicio.media_actualizada_en`
+- Creación/renovación del registro principal en `ejercicio_media`.
+- Actualización de Swagger/OpenAPI.
+- Reutilización del flujo visual existente del catálogo de media.
+
+## Seguridad y validaciones
+
+El backend valida:
+
+- Usuario autenticado.
+- Rol administrador.
+- `id_ejercicio` válido.
+- URL http/https.
+- Bloqueo de localhost, IP privada o dominios internos.
+- Evitar importar URLs que ya pertenecen a Cloudinary.
+- Verificación por `HEAD` de:
+  - estado HTTP correcto;
+  - `content-type` compatible con imagen/GIF;
+  - tamaño máximo de 10 MB;
+  - timeout para evitar requests lentos.
+
+## Flujo operativo
+
+1. El administrador entra en `/dashboard/rutinas/media`.
+2. Busca y selecciona un ejercicio.
+3. Usa la URL actual o pega una URL externa.
+4. Presiona `Importar URL a Cloudinary`.
+5. El backend valida la URL.
+6. Cloudinary importa el asset.
+7. Gym Master actualiza el ejercicio y su media principal.
+8. La pantalla recarga el catálogo y muestra la nueva imagen/GIF desde Cloudinary.
+
+## Próximos pasos sugeridos
+
+- Crear barrido semi-automático de equivalencias para copiar media desde ejercicios con imagen real hacia ejercicios con fallback.
+- Usar Volumen Avanzado como fuente prioritaria de imágenes/GIFs.
+- Agregar importación masiva seleccionada con reporte de éxitos/errores.
+- Integrar validación previa de candidatos dudosos para evitar copiar media entre variantes distintas.

--- a/src/app/api/rutinas/ejercicios-media/import/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/import/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { importExerciseMediaFromRemoteUrl } from '@/services/ejercicioMediaCatalogService';
+
+export const dynamic = 'force-dynamic';
+
+function getStatusFromError(error: any) {
+  const message = error?.message ?? '';
+
+  if (message.includes('Token no proporcionado') || message.includes('Token inválido')) {
+    return 401;
+  }
+
+  if (message.includes('No autorizado')) {
+    return 403;
+  }
+
+  if (
+    message.includes('URL') ||
+    message.includes('imagen') ||
+    message.includes('Cloudinary') ||
+    message.includes('máximo permitido') ||
+    message.includes('protocolo') ||
+    message.includes('privadas') ||
+    message.includes('id_ejercicio')
+  ) {
+    return 400;
+  }
+
+  return 500;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authMiddleware(request);
+    const payload = await request.json();
+
+    if (!payload?.id_ejercicio || !Number.isInteger(Number(payload.id_ejercicio))) {
+      return NextResponse.json(
+        { error: 'Debe indicar un id_ejercicio válido.' },
+        { status: 400 }
+      );
+    }
+
+    const imported = await importExerciseMediaFromRemoteUrl(user, {
+      ...payload,
+      id_ejercicio: Number(payload.id_ejercicio),
+    });
+
+    return NextResponse.json(
+      {
+        message: 'Media importada correctamente a Cloudinary.',
+        ...imported,
+      },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    const status = getStatusFromError(error);
+
+    if (status === 500) {
+      console.error('Error al importar media remota de ejercicio:', error);
+    }
+
+    return NextResponse.json(
+      { error: error?.message ?? 'Error al importar media remota de ejercicio.' },
+      { status }
+    );
+  }
+}

--- a/src/app/dashboard/rutinas/media/page.tsx
+++ b/src/app/dashboard/rutinas/media/page.tsx
@@ -30,6 +30,7 @@ import { Nivel } from '@/interfaces/niveles.interface';
 import { Objetivo } from '@/interfaces/objetivo.interface';
 import {
   getEjerciciosMediaCatalog,
+  importEjercicioMediaFromUrl,
   getNiveles,
   getObjetivos,
   updateEjercicioMediaCatalog,
@@ -91,6 +92,7 @@ export default function RutinasExerciseMediaCatalogPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [importing, setImporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
@@ -266,6 +268,43 @@ export default function RutinasExerciseMediaCatalogPage() {
       setSaving(false);
     }
   };
+
+
+  const handleImportExternalImage = async () => {
+    if (!selectedExercise) return;
+
+    const sourceUrl = externalImageUrl.trim() || selectedExercise.imagen?.trim();
+
+    if (!sourceUrl) {
+      setError('Debe indicar una URL externa o usar la imagen actual del ejercicio.');
+      return;
+    }
+
+    setImporting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await importEjercicioMediaFromUrl({
+        id_ejercicio: selectedExercise.id_ejercicio,
+        url: sourceUrl,
+        titulo: selectedExercise.nombre_ejercicio,
+        descripcion_media: 'Media principal importada automáticamente a Cloudinary desde el catálogo administrativo.',
+      });
+
+      if (!response.ok) {
+        throw new Error(response.error || 'No se pudo importar la imagen/GIF a Cloudinary.');
+      }
+
+      setSuccess('Imagen/GIF importada a Cloudinary y asociada al ejercicio.');
+      await loadCatalog();
+    } catch (importError: any) {
+      setError(importError?.message ?? 'No se pudo importar la media remota.');
+    } finally {
+      setImporting(false);
+    }
+  };
+
 
   const handleSaveYoutube = async () => {
     if (!selectedExercise) return;
@@ -553,7 +592,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                             <p className='text-xs text-slate-500'>Recomendado para evitar URLs rotas.</p>
                           </div>
                           <input ref={fileInputRef} type='file' accept='image/*' className='hidden' onChange={handleFileChange} />
-                          <Button onClick={handleSelectFile} disabled={uploading || saving}>
+                          <Button onClick={handleSelectFile} disabled={uploading || saving || importing}>
                             {uploading ? <Loader2 className='w-4 h-4 mr-2 animate-spin' /> : <UploadCloud className='w-4 h-4 mr-2' />}
                             Subir
                           </Button>
@@ -568,10 +607,19 @@ export default function RutinasExerciseMediaCatalogPage() {
                           onChange={(event) => setExternalImageUrl(event.target.value)}
                           placeholder='https://...'
                         />
-                        <Button variant='outline' className='w-full' onClick={handleSaveExternalImage} disabled={saving || uploading}>
-                          <ImageIcon className='w-4 h-4 mr-2' />
-                          Guardar URL de imagen
-                        </Button>
+                        <div className='grid grid-cols-1 gap-2'>
+                          <Button variant='outline' className='w-full' onClick={handleSaveExternalImage} disabled={saving || uploading || importing}>
+                            <ImageIcon className='w-4 h-4 mr-2' />
+                            Guardar URL de imagen
+                          </Button>
+                          <Button className='w-full' onClick={handleImportExternalImage} disabled={saving || uploading || importing || !externalImageUrl.trim()}>
+                            {importing ? <Loader2 className='w-4 h-4 mr-2 animate-spin' /> : <Cloud className='w-4 h-4 mr-2' />}
+                            Importar URL a Cloudinary
+                          </Button>
+                        </div>
+                        <p className='text-xs text-slate-500'>
+                          Usa este botón para tomar una URL externa existente, importarla a Cloudinary y reemplazar la imagen del ejercicio por la URL segura nueva.
+                        </p>
                       </div>
 
                       <div className='space-y-2'>
@@ -583,7 +631,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                           placeholder='https://www.youtube.com/watch?v=...'
                         />
                         <div className='flex gap-2'>
-                          <Button className='flex-1' onClick={handleSaveYoutube} disabled={saving || uploading}>
+                          <Button className='flex-1' onClick={handleSaveYoutube} disabled={saving || uploading || importing}>
                             {saving ? <Loader2 className='w-4 h-4 mr-2 animate-spin' /> : <Video className='w-4 h-4 mr-2' />}
                             Guardar video
                           </Button>
@@ -598,7 +646,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                       </div>
 
                       <div className='p-3 text-xs border rounded-lg bg-blue-50 text-blue-700 border-blue-200'>
-                        Cloudinary debe ser la fuente principal para imágenes/GIFs. YouTube queda como apoyo didáctico para que el socio vea la técnica del ejercicio.
+                        Cloudinary debe ser la fuente principal para imágenes/GIFs. Podés subir archivos locales o importar URLs externas para evitar descargas manuales. YouTube queda como apoyo didáctico para que el socio vea la técnica del ejercicio.
                       </div>
                     </>
                   )}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -15,6 +15,28 @@ cloudinary.config({
   api_secret: process.env.CLOUDINARY_CLOUD_API_SECRET,
 });
 
+function getSafePublicIdBase(originalName: string) {
+  return originalName
+    .replace(/\.[^/.]+$/, "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+function buildUploadOptions(originalName: string, folder: string): UploadApiOptions {
+  const timestamp = Date.now();
+  const safeOriginalName = getSafePublicIdBase(originalName);
+
+  return {
+    folder,
+    public_id: `${timestamp}_${safeOriginalName || "gym-master-file"}`,
+    resource_type: "auto",
+    overwrite: false,
+  };
+}
+
 export async function uploadFileCloudinary(
   buffer: Buffer,
   originalName: string,
@@ -29,21 +51,7 @@ export async function uploadFileCloudinaryWithResult(
   originalName: string,
   folder: string
 ): Promise<UploadApiResponse> {
-  const timestamp = Date.now();
-  const safeOriginalName = originalName
-    .replace(/\.[^/.]+$/, "")
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-zA-Z0-9_-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .toLowerCase();
-
-  const options: UploadApiOptions = {
-    folder,
-    public_id: `${timestamp}_${safeOriginalName || "gym-master-file"}`,
-    resource_type: "auto",
-    overwrite: false,
-  };
+  const options = buildUploadOptions(originalName, folder);
 
   return new Promise((resolve, reject) => {
     const stream = cloudinary.uploader.upload_stream(options, (error, result) => {
@@ -63,4 +71,14 @@ export async function uploadFileCloudinaryWithResult(
     stream.write(buffer);
     stream.end();
   });
+}
+
+export async function uploadRemoteUrlCloudinaryWithResult(
+  remoteUrl: string,
+  originalName: string,
+  folder: string
+): Promise<UploadApiResponse> {
+  const options = buildUploadOptions(originalName, folder);
+
+  return cloudinary.uploader.upload(remoteUrl, options);
 }

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1734,6 +1734,27 @@ const endpointDefinitions: EndpointDefinition[] = [
     "source": "src/app/api/rutinas/ejercicios-media/route.ts"
   },
   {
+    "path": "/api/rutinas/ejercicios-media/import",
+    "methods": [
+      "POST"
+    ],
+    "tag": "Rutinas",
+    "summary": "Importación de imagen/GIF remoto a Cloudinary",
+    "description": "Importa una imagen o GIF desde una URL pública externa hacia Cloudinary y la asocia como media principal de un ejercicio. Requiere rol administrador.",
+    "auth": true,
+    "admin": true,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      400,
+      401,
+      403,
+      500
+    ],
+    "queryParams": [],
+    "source": "src/app/api/rutinas/ejercicios-media/import/route.ts"
+  },
+  {
     "path": "/api/rutinas/ejercicios-media/upload",
     "methods": [
       "POST"

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -753,3 +753,23 @@ export async function uploadEjercicioMedia(file: File, idEjercicio?: number | st
   const data = await res.json();
   return { ok: res.ok, ...data };
 }
+
+
+export async function importEjercicioMediaFromUrl(payload: {
+  id_ejercicio: number | string;
+  url: string;
+  titulo?: string | null;
+  descripcion_media?: string | null;
+}) {
+  const token = getToken();
+  const res = await fetch('/api/rutinas/ejercicios-media/import', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}

--- a/src/services/ejercicioMediaCatalogService.ts
+++ b/src/services/ejercicioMediaCatalogService.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
 import {
   EjercicioMediaCatalogItem,
@@ -5,9 +6,22 @@ import {
   EjercicioMediaItem,
   EjercicioMediaUpdatePayload,
 } from '@/interfaces/ejercicioMedia.interface';
+import { uploadRemoteUrlCloudinaryWithResult } from '@/lib/cloudinary';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 
 type SupabaseExerciseRow = Record<string, any>;
+
+type EjercicioMediaImportPayload = {
+  id_ejercicio: number;
+  url: string;
+  titulo?: string | null;
+  descripcion_media?: string | null;
+};
+
+const MAX_REMOTE_IMAGE_BYTES = 10 * 1024 * 1024;
+const REMOTE_IMAGE_HEAD_TIMEOUT_MS = 8000;
+const VALID_REMOTE_IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|svg\+xml|heic|heif)$/i;
+
 
 const DEFAULT_PAGE_SIZE = 24;
 const MAX_PAGE_SIZE = 100;
@@ -291,6 +305,175 @@ async function replacePrimaryMedia(params: {
     throw new Error(insertError.message);
   }
 }
+
+
+function isPrivateIpAddress(hostname: string) {
+  const ipVersion = isIP(hostname);
+
+  if (ipVersion === 0) {
+    return false;
+  }
+
+  if (ipVersion === 6) {
+    const lower = hostname.toLowerCase();
+    return (
+      lower === '::1' ||
+      lower.startsWith('fc') ||
+      lower.startsWith('fd') ||
+      lower.startsWith('fe80')
+    );
+  }
+
+  const parts = hostname.split('.').map(Number);
+
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    return true;
+  }
+
+  const [a, b] = parts;
+
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function assertPublicRemoteImageUrl(rawUrl?: string | null) {
+  const cleanUrl = rawUrl?.trim();
+
+  if (!cleanUrl) {
+    throw new Error('Debe indicar una URL de imagen o GIF para importar.');
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(cleanUrl);
+  } catch {
+    throw new Error('La URL de imagen no es válida.');
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw new Error('La URL debe usar protocolo http o https.');
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal') ||
+    isPrivateIpAddress(hostname)
+  ) {
+    throw new Error('No se permiten URLs locales, privadas o internas.');
+  }
+
+  if (hostname.includes('cloudinary.com')) {
+    throw new Error('La imagen ya pertenece a Cloudinary. No es necesario importarla nuevamente.');
+  }
+
+  return parsedUrl;
+}
+
+function getRemoteOriginalName(parsedUrl: URL, fallback: string) {
+  const lastSegment = parsedUrl.pathname.split('/').filter(Boolean).pop();
+  const decodedSegment = lastSegment ? decodeURIComponent(lastSegment) : '';
+
+  return decodedSegment || `${fallback}.image`;
+}
+
+async function assertRemoteImageMetadata(parsedUrl: URL) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REMOTE_IMAGE_HEAD_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(parsedUrl.toString(), {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`La URL externa respondió con estado ${response.status}.`);
+    }
+
+    const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ?? '';
+
+    if (!VALID_REMOTE_IMAGE_TYPES.test(contentType)) {
+      throw new Error('La URL externa no parece ser una imagen/GIF válido.');
+    }
+
+    const contentLength = Number(response.headers.get('content-length') ?? 0);
+
+    if (contentLength > MAX_REMOTE_IMAGE_BYTES) {
+      throw new Error('La imagen/GIF remoto supera el máximo permitido de 10MB.');
+    }
+  } catch (error: any) {
+    if (error?.name === 'AbortError') {
+      throw new Error('La URL externa tardó demasiado en responder.');
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function importExerciseMediaFromRemoteUrl(
+  user: JwtUser,
+  payload: EjercicioMediaImportPayload
+) {
+  assertCanManageExerciseMedia(user);
+
+  if (!Number.isInteger(Number(payload.id_ejercicio))) {
+    throw new Error('Debe indicar un id_ejercicio válido.');
+  }
+
+  const parsedUrl = assertPublicRemoteImageUrl(payload.url);
+  await assertRemoteImageMetadata(parsedUrl);
+
+  const folder = `gym-master/exercises/${payload.id_ejercicio}`;
+  const originalName = getRemoteOriginalName(parsedUrl, `ejercicio-${payload.id_ejercicio}`);
+
+  const uploadResult = await uploadRemoteUrlCloudinaryWithResult(
+    parsedUrl.toString(),
+    originalName,
+    folder
+  );
+
+  if (!uploadResult.secure_url || !uploadResult.public_id) {
+    throw new Error('Cloudinary no devolvió URL segura o public_id para la imagen importada.');
+  }
+
+  const data = await updateExerciseMediaCatalogItem(user, {
+    id_ejercicio: Number(payload.id_ejercicio),
+    imagen: uploadResult.secure_url,
+    imagen_origen: 'cloudinary',
+    cloudinary_public_id: uploadResult.public_id,
+    titulo: payload.titulo ?? null,
+    descripcion_media:
+      payload.descripcion_media ??
+      `Media principal importada automáticamente a Cloudinary desde URL externa: ${parsedUrl.hostname}`,
+  });
+
+  return {
+    data,
+    cloudinary: {
+      secure_url: uploadResult.secure_url,
+      public_id: uploadResult.public_id,
+      resource_type: uploadResult.resource_type,
+      format: uploadResult.format,
+      bytes: uploadResult.bytes,
+      width: uploadResult.width,
+      height: uploadResult.height,
+    },
+  };
+}
+
 
 export async function updateExerciseMediaCatalogItem(
   user: JwtUser,


### PR DESCRIPTION
# feat: import external exercise media into Cloudinary

## Resumen

Esta PR incorpora la importación automática de imágenes/GIFs externos hacia Cloudinary desde el panel de media de ejercicios de Gym Master.

La mejora evita el proceso manual de descargar una imagen externa, subirla a Cloudinary, copiar la nueva URL y actualizar la base de datos. Ahora el administrador puede importar la URL directamente desde el backend y dejar el ejercicio normalizado con `secure_url`, `public_id` y registro principal en `ejercicio_media`.

## Objetivo

Permitir que el catálogo de media de ejercicios pueda tomar una URL externa existente o ingresada por el administrador, importarla a Cloudinary y actualizar los campos correspondientes del ejercicio.

## Cambios principales

- Se agrega endpoint de importación remota:

```txt
POST /api/rutinas/ejercicios-media/import
```

- Se agrega acción en el panel:

```txt
/dashboard/rutinas/media
```

- Se incorpora botón/flujo:

```txt
Importar URL a Cloudinary
```

- Se actualiza el servicio frontend del catálogo de media.
- Se extiende la integración Cloudinary para soportar importación desde URL remota.
- Se actualiza Swagger/OpenAPI.
- Se agrega documentación técnica de la feature.

## Flujo funcional

```txt
URL externa actual o ingresada
→ backend valida la URL
→ Cloudinary importa el archivo remoto
→ Gym Master recibe secure_url + public_id
→ actualiza ejercicio.imagen
→ actualiza ejercicio.imagen_origen = cloudinary
→ actualiza ejercicio.cloudinary_public_id
→ actualiza ejercicio.media_actualizada_en
→ crea/actualiza ejercicio_media principal
```

## Validaciones incorporadas

El backend valida:

- URL obligatoria y válida.
- Protocolo `http` o `https`.
- Bloqueo de `localhost`.
- Bloqueo de IPs privadas o internas.
- Bloqueo de URL ya perteneciente a Cloudinary para evitar duplicados.
- Verificación de `content-type` compatible con imagen.
- Verificación de tamaño máximo cuando el servidor informa `content-length`.
- Timeout/control de error para URLs externas no disponibles.
- Rol administrador para ejecutar la importación.

## Archivos principales modificados

```txt
src/app/api/rutinas/ejercicios-media/import/route.ts
src/app/dashboard/rutinas/media/page.tsx
src/lib/cloudinary.ts
src/services/ejercicioMediaCatalogService.ts
src/services/apiClient.ts
src/lib/swagger/openApiSpec.ts
docs/rutinas/rutinas-exercise-media-cloudinary-import.md
```

## Base de datos

No se agregan nuevas migraciones en esta PR.

La feature reutiliza la estructura ya creada en la feature anterior:

```txt
ejercicio.imagen
ejercicio.imagen_origen
ejercicio.cloudinary_public_id
ejercicio.media_actualizada_en
ejercicio.video_youtube_url
ejercicio.youtube_video_id
ejercicio_media
```

## Pruebas realizadas

- Se validó la pantalla `/dashboard/rutinas/media` contra base remota.
- Se seleccionó un ejercicio con URL externa.
- Se ejecutó la importación hacia Cloudinary.
- Se confirmó actualización de preview en el panel.
- Se confirmó actualización de campos del ejercicio.
- Se confirmó creación/actualización de media principal en `ejercicio_media`.
- Se verificó que el flujo funcional opera correctamente.

## Build

Validar con:

```bash
npm run build
```

Si el build modifica archivos PWA sin intención:

```bash
git restore public/sw.js public/workbox-*.js
```

## Notas

Esta feature automatiza una tarea clave del banco de ejercicios y prepara el camino para futuras mejoras:

- importación masiva controlada;
- barrido de equivalencias entre ejercicios;
- reutilización de imágenes desde Volumen Avanzado;
- homogeneización completa del catálogo de media;
- soporte visual más sólido para web, mobile, PDF y futuro RAG.
