### PR TITLE
Feature/rag rutinas assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ STRIPE_WEBHOOK_SECRET=stripe-webhook-secret
 CLOUDINARY_CLOUD_NAME=nombre_cloudinary
 CLOUDINARY_CLOUD_API_KEY=api_key_cloudinary
 CLOUDINARY_CLOUD_API_SECRET=api_secret_cloudinary
+# Futuro microservicio externo Gym Master RAG Coach.
+# Si no se configura, /api/rutinas/rag-assistant/generar usa fallback local seguro.
+GYM_MASTER_RAG_COACH_URL=
+GYM_MASTER_RAG_COACH_API_KEY=
+GYM_MASTER_RAG_COACH_GENERATE_PATH=/api/v1/routines/generate

--- a/docs/rag-rutinas/README.md
+++ b/docs/rag-rutinas/README.md
@@ -14,6 +14,7 @@ Esta carpeta documenta la preparación del dataset/corpus inicial para el futuro
 | `prompts/prompt-generacion-pdf-dieta.md` | Prompt para PDF de dieta. |
 | `datasets/rag-rutinas-matriz-prioritaria.csv` | Matriz de combinaciones prioritaria. |
 | `datasets/rag-rutinas-prompts-prioritarios.md` | Bloques de parámetros para ejecutar prompts. |
+| `rag-rutinas-assistant-bridge.md` | Puente inicial entre Gym Master y el futuro microservicio `gym-master-rag-coach`. |
 
 ## Nota
 

--- a/docs/rag-rutinas/rag-rutinas-assistant-bridge.md
+++ b/docs/rag-rutinas/rag-rutinas-assistant-bridge.md
@@ -1,0 +1,119 @@
+# RAG Rutinas Assistant — puente inicial Gym Master
+
+## Rama
+
+`feature/rag-rutinas-assistant`
+
+## Objetivo
+
+Preparar a Gym Master para integrarse con el futuro microservicio externo `gym-master-rag-coach`, sin acoplar claves ni lógica pesada de IA dentro del frontend.
+
+Esta feature agrega un flujo inicial para que el socio pueda solicitar una rutina desde una pantalla conversacional/guiada. El sistema queda preparado para consultar al RAG cuando esté disponible y, mientras tanto, usa el generador formal actual de Gym Master como fallback seguro.
+
+## Componentes agregados
+
+- Pantalla: `/dashboard/rutinas/asistente`
+- Endpoint puente: `POST /api/rutinas/rag-assistant/generar`
+- Servicio frontend: `generarRutinaConAsistente`
+- Contratos TypeScript: `RagRutinasAssistantRequest`, `RagRutinasAssistantResponseData`
+- Documentación Swagger/OpenAPI
+- Variables de entorno opcionales para `gym-master-rag-coach`
+
+## Flujo funcional
+
+1. El socio ingresa al Asistente de Rutinas.
+2. Selecciona objetivo, nivel, días por semana e idioma.
+3. Agrega preferencias o restricciones.
+4. Gym Master envía los datos al endpoint seguro del backend.
+5. El backend arma el contrato para `gym-master-rag-coach`.
+6. Si el RAG está configurado, consulta el microservicio externo.
+7. Si no está configurado o falla, usa fallback local.
+8. Gym Master guarda la rutina usando el generador formal actual.
+9. El socio recibe el mensaje: “Dirigite al menú Rutinas y allí la encontrarás.”
+
+## Variables de entorno
+
+```env
+GYM_MASTER_RAG_COACH_URL=
+GYM_MASTER_RAG_COACH_API_KEY=
+GYM_MASTER_RAG_COACH_GENERATE_PATH=/api/v1/routines/generate
+```
+
+Si `GYM_MASTER_RAG_COACH_URL` no está definida, el endpoint opera en modo `local_fallback`.
+
+## Contrato hacia gym-master-rag-coach
+
+Payload esperado hacia el microservicio:
+
+```json
+{
+  "source": "gym-master",
+  "contractVersion": "v0.1",
+  "user": {
+    "id": "uuid_usuario",
+    "id_socio": "uuid_socio",
+    "email": "socio@email.com",
+    "rol": "socio"
+  },
+  "request": {
+    "objetivo": 1,
+    "nivel": 2,
+    "dias": 4,
+    "idioma": "es",
+    "mensajeSocio": "Quiero ganar masa muscular y priorizar pecho y espalda.",
+    "restricciones": "Sin lesiones. Prefiero máquinas."
+  },
+  "expectedOutput": {
+    "structuredJson": true,
+    "saveRoutineInGymMaster": false,
+    "returnSuggestedParameters": true
+  }
+}
+```
+
+Respuesta recomendada desde el microservicio:
+
+```json
+{
+  "objetivo": 1,
+  "nivel": 2,
+  "dias": 4,
+  "idioma": "es",
+  "resumen": "Se recomienda rutina de hipertrofia con frecuencia 2 en tren superior.",
+  "mensajeFinal": "Tu rutina se generó en base a lo que me pediste. Dirigite al menú Rutinas y allí la encontrarás.",
+  "advertencias": [],
+  "rutinaJson": {}
+}
+```
+
+En esta etapa, Gym Master no persiste directamente `rutinaJson` externo. El RAG sugiere parámetros y justificación, y Gym Master mantiene el guardado formal con su generador actual.
+
+## Seguridad
+
+- El frontend no conoce la URL interna ni la API key del RAG.
+- La llamada al microservicio ocurre únicamente desde backend.
+- Si falta token, el endpoint responde 401.
+- Si el RAG no está disponible, el sistema no rompe: usa fallback local.
+- Los textos enviados por el socio se limitan en longitud para evitar payloads excesivos.
+
+## Relación con features anteriores
+
+Esta feature depende conceptualmente de:
+
+- `feature/rutinas-exercise-knowledge-base-seed`
+- `feature/rutinas-exercise-media-catalog`
+- `feature/rutinas-exercise-media-cloudinary-import`
+- `feature/rutinas-exercise-media-equivalence-sync`
+- `feature/rag-rutinas-dataset-prompts`
+- `feature/rag-rutinas-coach-knowledge-base`
+
+## Próximos pasos
+
+1. Crear repo externo `gym-master-rag-coach`.
+2. Implementar microservicio Python/FastAPI.
+3. Cargar knowledge base/documentos curados.
+4. Agregar pgvector o vector store equivalente.
+5. Hacer que el RAG devuelva JSON estructurado validado.
+6. Evolucionar Gym Master para persistir rutinas generadas por JSON completo cuando corresponda.
+7. Incorporar comparación contra rutina previa para evitar rutinas idénticas.
+8. Agregar soporte bilingüe completo para rutina generada.

--- a/src/app/api/rutinas/rag-assistant/generar/route.ts
+++ b/src/app/api/rutinas/rag-assistant/generar/route.ts
@@ -1,0 +1,231 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { dataGeneracionRutina } from '@/services/rutinaService';
+import {
+  RagRutinasAssistantRequest,
+  RagRutinasIdioma,
+} from '@/interfaces/ragRutinasAssistant.interface';
+
+export const dynamic = 'force-dynamic';
+
+type RagCoachPayload = {
+  source: 'gym-master';
+  contractVersion: 'v0.1';
+  user: {
+    id: string;
+    id_socio?: string;
+    email?: string;
+    rol?: string;
+  };
+  request: Required<Pick<RagRutinasAssistantRequest, 'objetivo' | 'nivel' | 'dias'>> & {
+    idioma: RagRutinasIdioma;
+    mensajeSocio: string;
+    restricciones: string;
+  };
+  expectedOutput: {
+    structuredJson: true;
+    saveRoutineInGymMaster: false;
+    returnSuggestedParameters: true;
+  };
+};
+
+type RagCoachResponse = {
+  objetivo?: number;
+  nivel?: number;
+  dias?: number;
+  idioma?: RagRutinasIdioma;
+  resumen?: string;
+  mensajeFinal?: string;
+  advertencias?: string[];
+  rutinaJson?: unknown;
+  [key: string]: unknown;
+};
+
+const MAX_TEXT_LENGTH = 1200;
+const DEFAULT_RAG_GENERATE_PATH = '/api/v1/routines/generate';
+
+function cleanText(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, MAX_TEXT_LENGTH);
+}
+
+function toPositiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeDias(value: unknown): number {
+  const parsed = toPositiveInteger(value, 3);
+  return Math.min(Math.max(parsed, 1), 6);
+}
+
+function normalizeIdioma(value: unknown): RagRutinasIdioma {
+  return value === 'en' ? 'en' : 'es';
+}
+
+function getRagCoachEndpoint(): string | null {
+  const rawBaseUrl = process.env.GYM_MASTER_RAG_COACH_URL?.trim();
+
+  if (!rawBaseUrl) return null;
+
+  const baseUrl = rawBaseUrl.replace(/\/+$/, '');
+  const path = (
+    process.env.GYM_MASTER_RAG_COACH_GENERATE_PATH || DEFAULT_RAG_GENERATE_PATH
+  ).startsWith('/')
+    ? process.env.GYM_MASTER_RAG_COACH_GENERATE_PATH || DEFAULT_RAG_GENERATE_PATH
+    : `/${process.env.GYM_MASTER_RAG_COACH_GENERATE_PATH}`;
+
+  return `${baseUrl}${path}`;
+}
+
+async function callRagCoach(payload: RagCoachPayload): Promise<RagCoachResponse> {
+  const endpoint = getRagCoachEndpoint();
+
+  if (!endpoint) {
+    throw new Error('RAG Coach no configurado');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 20000);
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(process.env.GYM_MASTER_RAG_COACH_API_KEY
+          ? { Authorization: `Bearer ${process.env.GYM_MASTER_RAG_COACH_API_KEY}` }
+          : {}),
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      throw new Error(
+        typeof data?.error === 'string'
+          ? data.error
+          : 'El servicio gym-master-rag-coach respondió con error'
+      );
+    }
+
+    return data as RagCoachResponse;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => ({}))) as RagRutinasAssistantRequest;
+
+    const baseObjetivo = toPositiveInteger(body.objetivo, 1);
+    const baseNivel = toPositiveInteger(body.nivel, 1);
+    const baseDias = normalizeDias(body.dias);
+    const idioma = normalizeIdioma(body.idioma);
+    const mensajeSocio = cleanText(body.mensajeSocio);
+    const restricciones = cleanText(body.restricciones);
+
+    const ragPayload: RagCoachPayload = {
+      source: 'gym-master',
+      contractVersion: 'v0.1',
+      user: {
+        id: user.id,
+        id_socio: user.id_socio,
+        email: user.email,
+        rol: user.rol,
+      },
+      request: {
+        objetivo: baseObjetivo,
+        nivel: baseNivel,
+        dias: baseDias,
+        idioma,
+        mensajeSocio,
+        restricciones,
+      },
+      expectedOutput: {
+        structuredJson: true,
+        saveRoutineInGymMaster: false,
+        returnSuggestedParameters: true,
+      },
+    };
+
+    let ragRespuesta: RagCoachResponse | undefined;
+    let ragError: string | undefined;
+    const ragConfigurado = Boolean(getRagCoachEndpoint());
+
+    if (ragConfigurado) {
+      try {
+        ragRespuesta = await callRagCoach(ragPayload);
+      } catch (error) {
+        ragError = error instanceof Error ? error.message : 'Error desconocido del RAG Coach';
+        console.warn('RAG Coach no disponible. Se usa fallback local:', ragError);
+      }
+    }
+
+    const objetivoFinal = toPositiveInteger(ragRespuesta?.objetivo, baseObjetivo);
+    const nivelFinal = toPositiveInteger(ragRespuesta?.nivel, baseNivel);
+    const diasFinal = normalizeDias(ragRespuesta?.dias ?? baseDias);
+    const idiomaFinal = normalizeIdioma(ragRespuesta?.idioma ?? idioma);
+
+    const rutinaGenerada = await dataGeneracionRutina(user, {
+      objetivo: objetivoFinal,
+      nivel: nivelFinal,
+      dias: diasFinal,
+      id_socio: body.id_socio,
+    });
+
+    const mensajeFinal =
+      ragRespuesta?.mensajeFinal ||
+      'Tu rutina se generó en base a los datos indicados. Dirigite al menú Rutinas y allí la encontrarás.';
+
+    return NextResponse.json(
+      {
+        ok: true,
+        message: 'Rutina generada correctamente desde el asistente.',
+        data: {
+          modo: ragRespuesta ? 'rag_bridge' : 'local_fallback',
+          ragConfigurado,
+          rutinaGenerada,
+          parametros: {
+            objetivo: objetivoFinal,
+            nivel: nivelFinal,
+            dias: diasFinal,
+            idioma: idiomaFinal,
+          },
+          mensajeFinal,
+          resumen:
+            ragRespuesta?.resumen ||
+            'Se utilizó el generador formal de Gym Master con los parámetros seleccionados por el socio.',
+          advertencias: Array.isArray(ragRespuesta?.advertencias)
+            ? ragRespuesta.advertencias
+            : [],
+          ragRespuesta,
+          ragError,
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error inesperado';
+    const status = message.toLowerCase().includes('token') ? 401 : 500;
+
+    console.error('Error en asistente RAG de rutinas:', error);
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status }
+    );
+  }
+}

--- a/src/app/dashboard/rutinas/asistente/page.tsx
+++ b/src/app/dashboard/rutinas/asistente/page.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Bot, CheckCircle2, Loader2, MessageSquareText, Sparkles } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { AppFooter } from '@/components/footer/AppFooter';
+import { AppHeader } from '@/components/header/AppHeader';
+import { AppSidebar } from '@/components/sidebar/AppSidebar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { Nivel } from '@/interfaces/niveles.interface';
+import { Objetivo } from '@/interfaces/objetivo.interface';
+import { RagRutinasAssistantResponseData } from '@/interfaces/ragRutinasAssistant.interface';
+import { getNiveles, getObjetivos } from '@/services/apiClient';
+import { generarRutinaConAsistente } from '@/services/ragRutinasAssistantService';
+import { useAuthStore } from '@/stores/authStore';
+
+const DIAS_DISPONIBLES = [1, 2, 3, 4, 5, 6];
+
+function isAdminRole(role?: string | null) {
+  const normalized = role?.trim().toLowerCase();
+  return normalized === 'admin' || normalized === 'administrador';
+}
+
+export default function RutinasAssistantPage() {
+  const router = useRouter();
+  const { user, isAuthenticated, initializeAuth, isInitialized, token } = useAuthStore();
+
+  const [objetivos, setObjetivos] = useState<Objetivo[]>([]);
+  const [niveles, setNiveles] = useState<Nivel[]>([]);
+  const [objetivo, setObjetivo] = useState<string>('1');
+  const [nivel, setNivel] = useState<string>('1');
+  const [dias, setDias] = useState<number>(3);
+  const [idioma, setIdioma] = useState<'es' | 'en'>('es');
+  const [mensajeSocio, setMensajeSocio] = useState('');
+  const [restricciones, setRestricciones] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<RagRutinasAssistantResponseData | null>(null);
+
+  const usuarioEsAdmin = isAdminRole(user?.rol);
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
+  useEffect(() => {
+    if (isInitialized && !isAuthenticated) {
+      router.push('/auth/login');
+    }
+  }, [isAuthenticated, isInitialized, router]);
+
+  const cargarCatalogos = useCallback(async () => {
+    if (!token) return;
+
+    try {
+      const [objetivosResponse, nivelesResponse] = await Promise.all([
+        getObjetivos(),
+        getNiveles(),
+      ]);
+
+      if (objetivosResponse.ok) {
+        const objetivosData = objetivosResponse.data ?? [];
+        setObjetivos(objetivosData);
+        if (objetivosData[0]?.id_objetivo) setObjetivo(String(objetivosData[0].id_objetivo));
+      }
+
+      if (nivelesResponse.ok) {
+        const nivelesData = nivelesResponse.data ?? [];
+        setNiveles(nivelesData);
+        if (nivelesData[0]?.id_nivel) setNivel(String(nivelesData[0].id_nivel));
+      }
+    } catch (error) {
+      console.error('Error al cargar catálogos del asistente:', error);
+      toast.error('No se pudieron cargar objetivos y niveles');
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (isInitialized && isAuthenticated && token) {
+      cargarCatalogos();
+    }
+  }, [cargarCatalogos, isAuthenticated, isInitialized, token]);
+
+  const objetivoSeleccionado = useMemo(
+    () => objetivos.find((item) => String(item.id_objetivo) === objetivo)?.nombre_objetivo ?? `Objetivo ${objetivo}`,
+    [objetivo, objetivos]
+  );
+
+  const nivelSeleccionado = useMemo(
+    () => niveles.find((item) => String(item.id_nivel) === nivel)?.nombre_nivel ?? `Nivel ${nivel}`,
+    [nivel, niveles]
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setResult(null);
+
+    try {
+      const response = await generarRutinaConAsistente({
+        objetivo: Number(objetivo),
+        nivel: Number(nivel),
+        dias,
+        idioma,
+        mensajeSocio,
+        restricciones,
+      });
+
+      if (!response.ok || !response.data) {
+        throw new Error(response.error || 'No se pudo generar la rutina');
+      }
+
+      setResult(response.data);
+      toast.success('Rutina generada correctamente');
+    } catch (error) {
+      console.error('Error al generar rutina con asistente:', error);
+      toast.error(error instanceof Error ? error.message : 'Error al generar rutina');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isInitialized) {
+    return <div>Cargando...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <SidebarProvider>
+      <div className='flex min-h-screen w-full'>
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader title='Asistente de Rutinas' />
+
+          <main className='flex-1 bg-muted/30 px-4 py-6 md:px-8'>
+            <div className='mx-auto flex max-w-6xl flex-col gap-6'>
+              <section className='rounded-3xl border bg-card p-6 shadow-sm'>
+                <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
+                  <div className='space-y-2'>
+                    <div className='inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary'>
+                      <Bot className='h-4 w-4' />
+                      Gym Master RAG Coach · puente inicial
+                    </div>
+                    <h1 className='text-3xl font-bold tracking-tight text-foreground'>
+                      Generá tu rutina con asistencia inteligente
+                    </h1>
+                    <p className='max-w-3xl text-sm leading-6 text-muted-foreground'>
+                      Este flujo prepara la integración con el futuro microservicio{' '}
+                      <strong>gym-master-rag-coach</strong>. Por ahora usa el generador formal
+                      de Gym Master como respaldo seguro y deja listo el contrato para RAG.
+                    </p>
+                  </div>
+
+                  <div className='rounded-2xl border bg-background p-4 text-sm text-muted-foreground'>
+                    <p className='font-medium text-foreground'>Resultado esperado</p>
+                    <p>La rutina queda guardada en el menú Rutinas.</p>
+                  </div>
+                </div>
+              </section>
+
+              <div className='grid gap-6 lg:grid-cols-[1.15fr_0.85fr]'>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                      <MessageSquareText className='h-5 w-5 text-primary' />
+                      Entrevista rápida
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <form className='space-y-5' onSubmit={handleSubmit}>
+                      {usuarioEsAdmin && (
+                        <div className='rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200'>
+                          Estás ingresando como admin. Esta primera versión está orientada al socio
+                          logueado; para asignación administrativa avanzada se integrará luego con
+                          Gestor de Rutinas.
+                        </div>
+                      )}
+
+                      <div className='grid gap-4 md:grid-cols-3'>
+                        <div className='space-y-2'>
+                          <Label htmlFor='objetivo'>Objetivo</Label>
+                          <select
+                            id='objetivo'
+                            className='h-10 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            value={objetivo}
+                            onChange={(event) => setObjetivo(event.target.value)}
+                          >
+                            {objetivos.map((item) => (
+                              <option key={item.id_objetivo} value={String(item.id_objetivo)}>
+                                {item.nombre_objetivo}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+
+                        <div className='space-y-2'>
+                          <Label htmlFor='nivel'>Nivel</Label>
+                          <select
+                            id='nivel'
+                            className='h-10 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            value={nivel}
+                            onChange={(event) => setNivel(event.target.value)}
+                          >
+                            {niveles.map((item) => (
+                              <option key={item.id_nivel} value={String(item.id_nivel)}>
+                                {item.nombre_nivel}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+
+                        <div className='space-y-2'>
+                          <Label htmlFor='dias'>Días por semana</Label>
+                          <select
+                            id='dias'
+                            className='h-10 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            value={dias}
+                            onChange={(event) => setDias(Number(event.target.value))}
+                          >
+                            {DIAS_DISPONIBLES.map((item) => (
+                              <option key={item} value={item}>
+                                {item} {item === 1 ? 'día' : 'días'}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className='grid gap-4 md:grid-cols-[1fr_180px]'>
+                        <div className='space-y-2'>
+                          <Label htmlFor='mensaje'>Qué querés lograr o priorizar</Label>
+                          <textarea
+                            id='mensaje'
+                            className='min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            placeholder='Ejemplo: quiero ganar masa muscular, priorizar pecho y espalda, entrenar 6 días y no repetir exactamente mi rutina anterior.'
+                            value={mensajeSocio}
+                            maxLength={1200}
+                            onChange={(event) => setMensajeSocio(event.target.value)}
+                          />
+                        </div>
+
+                        <div className='space-y-2'>
+                          <Label htmlFor='idioma'>Idioma</Label>
+                          <select
+                            id='idioma'
+                            className='h-10 w-full rounded-md border border-input bg-background px-3 text-sm shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            value={idioma}
+                            onChange={(event) => setIdioma(event.target.value as 'es' | 'en')}
+                          >
+                            <option value='es'>Español</option>
+                            <option value='en'>English</option>
+                          </select>
+                        </div>
+                      </div>
+
+                      <div className='space-y-2'>
+                        <Label htmlFor='restricciones'>Restricciones o aclaraciones</Label>
+                        <Input
+                          id='restricciones'
+                          placeholder='Ejemplo: sin lesiones, evitar impacto, no tengo poleas, prefiero máquinas.'
+                          value={restricciones}
+                          maxLength={1200}
+                          onChange={(event) => setRestricciones(event.target.value)}
+                        />
+                      </div>
+
+                      <div className='flex flex-col gap-3 sm:flex-row sm:items-center'>
+                        <Button type='submit' disabled={usuarioEsAdmin || loading || objetivos.length === 0 || niveles.length === 0}>
+                          {loading ? (
+                            <>
+                              <Loader2 className='h-4 w-4 animate-spin' />
+                              Generando...
+                            </>
+                          ) : (
+                            <>
+                              <Sparkles className='h-4 w-4' />
+                              {usuarioEsAdmin ? 'Disponible para socio' : 'Generar rutina'}
+                            </>
+                          )}
+                        </Button>
+                        <Button type='button' variant='outline' asChild>
+                          <Link href='/dashboard/rutinas'>Ver mis rutinas</Link>
+                        </Button>
+                      </div>
+                    </form>
+                  </CardContent>
+                </Card>
+
+                <div className='space-y-6'>
+                  <Card>
+                    <CardHeader>
+                      <CardTitle>Parámetros actuales</CardTitle>
+                    </CardHeader>
+                    <CardContent className='space-y-3 text-sm'>
+                      <div className='rounded-2xl bg-muted p-4'>
+                        <p className='text-muted-foreground'>Objetivo</p>
+                        <p className='font-semibold'>{objetivoSeleccionado}</p>
+                      </div>
+                      <div className='rounded-2xl bg-muted p-4'>
+                        <p className='text-muted-foreground'>Nivel</p>
+                        <p className='font-semibold'>{nivelSeleccionado}</p>
+                      </div>
+                      <div className='rounded-2xl bg-muted p-4'>
+                        <p className='text-muted-foreground'>Frecuencia</p>
+                        <p className='font-semibold'>{dias} días por semana</p>
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  {result && (
+                    <Card className='border-green-200 bg-green-50 dark:border-green-900/60 dark:bg-green-950/20'>
+                      <CardHeader>
+                        <CardTitle className='flex items-center gap-2 text-green-800 dark:text-green-200'>
+                          <CheckCircle2 className='h-5 w-5' />
+                          Rutina generada
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className='space-y-4 text-sm text-green-900 dark:text-green-100'>
+                        <p>{result.mensajeFinal}</p>
+                        <div className='rounded-xl bg-background/80 p-3 text-muted-foreground'>
+                          <p>
+                            Modo: <strong>{result.modo === 'rag_bridge' ? 'RAG Coach' : 'Fallback local'}</strong>
+                          </p>
+                          <p>{result.resumen}</p>
+                          {result.ragError && <p>RAG externo: {result.ragError}</p>}
+                        </div>
+                        <Button asChild>
+                          <Link href='/dashboard/rutinas'>Ir al menú Rutinas</Link>
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  )}
+                </div>
+              </div>
+            </div>
+          </main>
+
+          <AppFooter />
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -35,6 +35,11 @@ export const sections: SidebarSectionType[] = [
         level: 2,
       },
       { title: 'Ficha Médica', link: '/dashboard/ficha-medica', level: 2 },
+      {
+        title: 'Asistente de Rutinas',
+        link: '/dashboard/rutinas/asistente',
+        level: 2,
+      },
     ],
   },
   {

--- a/src/interfaces/ragRutinasAssistant.interface.ts
+++ b/src/interfaces/ragRutinasAssistant.interface.ts
@@ -1,0 +1,37 @@
+export type RagRutinasIdioma = 'es' | 'en';
+
+export interface RagRutinasAssistantRequest {
+  objetivo: number;
+  nivel: number;
+  dias: number;
+  idioma?: RagRutinasIdioma;
+  mensajeSocio?: string;
+  restricciones?: string;
+  id_socio?: string;
+}
+
+export interface RagRutinasParametrosFinales {
+  objetivo: number;
+  nivel: number;
+  dias: number;
+  idioma: RagRutinasIdioma;
+}
+
+export interface RagRutinasAssistantResponseData {
+  modo: 'rag_bridge' | 'local_fallback';
+  ragConfigurado: boolean;
+  rutinaGenerada: unknown;
+  parametros: RagRutinasParametrosFinales;
+  mensajeFinal: string;
+  resumen: string;
+  advertencias: string[];
+  ragRespuesta?: unknown;
+  ragError?: string;
+}
+
+export interface RagRutinasAssistantApiResponse {
+  ok: boolean;
+  message?: string;
+  error?: string;
+  data?: RagRutinasAssistantResponseData;
+}

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -42,6 +42,13 @@ export const MENU_PERMISSION_GROUPS: Array<{
         roles: ['socio'],
       },
       {
+        key: 'Asistente de Rutinas',
+        label: 'Asistente de Rutinas',
+        path: '/dashboard/rutinas/asistente',
+        group: 'Menú personal / socio',
+        roles: ['socio', 'admin'],
+      },
+      {
         key: 'Pagar cuota',
         label: 'Pagar cuota',
         path: '/dashboard/mi-cuenta/pagar-cuota',
@@ -254,6 +261,7 @@ export const DEFAULT_MENU_PERMISSIONS_BY_ROLE: Record<AppRole, string[]> = {
     'Inicio',
     'Control de Asistencia',
     'Ficha Médica',
+    'Asistente de Rutinas',
     'Pagar cuota',
     'Historial de pagos',
     'Rutinas',

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1705,6 +1705,25 @@ const endpointDefinitions: EndpointDefinition[] = [
     "source": "src/app/api/swagger-json/route.ts"
   },
   {
+    "path": "/api/rutinas/rag-assistant/generar",
+    "methods": [
+      "POST"
+    ],
+    "tag": "Rutinas",
+    "summary": "Generar rutina desde asistente RAG",
+    "description": "Endpoint puente para el futuro gym-master-rag-coach. Si el microservicio RAG está configurado, consulta el servicio externo para sugerir parámetros; si no, usa fallback local con el generador formal de Gym Master. No expone claves en frontend.",
+    "auth": true,
+    "admin": false,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      401,
+      500
+    ],
+    "queryParams": [],
+    "source": "src/app/api/rutinas/rag-assistant/generar/route.ts"
+  },
+  {
     "path": "/api/rutinas/ejercicios-media",
     "methods": [
       "GET",

--- a/src/services/ragRutinasAssistantService.ts
+++ b/src/services/ragRutinasAssistantService.ts
@@ -1,0 +1,27 @@
+import {
+  RagRutinasAssistantApiResponse,
+  RagRutinasAssistantRequest,
+} from '@/interfaces/ragRutinasAssistant.interface';
+import { getToken } from './storageService';
+
+export async function generarRutinaConAsistente(
+  payload: RagRutinasAssistantRequest
+): Promise<RagRutinasAssistantApiResponse> {
+  const token = getToken();
+
+  const res = await fetch('/api/rutinas/rag-assistant/generar', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json().catch(() => ({}));
+
+  return {
+    ok: res.ok,
+    ...data,
+  };
+}


### PR DESCRIPTION
# feat: add routine RAG assistant bridge

## Resumen

Esta PR incorpora la primera base funcional del **Asistente de Rutinas** para Gym Master, preparando el frontend y backend de la aplicación para integrarse en el futuro con el microservicio externo `gym-master-rag-coach`.

La implementación agrega una pantalla inicial para socios y un endpoint puente seguro que puede comunicarse con un servicio RAG externo o, si no está configurado, utilizar un fallback local basado en el generador formal actual de Gym Master.

## Objetivo

Dejar Gym Master preparado para evolucionar hacia un asistente conversacional que pueda entrevistar al socio, interpretar sus necesidades, generar una rutina compatible con la base real de ejercicios y guardarla formalmente en el sistema.

## Cambios principales

### Nueva pantalla del asistente

Se agrega la ruta:

```txt
/dashboard/rutinas/asistente
```

La pantalla permite al socio iniciar una generación asistida de rutina con una primera entrevista guiada.

### Nuevo endpoint puente

Se agrega el endpoint:

```txt
POST /api/rutinas/rag-assistant/generar
```

Este endpoint centraliza la lógica para:

- recibir los datos del socio y su solicitud;
- preparar el payload compatible con el futuro RAG;
- intentar consultar `gym-master-rag-coach` si está configurado;
- usar fallback local si el servicio externo no está disponible;
- guardar la rutina generada formalmente en Gym Master;
- devolver un mensaje final amigable para el socio.

### Fallback local seguro

Si no existen variables de entorno para el microservicio RAG, la app no falla. En ese caso se utiliza el generador actual de rutinas como fallback local.

Esto permite que la feature sea funcional desde ahora, sin bloquear el avance hasta que exista el repositorio externo `gym-master-rag-coach`.

## Variables de entorno agregadas

Se actualiza `.env.example` con:

```env
GYM_MASTER_RAG_COACH_URL=
GYM_MASTER_RAG_COACH_API_KEY=
GYM_MASTER_RAG_COACH_GENERATE_PATH=/api/v1/routines/generate
```

## Archivos principales

```txt
.env.example
src/interfaces/ragRutinasAssistant.interface.ts
src/services/ragRutinasAssistantService.ts
src/app/api/rutinas/rag-assistant/generar/route.ts
src/app/dashboard/rutinas/asistente/page.tsx
src/components/sidebar/sidebarConfig.ts
src/lib/permissions/menuPermissions.ts
src/lib/swagger/openApiSpec.ts
docs/rag-rutinas/README.md
docs/rag-rutinas/rag-rutinas-assistant-bridge.md
```

## Seguridad y arquitectura

La implementación mantiene las claves y comunicación con el RAG fuera del frontend.

El flujo recomendado queda preparado así:

```txt
Socio → Gym Master Frontend → API interna Gym Master → gym-master-rag-coach → validación/guardado en Gym Master
```

No se exponen claves de OpenAI, service role ni credenciales del microservicio en el navegador.

## Documentación

Se agrega documentación técnica en:

```txt
docs/rag-rutinas/rag-rutinas-assistant-bridge.md
```

También se actualiza Swagger/OpenAPI para documentar el nuevo endpoint puente.

## Pruebas realizadas

Se validó:

- acceso a `/dashboard/rutinas/asistente`;
- generación de rutina desde la pantalla del asistente;
- funcionamiento del fallback local;
- guardado de rutina en Gym Master;
- navegación posterior hacia el menú Rutinas;
- build local exitoso.

```bash
npm run build
```

## Notas futuras

La versión actual usa una entrevista guiada inicial. La evolución prevista es llevar el asistente a una experiencia más conversacional, donde el socio pueda hablar naturalmente con el sistema y el asistente infiera objetivo, nivel, días, preferencias y restricciones, preguntando solo lo necesario.

También queda prevista una futura entrada por voz para socios que prefieran dictar en lugar de escribir.
