### PR TITLE
feat: add expenses receipts flow

### DIFF
--- a/docs/comercial/compras-proveedores-stock-fixes-frontend.md
+++ b/docs/comercial/compras-proveedores-stock-fixes-frontend.md
@@ -1,0 +1,39 @@
+# Fix frontend — Compras, gastos y descargas PDF
+
+## Rama
+
+`feature/compras-proveedores-stock`
+
+## Alcance
+
+Se incorporaron ajustes de QA detectados durante la validación funcional del circuito comercial:
+
+- Filtro adicional por rango de fecha `desde` / `hasta` en `QA: src/app/dashboard/otros-gastos/page.tsx`.
+- Card de acceso directo a `Gastos / Egresos` desde `QA: src/app/dashboard/comercial/page.tsx`.
+- Helper central para nombres de archivos descargables con timestamp.
+- PDFs generados desde frontend con nombre en formato:
+
+```txt
+YYYYMMDD-HHMM-tipo-de-documento.pdf
+```
+
+## Criterios
+
+- La base de datos mantiene las fechas en formato técnico.
+- Los inputs `type="date"` conservan `YYYY-MM-DD` porque es requerido por HTML.
+- La presentación visible y reportes usan formato de frontend consistente.
+- Los PDFs descargados quedan trazables por fecha, hora y tipo de reporte.
+
+## Archivos principales
+
+- `src/app/dashboard/otros-gastos/page.tsx`
+- `src/app/dashboard/comercial/page.tsx`
+- `src/utils/downloadFileName.ts`
+- `src/utils/commercialReportPdf.ts`
+- `src/utils/dietaPdf.ts`
+- `src/utils/rutinaPdf.ts`
+- `src/utils/evolucionFisicaPdf.ts`
+- `src/utils/pagoReciboPdf.ts`
+- `src/app/dashboard/dietas/page.tsx`
+- `src/components/modal/DietasViewModal.tsx`
+- `src/components/modal/RutinaModalView.tsx`

--- a/docs/comercial/frontend-excel-download-filenames-timestamp.md
+++ b/docs/comercial/frontend-excel-download-filenames-timestamp.md
@@ -1,0 +1,46 @@
+# Fix frontend - nombres de descarga Excel con timestamp
+
+## Objetivo
+
+Estandarizar los nombres de archivos Excel descargados desde el frontend para que sigan el mismo criterio aplicado a PDFs.
+
+## Formato aplicado
+
+```txt
+YYYYMMDD-HHMM-tipo-de-listado.xlsx
+```
+
+Ejemplos:
+
+```txt
+20260531-0845-listado-gastos-egresos.xlsx
+20260531-0845-listado-compras-proveedores.xlsx
+20260531-0845-listado-productos.xlsx
+```
+
+## Alcance
+
+Se actualizan las exportaciones Excel de los principales listados administrativos y comerciales:
+
+- Actividades
+- Asistencias
+- Compras
+- Cuotas
+- Entrenadores
+- Equipamientos
+- Evolución Física
+- Gastos / Egresos
+- Pagos
+- Productos
+- Proveedores
+- Servicios
+- Socios
+- Usuarios
+- Ventas
+- Detalles de venta
+
+## Notas técnicas
+
+- No modifica base de datos.
+- No requiere migración.
+- Reutiliza `buildTimestampedDownloadFileName` desde `src/utils/downloadFileName.ts`.

--- a/docs/comercial/gastos-egresos-comprobantes-gym.md
+++ b/docs/comercial/gastos-egresos-comprobantes-gym.md
@@ -1,0 +1,43 @@
+# Gastos / egresos con comprobantes
+
+## Objetivo
+
+Evolucionar el módulo legacy `Otros gastos` hacia un módulo operativo de gastos y egresos para Gym Master.
+
+## Alcance
+
+- Clasificación por `tipo_gasto` parametrizable.
+- Estado del gasto: pendiente, pagado, vencido o anulado.
+- Medio de pago.
+- Proveedor / entidad.
+- Número de comprobante.
+- Carga de comprobante PDF o imagen vía Cloudinary.
+- URL de comprobante externa.
+- Fecha de gasto, vencimiento y pago.
+- Período cubierto desde / hasta.
+- Observaciones internas.
+- Anulación lógica.
+- Exportación Excel.
+- PDF membretado Gym Master.
+
+## Flujo técnico
+
+1. Validar migración local contra DB QA restaurada desde dump.
+2. Ejecutar `database/scripts/validar_gastos_egresos_comprobantes_gym.sql` local.
+3. Backup remoto previo.
+4. Aplicar `npx supabase db push`.
+5. Refrescar schema cache remoto.
+6. Validar en Supabase Studio con el script de validación.
+7. Probar `/dashboard/otros-gastos`.
+
+## Archivos principales
+
+- `src/app/dashboard/otros-gastos/page.tsx`
+- `src/app/api/otros_gastos/route.ts`
+- `src/app/api/otros_gastos/comprobante-upload/route.ts`
+- `src/components/forms/OtrosGastosForm.tsx`
+- `src/components/modal/OtrosGastosModal.tsx`
+- `src/components/modal/OtrosGastosViewModal.tsx`
+- `src/components/tables/OtrosGastosTable.tsx`
+- `src/services/otrosGastosService.ts`
+- `src/interfaces/otros_gastos.interface.ts`

--- a/src/app/api/otros_gastos/comprobante-upload/route.ts
+++ b/src/app/api/otros_gastos/comprobante-upload/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { uploadFileCloudinary } from '@/lib/cloudinary';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const VALID_TYPES = /^(application\/pdf|image\/(png|jpe?g|webp|gif|heic|heif))$/i;
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authMiddleware(request);
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json(
+        { error: 'No se recibió ningún comprobante.' },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json(
+        { error: 'El comprobante debe ser menor a 10MB.' },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_TYPES.test(file.type)) {
+      return NextResponse.json(
+        { error: 'Formato no válido. Usá PDF, PNG, JPG, WEBP, GIF, HEIC o HEIF.' },
+        { status: 400 }
+      );
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const folder = `gastos/comprobantes/${user?.id ?? 'admin'}`;
+    const url = await uploadFileCloudinary(buffer, file.name, folder);
+
+    if (!url) {
+      return NextResponse.json(
+        { error: 'Error al subir el comprobante.' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        data: {
+          url,
+          originalName: file.name,
+          mimeType: file.type,
+          size: file.size,
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error: any) {
+    const message = error?.message || 'Error al subir comprobante.';
+    const status =
+      message.includes('Token no proporcionado') || message.includes('Token inválido')
+        ? 401
+        : 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/otros_gastos/route.ts
+++ b/src/app/api/otros_gastos/route.ts
@@ -1,50 +1,285 @@
-import { createOtrosGastos, deleteOtrosGastos, getAllOtrosGastos, updateOtrosGastos } from "@/services/otrosGastosService";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { conexionBD } from '@/middlewares/conexionBd.middleware';
+import {
+  OtrosGastosEstado,
+  OtrosGastosMedioPago,
+} from '@/interfaces/otros_gastos.interface';
 
-export async function GET() {
+export const dynamic = 'force-dynamic';
+
+const estadosValidos: OtrosGastosEstado[] = ['pendiente', 'pagado', 'vencido', 'anulado'];
+const mediosPagoValidos: OtrosGastosMedioPago[] = [
+  'efectivo',
+  'transferencia',
+  'tarjeta_debito',
+  'tarjeta_credito',
+  'mercado_pago',
+  'stripe',
+  'otro',
+];
+
+function parseText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const text = value.trim();
+  return text.length ? text : null;
+}
+
+function parseDate(value: unknown): string | null {
+  const text = parseText(value);
+  if (!text) return null;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+    throw new Error('Formato de fecha inválido. Usá YYYY-MM-DD.');
+  }
+  return text;
+}
+
+function parseMoney(value: unknown, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} debe ser mayor a 0`);
+  }
+  return Math.round(parsed * 100) / 100;
+}
+
+function normalizeEstado(value: unknown): OtrosGastosEstado {
+  return estadosValidos.includes(value as OtrosGastosEstado)
+    ? (value as OtrosGastosEstado)
+    : 'pagado';
+}
+
+function normalizeMedioPago(value: unknown): OtrosGastosMedioPago {
+  return mediosPagoValidos.includes(value as OtrosGastosMedioPago)
+    ? (value as OtrosGastosMedioPago)
+    : 'efectivo';
+}
+
+function buildPayload(body: Record<string, unknown>, mode: 'create' | 'update') {
+  const payload: Record<string, unknown> = {};
+
+  const descripcion = parseText(body.descripcion);
+  if (mode === 'create' && !descripcion) {
+    throw new Error('La descripción es obligatoria');
+  }
+  if (descripcion || mode === 'create') payload.descripcion = descripcion;
+
+  if ('monto' in body || mode === 'create') {
+    payload.monto = parseMoney(body.monto, 'El monto');
+  }
+
+  if ('fecha' in body || mode === 'create') {
+    const fecha = parseDate(body.fecha);
+    if (!fecha) throw new Error('La fecha es obligatoria');
+    payload.fecha = fecha;
+  }
+
+  if ('id_tipo_gasto' in body || mode === 'create') {
+    payload.id_tipo_gasto = parseText(body.id_tipo_gasto);
+  }
+
+  if ('estado' in body || mode === 'create') {
+    payload.estado = normalizeEstado(body.estado);
+  }
+
+  if ('medio_pago' in body || mode === 'create') {
+    payload.medio_pago = normalizeMedioPago(body.medio_pago);
+  }
+
+  if ('proveedor_nombre' in body || mode === 'create') {
+    payload.proveedor_nombre = parseText(body.proveedor_nombre);
+  }
+
+  if ('entidad' in body || mode === 'create') {
+    payload.entidad = parseText(body.entidad);
+  }
+
+  if ('numero_comprobante' in body || mode === 'create') {
+    payload.numero_comprobante = parseText(body.numero_comprobante);
+  }
+
+  if ('comprobante_url' in body || mode === 'create') {
+    payload.comprobante_url = parseText(body.comprobante_url);
+  }
+
+  if ('comprobante_nombre' in body || mode === 'create') {
+    payload.comprobante_nombre = parseText(body.comprobante_nombre);
+  }
+
+  if ('comprobante_mime_type' in body || mode === 'create') {
+    payload.comprobante_mime_type = parseText(body.comprobante_mime_type);
+  }
+
+  if ('fecha_vencimiento' in body || mode === 'create') {
+    payload.fecha_vencimiento = parseDate(body.fecha_vencimiento);
+  }
+
+  if ('fecha_pago' in body || mode === 'create') {
+    payload.fecha_pago = parseDate(body.fecha_pago);
+  }
+
+  if ('periodo_desde' in body || mode === 'create') {
+    payload.periodo_desde = parseDate(body.periodo_desde);
+  }
+
+  if ('periodo_hasta' in body || mode === 'create') {
+    payload.periodo_hasta = parseDate(body.periodo_hasta);
+  }
+
+  if ('observaciones' in body || mode === 'create') {
+    payload.observaciones = parseText(body.observaciones);
+  }
+
+  if ('activo' in body) {
+    payload.activo = body.activo !== false;
+  }
+
+  payload.actualizado_en = new Date().toISOString();
+
+  return payload;
+}
+
+async function fetchGastoById(supabase: ReturnType<typeof conexionBD>, id: string) {
+  const { data, error } = await supabase
+    .from('otros_gastos')
+    .select(`
+      *,
+      tipo_gasto:id_tipo_gasto(id, codigo, nombre, descripcion, activo)
+    `)
+    .eq('id', id)
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function GET(req: NextRequest) {
   try {
-    const gastos = await getAllOtrosGastos();
-    return NextResponse.json({ data: gastos }, { status: 200 });
+    await authMiddleware(req);
+    const supabase = conexionBD();
+    const { searchParams } = new URL(req.url);
+    const estado = searchParams.get('estado');
+    const tipoGastoId = searchParams.get('id_tipo_gasto');
+
+    let query = supabase
+      .from('otros_gastos')
+      .select(`
+        *,
+        tipo_gasto:id_tipo_gasto(id, codigo, nombre, descripcion, activo)
+      `)
+      .order('fecha', { ascending: false })
+      .order('creado_en', { ascending: false });
+
+    query = query.neq('activo', false);
+
+    if (estado && estadosValidos.includes(estado as OtrosGastosEstado)) {
+      query = query.eq('estado', estado);
+    }
+
+    if (tipoGastoId) {
+      query = query.eq('id_tipo_gasto', tipoGastoId);
+    }
+
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+
+    return NextResponse.json({ data: data ?? [] }, { status: 200 });
   } catch (error: any) {
-    return NextResponse.json({ error: "Error al obtener los gastos" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al obtener los gastos' },
+      { status: 500 }
+    );
   }
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
+    const { user } = await authMiddleware(req);
+    const supabase = conexionBD();
     const body = await req.json();
-    if (!body.descripcion || !body.monto || !body.fecha) {
-      return NextResponse.json({ error: "Todos los campos son obligatorios" }, { status: 400 });
-    }
-    const gasto = await createOtrosGastos(body);
-    return NextResponse.json({ message: "Gasto creado con éxito", data: gasto }, { status: 201 });
+    const payload = buildPayload(body, 'create');
+
+    payload.activo = true;
+    payload.registrado_por = user?.id ?? null;
+
+    const { data, error } = await supabase
+      .from('otros_gastos')
+      .insert(payload)
+      .select(`
+        *,
+        tipo_gasto:id_tipo_gasto(id, codigo, nombre, descripcion, activo)
+      `)
+      .single();
+
+    if (error) throw new Error(error.message);
+
+    return NextResponse.json({ message: 'Gasto creado con éxito', data }, { status: 201 });
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || "Error al crear el gasto" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al crear el gasto' },
+      { status: 500 }
+    );
   }
 }
 
-export async function PUT(req: Request) {
-  const { id, updateData } = await req.json();
+export async function PUT(req: NextRequest) {
   try {
-    if (!id || typeof id !== "string") {
-      return NextResponse.json({ error: "ID inválido para actualizar" }, { status: 400 });
+    await authMiddleware(req);
+    const supabase = conexionBD();
+    const { id, updateData } = await req.json();
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 });
     }
-    const gastoModificado = await updateOtrosGastos(id, updateData);
-    return NextResponse.json({ message: "Gasto actualizado con éxito", data: gastoModificado }, { status: 200 });
+
+    const payload = buildPayload(updateData ?? {}, 'update');
+
+    const { error } = await supabase
+      .from('otros_gastos')
+      .update(payload)
+      .eq('id', id)
+      .neq('activo', false);
+
+    if (error) throw new Error(error.message);
+
+    const gasto = await fetchGastoById(supabase, id);
+    return NextResponse.json(
+      { message: 'Gasto actualizado con éxito', data: gasto },
+      { status: 200 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || "Error al actualizar gasto" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al actualizar gasto' },
+      { status: 500 }
+    );
   }
 }
 
-export async function DELETE(req: Request) {
-  const { id } = await req.json();
+export async function DELETE(req: NextRequest) {
   try {
-    if (!id || typeof id !== "string") {
-      return NextResponse.json({ error: "ID inválido para eliminar" }, { status: 400 });
+    await authMiddleware(req);
+    const supabase = conexionBD();
+    const { id } = await req.json();
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'ID inválido para eliminar' }, { status: 400 });
     }
-    await deleteOtrosGastos(id);
-    return NextResponse.json({ message: "Gasto eliminado con éxito" }, { status: 200 });
+
+    const { error } = await supabase
+      .from('otros_gastos')
+      .update({ activo: false, estado: 'anulado', actualizado_en: new Date().toISOString() })
+      .eq('id', id);
+
+    if (error) throw new Error(error.message);
+
+    const gasto = await fetchGastoById(supabase, id);
+    return NextResponse.json(
+      { message: 'Gasto eliminado con éxito', data: gasto },
+      { status: 200 }
+    );
   } catch (error: any) {
-    return NextResponse.json({ error: error.message || "Error al eliminar gasto" }, { status: 500 });
+    return NextResponse.json(
+      { error: error.message || 'Error al eliminar gasto' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/dashboard/actividades/page.tsx
+++ b/src/app/dashboard/actividades/page.tsx
@@ -21,6 +21,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { PaginationControls } from "@/components/ui/PaginationControls";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
@@ -110,7 +111,7 @@ export default function ActividadesPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Actividades.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-actividades", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/asistencias/page.tsx
+++ b/src/app/dashboard/asistencias/page.tsx
@@ -22,6 +22,7 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import { formatFrontendTime } from '@/utils/dateFormat';
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { JwtUser } from "@/interfaces/jwtUser.interface";
 
@@ -155,7 +156,7 @@ export default function AsistenciasPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Asistencias.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-asistencias", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/comercial/page.tsx
+++ b/src/app/dashboard/comercial/page.tsx
@@ -272,6 +272,12 @@ export default function ComercialKioscoPage() {
                 icon={ShoppingCart}
               />
               <ActionCard
+                title='Gastos / Egresos'
+                description='Registrá egresos operativos, vencimientos, medios de pago y comprobantes para alimentar el BI financiero.'
+                href='/dashboard/otros-gastos'
+                icon={ClipboardList}
+              />
+              <ActionCard
                 title='Servicios adicionales'
                 description='Servicios parametrizables como masajes, cama solar o sesiones especiales para socios y no socios.'
                 href='/dashboard/servicios'

--- a/src/app/dashboard/compras/page.tsx
+++ b/src/app/dashboard/compras/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ExcelJS from 'exceljs';
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { toast } from 'sonner';
 import { FileSpreadsheet, FileText, Plus, Search, ShoppingBag, Store } from 'lucide-react';
 import { AppHeader } from '@/components/header/AppHeader';
@@ -150,7 +151,7 @@ export default function ComprasPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'Listado_Compras_Proveedores.xlsx';
+    a.download = buildTimestampedDownloadFileName('listado-compras-proveedores', 'xlsx');
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/cuotas/page.tsx
+++ b/src/app/dashboard/cuotas/page.tsx
@@ -18,6 +18,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -121,7 +122,7 @@ export default function CuotasPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Cuotas.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-cuotas", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/dietas/page.tsx
+++ b/src/app/dashboard/dietas/page.tsx
@@ -13,6 +13,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import DietaHistorial from "@/components/tables/DietaHistorial";
 import DietaForm from "@/components/forms/DietaForm";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 
 export default function DietasPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } =
@@ -65,7 +66,7 @@ export default function DietasPage() {
           },
           pageOrientation: "landscape",
         })
-        .download("Historial_Dietas.pdf");
+        .download(buildTimestampedDownloadFileName("historial-dietas", "pdf"));
     });
   };
 

--- a/src/app/dashboard/entrenadores/page.tsx
+++ b/src/app/dashboard/entrenadores/page.tsx
@@ -16,6 +16,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { Entrenador } from "@/interfaces/entrenador.interface";
 import { getEntrenadores } from "@/services/apiClient";
 
@@ -90,7 +91,7 @@ export default function EntrenadoresPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Entrenadores.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-entrenadores", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/equipamientos/page.tsx
+++ b/src/app/dashboard/equipamientos/page.tsx
@@ -28,6 +28,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { AppHeader } from "@/components/header/AppHeader";
 import { AppFooter } from "@/components/footer/AppFooter";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 
 export default function EquipamientosPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } =
@@ -153,7 +154,7 @@ export default function EquipamientosPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Equipamientos.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-equipamientos", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/evolucion-fisica/page.tsx
+++ b/src/app/dashboard/evolucion-fisica/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { Download, FileSpreadsheet, Search } from "lucide-react";
 import { toast } from "sonner";
 import { AppFooter } from "@/components/footer/AppFooter";
@@ -396,7 +397,7 @@ export default function EvolucionFisicaPage() {
     const a = document.createElement("a");
 
     a.href = url;
-    a.download = "Evolucion_Fisica.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-evolucion-fisica", "xlsx");
     a.click();
 
     window.URL.revokeObjectURL(url);

--- a/src/app/dashboard/otros-gastos/page.tsx
+++ b/src/app/dashboard/otros-gastos/page.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
+import { toast } from "sonner";
+import { FileSpreadsheet, FileText, Plus, ReceiptText, Search } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { AppHeader } from "@/components/header/AppHeader";
 import { AppFooter } from "@/components/footer/AppFooter";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Printer, FileSpreadsheet } from "lucide-react";
+import { PaginationControls } from "@/components/ui/PaginationControls";
 import {
   getAllOtrosGastos,
   deleteOtrosGastos,
@@ -16,19 +20,44 @@ import {
 import OtrosGastosModal from "@/components/modal/OtrosGastosModal";
 import OtrosGastosViewModal from "@/components/modal/OtrosGastosViewModal";
 import OtrosGastosTable from "@/components/tables/OtrosGastosTable";
-import { OtrosGastos } from "@/interfaces/otros_gastos.interface";
+import { OtrosGastos, OtrosGastosEstado } from "@/interfaces/otros_gastos.interface";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
-import { toast } from "sonner";
-import ExcelJS from "exceljs";
+import { formatCurrencyARS } from "@/lib/comercial/productos";
+import { formatFrontendDate } from "@/utils/dateFormat";
+import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
+
+const PAGE_SIZE = 10;
+type EstadoFilter = "todos" | OtrosGastosEstado;
+
+function estadoLabel(estado: EstadoFilter) {
+  if (estado === "todos") return "Todos";
+  return estado.charAt(0).toUpperCase() + estado.slice(1);
+}
+
+function getTipoNombre(gasto: OtrosGastos) {
+  return gasto.tipo_gasto?.nombre ?? "Sin clasificar";
+}
+
+function getDateOnlyTime(value?: string | null) {
+  if (!value) return null;
+
+  const raw = String(value).slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null;
+
+  const time = new Date(`${raw}T00:00:00`).getTime();
+  return Number.isNaN(time) ? null : time;
+}
 
 export default function OtrosGastosPage() {
-  const { user, isAuthenticated, initializeAuth, isInitialized } =
-    useAuthStore();
+  const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
   const [gastos, setGastos] = useState<OtrosGastos[]>([]);
-  const [filteredGastos, setFilteredGastos] = useState<OtrosGastos[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
+  const [estadoFilter, setEstadoFilter] = useState<EstadoFilter>("todos");
+  const [fechaDesde, setFechaDesde] = useState("");
+  const [fechaHasta, setFechaHasta] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [openModal, setOpenModal] = useState(false);
   const [selectedGasto, setSelectedGasto] = useState<OtrosGastos | null>(null);
@@ -47,31 +76,123 @@ export default function OtrosGastosPage() {
 
   const loadGastos = async () => {
     setLoading(true);
-    const data = await getAllOtrosGastos();
-    setGastos(data ?? []);
-    setFilteredGastos(data ?? []);
-    setLoading(false);
+    try {
+      const data = await getAllOtrosGastos();
+      setGastos(data ?? []);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handlePrint = () => {
-    window.print();
-  };
+  useEffect(() => {
+    if (isInitialized && isAuthenticated) {
+      loadGastos();
+    }
+  }, [isInitialized, isAuthenticated]);
+
+  const filteredGastos = useMemo(() => {
+    const lowercaseSearch = searchTerm.trim().toLowerCase();
+    const desdeTime = getDateOnlyTime(fechaDesde);
+    const hastaTime = getDateOnlyTime(fechaHasta);
+
+    return gastos.filter((gasto) => {
+      const matchesEstado = estadoFilter === "todos" || gasto.estado === estadoFilter;
+      const gastoTime = getDateOnlyTime(gasto.fecha);
+      const matchesFechaDesde = !desdeTime || (gastoTime !== null && gastoTime >= desdeTime);
+      const matchesFechaHasta = !hastaTime || (gastoTime !== null && gastoTime <= hastaTime);
+      const searchable = [
+        gasto.descripcion,
+        getTipoNombre(gasto),
+        gasto.proveedor_nombre,
+        gasto.entidad,
+        gasto.numero_comprobante,
+        gasto.medio_pago,
+        gasto.estado,
+        gasto.fecha,
+        gasto.fecha_vencimiento,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+
+      return (
+        matchesEstado &&
+        matchesFechaDesde &&
+        matchesFechaHasta &&
+        (!lowercaseSearch || searchable.includes(lowercaseSearch))
+      );
+    });
+  }, [estadoFilter, fechaDesde, fechaHasta, gastos, searchTerm]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchTerm, estadoFilter, fechaDesde, fechaHasta]);
+
+  const paginatedGastos = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return filteredGastos.slice(start, start + PAGE_SIZE);
+  }, [currentPage, filteredGastos]);
+
+  const metrics = useMemo(() => {
+    const activos = gastos.filter((gasto) => gasto.activo !== false && gasto.estado !== "anulado");
+    const total = activos.reduce((acc, gasto) => acc + Number(gasto.monto ?? 0), 0);
+    const pendientes = activos.filter((gasto) => gasto.estado === "pendiente");
+    const vencidos = activos.filter((gasto) => gasto.estado === "vencido");
+    const conComprobante = activos.filter((gasto) => Boolean(gasto.comprobante_url));
+
+    return {
+      total: formatCurrencyARS(total),
+      activos: activos.length,
+      pendientes: pendientes.length,
+      vencidos: vencidos.length,
+      conComprobante: conComprobante.length,
+    };
+  }, [gastos]);
+
+  const filtersLabel = [
+    `Estado: ${estadoLabel(estadoFilter)}`,
+    fechaDesde ? `Desde: ${formatFrontendDate(fechaDesde)}` : null,
+    fechaHasta ? `Hasta: ${formatFrontendDate(fechaHasta)}` : null,
+    searchTerm ? `Búsqueda: ${searchTerm}` : null,
+  ]
+    .filter(Boolean)
+    .join(" | ");
 
   const handleExportExcel = async () => {
     const workbook = new ExcelJS.Workbook();
-    const worksheet = workbook.addWorksheet("Otros Gastos");
+    const worksheet = workbook.addWorksheet("Gastos");
 
     worksheet.columns = [
-      { header: "Descripción", key: "descripcion", width: 40 },
-      { header: "Monto", key: "monto", width: 15 },
-      { header: "Fecha", key: "fecha", width: 20 },
+      { header: "Descripción", key: "descripcion", width: 38 },
+      { header: "Tipo", key: "tipo", width: 22 },
+      { header: "Entidad", key: "entidad", width: 24 },
+      { header: "Estado", key: "estado", width: 14 },
+      { header: "Medio de pago", key: "medio_pago", width: 18 },
+      { header: "Monto", key: "monto", width: 16 },
+      { header: "Fecha", key: "fecha", width: 14 },
+      { header: "Vencimiento", key: "fecha_vencimiento", width: 14 },
+      { header: "Fecha pago", key: "fecha_pago", width: 14 },
+      { header: "Período desde", key: "periodo_desde", width: 14 },
+      { header: "Período hasta", key: "periodo_hasta", width: 14 },
+      { header: "Comprobante", key: "comprobante", width: 35 },
+      { header: "Observaciones", key: "observaciones", width: 35 },
     ];
 
     filteredGastos.forEach((g) => {
       worksheet.addRow({
         descripcion: g.descripcion,
-        monto: g.monto,
-        fecha: g.fecha,
+        tipo: getTipoNombre(g),
+        entidad: g.proveedor_nombre || g.entidad || "-",
+        estado: g.estado ?? "-",
+        medio_pago: g.medio_pago?.replace(/_/g, " ") ?? "-",
+        monto: Number(g.monto ?? 0),
+        fecha: formatFrontendDate(g.fecha),
+        fecha_vencimiento: g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-",
+        fecha_pago: g.fecha_pago ? formatFrontendDate(g.fecha_pago) : "-",
+        periodo_desde: g.periodo_desde ? formatFrontendDate(g.periodo_desde) : "-",
+        periodo_hasta: g.periodo_hasta ? formatFrontendDate(g.periodo_hasta) : "-",
+        comprobante: g.comprobante_url ?? "-",
+        observaciones: g.observaciones ?? "-",
       });
     });
 
@@ -82,32 +203,38 @@ export default function OtrosGastosPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Otros_Gastos.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-gastos-egresos", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };
 
-  useEffect(() => {
-    if (isInitialized && isAuthenticated) {
-      loadGastos();
-    }
-  }, [isInitialized, isAuthenticated]);
-
-  useEffect(() => {
-    if (searchTerm.trim() === "") {
-      setFilteredGastos(gastos);
-      return;
-    }
-
-    const lowercaseSearch = searchTerm.toLowerCase();
-    const filtered = gastos.filter(
-      (g) =>
-        g.descripcion.toLowerCase().includes(lowercaseSearch) ||
-        g.fecha.toLowerCase().includes(lowercaseSearch)
-    );
-
-    setFilteredGastos(filtered);
-  }, [searchTerm, gastos]);
+  const handleDownloadPdf = async () => {
+    await downloadCommercialReportPdf<OtrosGastos>({
+      title: "Listado de Gastos / Egresos",
+      subtitle: "Control operativo de egresos del gimnasio",
+      fileName: "listado-gastos-egresos",
+      rows: filteredGastos,
+      filtersLabel,
+      metrics: [
+        { label: "Total", value: metrics.total },
+        { label: "Activos", value: metrics.activos },
+        { label: "Pendientes", value: metrics.pendientes },
+        { label: "Vencidos", value: metrics.vencidos },
+        { label: "Con comprobante", value: metrics.conComprobante },
+      ],
+      columns: [
+        { header: "Descripción", width: 34, getValue: (g) => g.descripcion },
+        { header: "Tipo", width: 22, getValue: (g) => getTipoNombre(g) },
+        { header: "Entidad", width: 24, getValue: (g) => g.proveedor_nombre || g.entidad || "-" },
+        { header: "Estado", width: 16, getValue: (g) => g.estado ?? "-" },
+        { header: "Medio", width: 18, getValue: (g) => g.medio_pago?.replace(/_/g, " ") ?? "-" },
+        { header: "Monto", width: 20, align: "right", getValue: (g) => formatCurrencyARS(Number(g.monto ?? 0)) },
+        { header: "Fecha", width: 16, getValue: (g) => formatFrontendDate(g.fecha) },
+        { header: "Venc.", width: 16, getValue: (g) => g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-" },
+        { header: "Comp.", width: 18, getValue: (g) => g.numero_comprobante ?? "-" },
+      ],
+    });
+  };
 
   if (!isInitialized) {
     return <div>Cargando...</div>;
@@ -119,75 +246,171 @@ export default function OtrosGastosPage() {
 
   return (
     <SidebarProvider>
-      <div className="flex w-full min-h-screen">
+      <div className="flex min-h-screen w-full">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Otros Gastos" />
-          <main className="flex-1 p-6 space-y-6">
+          <AppHeader title="Gastos / Egresos" />
+          <main className="flex-1 space-y-6 p-6">
+            <section className="grid grid-cols-1 gap-4 md:grid-cols-5">
+              <Card>
+                <CardContent className="p-5">
+                  <p className="text-sm text-muted-foreground">Total egresos</p>
+                  <p className="text-2xl font-bold">{metrics.total}</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-5">
+                  <p className="text-sm text-muted-foreground">Activos</p>
+                  <p className="text-2xl font-bold">{metrics.activos}</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-5">
+                  <p className="text-sm text-muted-foreground">Pendientes</p>
+                  <p className="text-2xl font-bold text-amber-600">{metrics.pendientes}</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-5">
+                  <p className="text-sm text-muted-foreground">Vencidos</p>
+                  <p className="text-2xl font-bold text-red-600">{metrics.vencidos}</p>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="p-5">
+                  <p className="text-sm text-muted-foreground">Comprobantes</p>
+                  <p className="text-2xl font-bold text-sky-600">{metrics.conComprobante}</p>
+                </CardContent>
+              </Card>
+            </section>
+
             <Card className="w-full">
-              <CardHeader className="flex flex-wrap gap-4 justify-between items-center p-4 border-b md:flex-nowrap">
-                <h2 className="text-xl font-bold">Listado de Otros Gastos</h2>
-                <div className="flex flex-wrap gap-2 items-center w-full md:w-auto">
+              <CardHeader className="flex flex-wrap items-center justify-between gap-4 border-b p-4 md:flex-nowrap">
+                <div>
+                  <h2 className="text-xl font-bold">Listado de Gastos / Egresos</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Registrá gastos operativos, vencimientos, medios de pago y comprobantes.
+                  </p>
+                </div>
+                <div className="flex w-full flex-wrap items-center gap-2 md:w-auto">
+                  <select
+                    value={estadoFilter}
+                    onChange={(event) => setEstadoFilter(event.target.value as EstadoFilter)}
+                    className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  >
+                    <option value="todos">Todos</option>
+                    <option value="pagado">Pagados</option>
+                    <option value="pendiente">Pendientes</option>
+                    <option value="vencido">Vencidos</option>
+                    <option value="anulado">Anulados</option>
+                  </select>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      type="date"
+                      aria-label="Fecha desde"
+                      title="Fecha desde"
+                      value={fechaDesde}
+                      onChange={(event) => setFechaDesde(event.target.value)}
+                      className="w-[150px]"
+                    />
+                    <Input
+                      type="date"
+                      aria-label="Fecha hasta"
+                      title="Fecha hasta"
+                      value={fechaHasta}
+                      onChange={(event) => setFechaHasta(event.target.value)}
+                      className="w-[150px]"
+                    />
+                    {(fechaDesde || fechaHasta) && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => {
+                          setFechaDesde("");
+                          setFechaHasta("");
+                        }}
+                        className="h-10 px-2 text-xs"
+                      >
+                        Limpiar
+                      </Button>
+                    )}
+                  </div>
                   <div className="relative flex-grow md:flex-grow-0">
-                    <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
                       type="search"
-                      placeholder="Buscar por descripción, fecha..."
-                      className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
+                      placeholder="Buscar gasto, tipo, entidad, comprobante..."
+                      className="w-full pl-8 sm:w-[320px]"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
                     />
                   </div>
                   <Button
-                    onClick={handlePrint}
+                    onClick={handleDownloadPdf}
                     variant="outline"
-                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
-                    <Printer className="w-4 h-4" />
-                    <span className="hidden sm:inline">Imprimir</span>
+                    <FileText className="h-4 w-4" />
+                    <span className="hidden sm:inline">Descargar PDF</span>
                   </Button>
                   <Button
                     variant="outline"
                     onClick={handleExportExcel}
-                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
-                    <FileSpreadsheet className="w-4 h-4" />
+                    <FileSpreadsheet className="h-4 w-4" />
                     <span className="hidden sm:inline">Exportar</span>
                   </Button>
-                  <Button
-                    onClick={() => setOpenModal(true)}
-                    className="bg-[#02a8e1] hover:bg-[#0288b1]"
-                  >
+                  <Button onClick={() => setOpenModal(true)} className="bg-[#02a8e1] hover:bg-[#0288b1]">
+                    <Plus className="mr-2 h-4 w-4" />
                     <span className="hidden sm:inline">Añadir Gasto</span>
                     <span className="sm:hidden">Añadir</span>
                   </Button>
                 </div>
               </CardHeader>
-              <CardContent className="p-4 space-y-4">
+              <CardContent className="space-y-4 p-4">
+                <div className="rounded-xl border bg-sky-50/60 p-4 text-sm text-sky-900">
+                  <div className="flex items-start gap-2">
+                    <ReceiptText className="mt-0.5 h-4 w-4" />
+                    <p>
+                      Los comprobantes pueden guardarse como URL o subirse a Cloudinary en formato PDF o imagen.
+                      Los gastos anulados quedan fuera del total operativo.
+                    </p>
+                  </div>
+                </div>
                 <div className="overflow-x-auto">
                   <OtrosGastosTable
-                    gastos={filteredGastos}
+                    gastos={paginatedGastos}
                     loading={loading}
+                    onView={(gasto) => {
+                      setGastoVer(gasto);
+                      setOpenModalVer(true);
+                    }}
                     onEdit={(gasto) => {
-                      setSelectedGasto(gasto as OtrosGastos);
+                      setSelectedGasto(gasto);
                       setOpenModal(true);
                     }}
                     onDelete={async (gasto) => {
-                      const confirmar = window.confirm(
-                        "¿Está seguro de eliminar el gasto?"
-                      );
+                      const confirmar = window.confirm("¿Está seguro de anular el gasto?");
                       if (!confirmar) return;
 
                       try {
                         await deleteOtrosGastos(gasto.id);
-                        toast.success("Gasto eliminado correctamente");
+                        toast.success("Gasto anulado correctamente");
                         await loadGastos();
-                      } catch (err) {
-                        toast.error("Error al eliminar gasto");
+                      } catch (err: any) {
+                        toast.error(err?.message || "Error al anular gasto");
                       }
                     }}
                   />
                 </div>
+                <PaginationControls
+                  currentPage={currentPage}
+                  totalItems={filteredGastos.length}
+                  pageSize={PAGE_SIZE}
+                  onPageChange={setCurrentPage}
+                  itemLabel="gastos"
+                />
               </CardContent>
             </Card>
           </main>
@@ -211,7 +434,7 @@ export default function OtrosGastosPage() {
           setOpenModalVer(false);
           setGastoVer(null);
         }}
-        gasto={gastoVer || undefined}
+        gasto={gastoVer}
       />
     </SidebarProvider>
   );

--- a/src/app/dashboard/pagos/page.tsx
+++ b/src/app/dashboard/pagos/page.tsx
@@ -21,6 +21,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { descargarPagoReciboPdf } from "@/utils/pagoReciboPdf";
 import { PaginationControls } from "@/components/ui/PaginationControls";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
@@ -144,7 +145,7 @@ export default function PagosPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Pagos.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-pagos", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/productos/page.tsx
+++ b/src/app/dashboard/productos/page.tsx
@@ -23,6 +23,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { useCatalogoParametrizable } from "@/hooks/useCatalogosParametrizables";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { PaginationControls } from "@/components/ui/PaginationControls";
@@ -169,7 +170,7 @@ export default function ProductoPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Productos.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-productos", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/proveedores/page.tsx
+++ b/src/app/dashboard/proveedores/page.tsx
@@ -21,6 +21,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { PaginationControls } from "@/components/ui/PaginationControls";
 
@@ -181,7 +182,7 @@ export default function ProveedoresPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Proveedores.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-proveedores", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/servicios/page.tsx
+++ b/src/app/dashboard/servicios/page.tsx
@@ -17,6 +17,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -114,7 +115,7 @@ export default function ServiciosPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Servicios.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-servicios", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/socios/page.tsx
+++ b/src/app/dashboard/socios/page.tsx
@@ -18,6 +18,7 @@ import { AppSidebar } from '@/components/sidebar/AppSidebar';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { toast } from 'sonner';
 import ExcelJS from 'exceljs';
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { PaginationControls } from '@/components/ui/PaginationControls';
 import { downloadCommercialReportPdf } from '@/utils/commercialReportPdf';
 
@@ -124,7 +125,7 @@ export default function SociosPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'Listado_Socios.xlsx';
+    a.download = buildTimestampedDownloadFileName('listado-socios', 'xlsx');
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/usuarios/page.tsx
+++ b/src/app/dashboard/usuarios/page.tsx
@@ -22,6 +22,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -120,7 +121,7 @@ export default function UsuariosPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Usuarios.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-usuarios", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/ventas-detalle/page.tsx
+++ b/src/app/dashboard/ventas-detalle/page.tsx
@@ -21,6 +21,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 
 export default function VentaDetallePage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } =
@@ -92,7 +93,7 @@ export default function VentaDetallePage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "Listado_Detalles_Venta.xlsx";
+    a.download = buildTimestampedDownloadFileName("listado-detalles-venta", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/app/dashboard/ventas/page.tsx
+++ b/src/app/dashboard/ventas/page.tsx
@@ -19,6 +19,7 @@ import { AppSidebar } from '@/components/sidebar/AppSidebar';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { toast } from 'sonner';
 import ExcelJS from 'exceljs';
+import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { formatCurrencyARS } from '@/lib/comercial/productos';
 import { PaginationControls } from '@/components/ui/PaginationControls';
 
@@ -152,7 +153,7 @@ export default function VentasPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'Listado_Ventas_Kiosco.xlsx';
+    a.download = buildTimestampedDownloadFileName('listado-ventas-kiosco', 'xlsx');
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/components/forms/OtrosGastosForm.tsx
+++ b/src/components/forms/OtrosGastosForm.tsx
@@ -1,53 +1,136 @@
 "use client";
 
 import { QaFileNameBadge } from "@/components/qa/QaFileNameBadge";
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
   createOtrosGastos,
   updateOtrosGastos,
+  uploadOtrosGastosComprobante,
 } from "@/services/otrosGastosService";
+import { getParametrizacionCatalogos } from "@/services/parametrizacionService";
+import {
+  CreateOtrosGastosDto,
+  OtrosGastos,
+  OtrosGastosEstado,
+  OtrosGastosMedioPago,
+  TipoGastoLite,
+} from "@/interfaces/otros_gastos.interface";
 import { toast } from "sonner";
+import { FileUp, Link as LinkIcon } from "lucide-react";
 
 export interface OtrosGastosFormProps {
-  gasto?: {
-    id?: string;
-    descripcion: string;
-    monto: number;
-    fecha: string;
-  } | null;
+  gasto?: OtrosGastos | null;
   onCreated: () => void;
 }
 
-const emptyForm = {
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+const emptyForm: CreateOtrosGastosDto = {
   descripcion: "",
   monto: 0,
-  fecha: "",
+  fecha: todayIso(),
+  id_tipo_gasto: null,
+  estado: "pagado",
+  medio_pago: "efectivo",
+  proveedor_nombre: "",
+  entidad: "",
+  numero_comprobante: "",
+  comprobante_url: "",
+  comprobante_nombre: "",
+  comprobante_mime_type: "",
+  fecha_vencimiento: "",
+  fecha_pago: todayIso(),
+  periodo_desde: "",
+  periodo_hasta: "",
+  observaciones: "",
 };
 
-export default function OtrosGastosForm({
-  gasto,
-  onCreated,
-}: OtrosGastosFormProps) {
-  const [form, setForm] = useState(emptyForm);
+const estados: { value: OtrosGastosEstado; label: string }[] = [
+  { value: "pendiente", label: "Pendiente" },
+  { value: "pagado", label: "Pagado" },
+  { value: "vencido", label: "Vencido" },
+  { value: "anulado", label: "Anulado" },
+];
+
+const mediosPago: { value: OtrosGastosMedioPago; label: string }[] = [
+  { value: "efectivo", label: "Efectivo" },
+  { value: "transferencia", label: "Transferencia" },
+  { value: "tarjeta_debito", label: "Tarjeta débito" },
+  { value: "tarjeta_credito", label: "Tarjeta crédito" },
+  { value: "mercado_pago", label: "Mercado Pago" },
+  { value: "stripe", label: "Stripe" },
+  { value: "otro", label: "Otro" },
+];
+
+function normalizeNullable(value?: string | null) {
+  return value && value.trim().length > 0 ? value.trim() : null;
+}
+
+export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormProps) {
+  const [form, setForm] = useState<CreateOtrosGastosDto>(emptyForm);
+  const [tiposGasto, setTiposGasto] = useState<TipoGastoLite[]>([]);
   const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    async function loadCatalogos() {
+      try {
+        const response = await getParametrizacionCatalogos();
+        const catalogo = response.catalogos.find((item) => item.key === "tipo_gasto");
+        const items = (catalogo?.items ?? [])
+          .filter((item) => item.activo !== false)
+          .map((item) => ({
+            id: item.id,
+            codigo: item.codigo,
+            nombre: item.nombre,
+            descripcion: item.descripcion,
+            activo: item.activo,
+          }));
+        setTiposGasto(items);
+      } catch {
+        setTiposGasto([]);
+      }
+    }
+
+    loadCatalogos();
+  }, []);
 
   useEffect(() => {
     if (gasto) {
       setForm({
         descripcion: gasto.descripcion ?? "",
-        monto: gasto.monto ?? 0,
-        fecha: gasto.fecha ?? "",
+        monto: Number(gasto.monto ?? 0),
+        fecha: gasto.fecha ?? todayIso(),
+        id_tipo_gasto: gasto.id_tipo_gasto ?? null,
+        estado: gasto.estado ?? "pagado",
+        medio_pago: gasto.medio_pago ?? "efectivo",
+        proveedor_nombre: gasto.proveedor_nombre ?? "",
+        entidad: gasto.entidad ?? "",
+        numero_comprobante: gasto.numero_comprobante ?? "",
+        comprobante_url: gasto.comprobante_url ?? "",
+        comprobante_nombre: gasto.comprobante_nombre ?? "",
+        comprobante_mime_type: gasto.comprobante_mime_type ?? "",
+        fecha_vencimiento: gasto.fecha_vencimiento ?? "",
+        fecha_pago: gasto.fecha_pago ?? "",
+        periodo_desde: gasto.periodo_desde ?? "",
+        periodo_hasta: gasto.periodo_hasta ?? "",
+        observaciones: gasto.observaciones ?? "",
       });
     } else {
       setForm(emptyForm);
     }
   }, [gasto]);
 
+  const selectedTipo = useMemo(
+    () => tiposGasto.find((tipo) => tipo.id === form.id_tipo_gasto),
+    [form.id_tipo_gasto, tiposGasto]
+  );
+
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
   ) => {
     const { name, value } = e.target;
     setForm((prev) => ({
@@ -56,77 +139,286 @@ export default function OtrosGastosForm({
     }));
   };
 
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setUploading(true);
+    try {
+      const uploaded = await uploadOtrosGastosComprobante(file);
+      setForm((prev) => ({
+        ...prev,
+        comprobante_url: uploaded.url,
+        comprobante_nombre: uploaded.originalName,
+        comprobante_mime_type: uploaded.mimeType,
+      }));
+      toast.success("Comprobante subido correctamente");
+    } catch (error: any) {
+      toast.error(error?.message || "Error al subir comprobante");
+    } finally {
+      setUploading(false);
+      event.target.value = "";
+    }
+  };
+
+  const buildPayload = (): CreateOtrosGastosDto => ({
+    descripcion: form.descripcion.trim(),
+    monto: Number(form.monto),
+    fecha: form.fecha,
+    id_tipo_gasto: normalizeNullable(form.id_tipo_gasto ?? ""),
+    estado: form.estado ?? "pagado",
+    medio_pago: form.medio_pago ?? "efectivo",
+    proveedor_nombre: normalizeNullable(form.proveedor_nombre ?? ""),
+    entidad: normalizeNullable(form.entidad ?? ""),
+    numero_comprobante: normalizeNullable(form.numero_comprobante ?? ""),
+    comprobante_url: normalizeNullable(form.comprobante_url ?? ""),
+    comprobante_nombre: normalizeNullable(form.comprobante_nombre ?? ""),
+    comprobante_mime_type: normalizeNullable(form.comprobante_mime_type ?? ""),
+    fecha_vencimiento: normalizeNullable(form.fecha_vencimiento ?? ""),
+    fecha_pago: normalizeNullable(form.fecha_pago ?? ""),
+    periodo_desde: normalizeNullable(form.periodo_desde ?? ""),
+    periodo_hasta: normalizeNullable(form.periodo_hasta ?? ""),
+    observaciones: normalizeNullable(form.observaciones ?? ""),
+  });
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     try {
-      if (gasto && gasto.id) {
-        await updateOtrosGastos(gasto.id, form);
+      const payload = buildPayload();
+      if (gasto?.id) {
+        await updateOtrosGastos(gasto.id, payload);
         toast.success("Gasto actualizado");
       } else {
-        await createOtrosGastos(form);
+        await createOtrosGastos(payload);
         toast.success("Gasto creado");
       }
       setForm(emptyForm);
       onCreated();
     } catch (error: any) {
-      let msg = error.message || "Error al guardar gasto";
-      if (msg.includes("value too long")) {
-        msg =
-          "Uno de los campos excede la cantidad máxima de caracteres permitidos.";
-      }
-      toast.error(msg);
+      toast.error(error?.message || "Error al guardar gasto");
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="grid grid-cols-1 md:grid-cols-2 gap-4"
-    >
+    <form onSubmit={handleSubmit} className="relative mt-4 space-y-6">
       <QaFileNameBadge file="src/components/forms/OtrosGastosForm.tsx" />
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="descripcion">Descripción</Label>
-        <Input
-          id="descripcion"
-          name="descripcion"
-          placeholder="Ingrese descripción"
-          value={form.descripcion}
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-2 md:col-span-2">
+          <Label htmlFor="descripcion">Descripción *</Label>
+          <Input
+            id="descripcion"
+            name="descripcion"
+            value={form.descripcion}
+            onChange={handleChange}
+            placeholder="Ej.: Factura de luz, reparación, insumos de limpieza..."
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="id_tipo_gasto">Tipo de gasto</Label>
+          <select
+            id="id_tipo_gasto"
+            name="id_tipo_gasto"
+            value={form.id_tipo_gasto ?? ""}
+            onChange={handleChange}
+            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            <option value="">Sin clasificar</option>
+            {tiposGasto.map((tipo) => (
+              <option key={tipo.id} value={tipo.id}>
+                {tipo.nombre}
+              </option>
+            ))}
+          </select>
+          {selectedTipo?.descripcion ? (
+            <p className="text-xs text-muted-foreground">{selectedTipo.descripcion}</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="monto">Monto *</Label>
+          <Input
+            id="monto"
+            name="monto"
+            type="number"
+            min="0"
+            step="0.01"
+            value={form.monto || ""}
+            onChange={handleChange}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fecha">Fecha del gasto *</Label>
+          <Input id="fecha" name="fecha" type="date" value={form.fecha} onChange={handleChange} required />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fecha_vencimiento">Fecha de vencimiento</Label>
+          <Input
+            id="fecha_vencimiento"
+            name="fecha_vencimiento"
+            type="date"
+            value={form.fecha_vencimiento ?? ""}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="fecha_pago">Fecha de pago</Label>
+          <Input
+            id="fecha_pago"
+            name="fecha_pago"
+            type="date"
+            value={form.fecha_pago ?? ""}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="estado">Estado</Label>
+          <select
+            id="estado"
+            name="estado"
+            value={form.estado ?? "pagado"}
+            onChange={handleChange}
+            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            {estados.map((estado) => (
+              <option key={estado.value} value={estado.value}>
+                {estado.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="medio_pago">Medio de pago</Label>
+          <select
+            id="medio_pago"
+            name="medio_pago"
+            value={form.medio_pago ?? "efectivo"}
+            onChange={handleChange}
+            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            {mediosPago.map((medio) => (
+              <option key={medio.value} value={medio.value}>
+                {medio.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="proveedor_nombre">Proveedor / entidad</Label>
+          <Input
+            id="proveedor_nombre"
+            name="proveedor_nombre"
+            value={form.proveedor_nombre ?? ""}
+            onChange={handleChange}
+            placeholder="Ej.: Edesur, AFIP, alquiler, técnico..."
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="numero_comprobante">Nº comprobante / factura</Label>
+          <Input
+            id="numero_comprobante"
+            name="numero_comprobante"
+            value={form.numero_comprobante ?? ""}
+            onChange={handleChange}
+            placeholder="Factura, ticket, transferencia..."
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="periodo_desde">Período desde</Label>
+          <Input
+            id="periodo_desde"
+            name="periodo_desde"
+            type="date"
+            value={form.periodo_desde ?? ""}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="periodo_hasta">Período hasta</Label>
+          <Input
+            id="periodo_hasta"
+            name="periodo_hasta"
+            type="date"
+            value={form.periodo_hasta ?? ""}
+            onChange={handleChange}
+          />
+        </div>
+      </section>
+
+      <section className="rounded-xl border bg-muted/20 p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <FileUp className="h-4 w-4 text-sky-600" />
+          <h3 className="font-semibold">Comprobante</h3>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="comprobante_file">Subir PDF o imagen</Label>
+            <Input
+              id="comprobante_file"
+              type="file"
+              accept="application/pdf,image/png,image/jpeg,image/webp,image/gif,image/heic,image/heif"
+              onChange={handleFileChange}
+              disabled={uploading}
+            />
+            <p className="text-xs text-muted-foreground">
+              Formatos permitidos: PDF, PNG, JPG, WEBP, GIF, HEIC/HEIF. Máximo 10MB.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="comprobante_url">URL del comprobante</Label>
+            <div className="flex gap-2">
+              <Input
+                id="comprobante_url"
+                name="comprobante_url"
+                value={form.comprobante_url ?? ""}
+                onChange={handleChange}
+                placeholder="URL de Cloudinary o comprobante externo"
+              />
+              {form.comprobante_url ? (
+                <Button type="button" variant="outline" asChild>
+                  <a href={form.comprobante_url} target="_blank" rel="noreferrer" title="Abrir comprobante">
+                    <LinkIcon className="h-4 w-4" />
+                  </a>
+                </Button>
+              ) : null}
+            </div>
+            {form.comprobante_nombre ? (
+              <p className="text-xs text-muted-foreground">Archivo: {form.comprobante_nombre}</p>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <div className="space-y-2">
+        <Label htmlFor="observaciones">Observaciones</Label>
+        <textarea
+          id="observaciones"
+          name="observaciones"
+          value={form.observaciones ?? ""}
           onChange={handleChange}
-          required
+          rows={3}
+          placeholder="Notas internas, detalle del gasto, condiciones de pago..."
+          className="min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
         />
       </div>
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="monto">Monto</Label>
-        <Input
-          id="monto"
-          name="monto"
-          type="number"
-          placeholder="Ingrese monto"
-          value={form.monto}
-          onChange={handleChange}
-          required
-          min={0}
-        />
-      </div>
-      <div className="flex flex-col gap-1.5 md:col-span-2">
-        <Label htmlFor="fecha">Fecha</Label>
-        <Input
-          id="fecha"
-          name="fecha"
-          type="date"
-          value={form.fecha}
-          onChange={handleChange}
-          required
-        />
-      </div>
-      <Button
-        type="submit"
-        className="col-span-full justify-self-end"
-        disabled={loading}
-      >
+
+      <Button type="submit" disabled={loading || uploading} className="w-full bg-[#02a8e1] hover:bg-[#0288b1]">
         {loading ? "Guardando..." : gasto ? "Actualizar Gasto" : "Crear Gasto"}
       </Button>
     </form>

--- a/src/components/modal/DietasViewModal.tsx
+++ b/src/components/modal/DietasViewModal.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { FileSpreadsheet } from "lucide-react";
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import {
   Accordion,
   AccordionContent,
@@ -172,7 +173,7 @@ export default function DietasViewModal({
           defaultStyle: { fontSize: 10 },
           pageOrientation: "portrait",
         })
-        .download("Detalle_Dieta.pdf");
+        .download(buildTimestampedDownloadFileName("detalle-dieta", "pdf"));
       setPdfExporting(false);
     }, 100);
   };

--- a/src/components/modal/OtrosGastosModal.tsx
+++ b/src/components/modal/OtrosGastosModal.tsx
@@ -27,7 +27,7 @@ export default function OtrosGastosModal({
         <QaFileNameBadge file="src/components/modal/OtrosGastosModal.tsx" />
         <DialogHeader>
           <div className="flex gap-4 justify-between items-center w-full">
-            <DialogTitle>{gasto ? "Editar Gasto" : "Nuevo Gasto"}</DialogTitle>
+            <DialogTitle>{gasto ? "Editar Gasto / Egreso" : "Nuevo Gasto / Egreso"}</DialogTitle>
             <FechaHora />
           </div>
         </DialogHeader>

--- a/src/components/modal/OtrosGastosViewModal.tsx
+++ b/src/components/modal/OtrosGastosViewModal.tsx
@@ -7,8 +7,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { OtrosGastos } from "@/interfaces/otros_gastos.interface";
-import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
+import { formatFrontendDateTime, formatFrontendDate } from "@/utils/dateFormat";
+import { formatCurrencyARS } from "@/lib/comercial/productos";
+import { ExternalLink } from "lucide-react";
+
+function ReadOnlyField({ label, value }: { label: string; value?: string | number | null }) {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium">{label}</label>
+      <div className="min-h-10 rounded-md border bg-gray-50 p-2 text-sm">
+        {value === null || value === undefined || value === "" ? "-" : value}
+      </div>
+    </div>
+  );
+}
 
 export default function OtrosGastosViewModal({
   open,
@@ -23,38 +37,53 @@ export default function OtrosGastosViewModal({
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="!max-w-[90vw] sm:!max-w-[800px] !w-full">
+      <DialogContent className="!w-full !max-w-[900px]">
         <QaFileNameBadge file="src/components/modal/OtrosGastosViewModal.tsx" />
         <DialogHeader>
-          <DialogTitle className="text-xl font-semibold">
-            Detalle Gasto
-          </DialogTitle>
-          <div className="text-sm text-right text-muted-foreground">
+          <DialogTitle className="text-xl font-semibold">Detalle de gasto / egreso</DialogTitle>
+          <div className="text-right text-sm text-muted-foreground">
             {formatFrontendDateTime(new Date())}
           </div>
         </DialogHeader>
-        <div className="grid grid-cols-1 gap-6 mt-4 md:grid-cols-2">
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Descripción</label>
-              <div className="p-2 border rounded-md bg-gray-50">
-                {gasto.descripcion || "-"}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Monto</label>
-              <div className="p-2 border rounded-md bg-gray-50">
-                ${gasto.monto}
-              </div>
-            </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-5 md:grid-cols-2">
+          <ReadOnlyField label="Descripción" value={gasto.descripcion} />
+          <ReadOnlyField label="Tipo de gasto" value={gasto.tipo_gasto?.nombre ?? "Sin clasificar"} />
+          <ReadOnlyField label="Monto" value={formatCurrencyARS(Number(gasto.monto ?? 0))} />
+          <ReadOnlyField label="Estado" value={gasto.estado ?? "-"} />
+          <ReadOnlyField label="Medio de pago" value={gasto.medio_pago?.replace(/_/g, " ") ?? "-"} />
+          <ReadOnlyField label="Fecha del gasto" value={formatFrontendDate(gasto.fecha)} />
+          <ReadOnlyField label="Fecha vencimiento" value={gasto.fecha_vencimiento ? formatFrontendDate(gasto.fecha_vencimiento) : "-"} />
+          <ReadOnlyField label="Fecha pago" value={gasto.fecha_pago ? formatFrontendDate(gasto.fecha_pago) : "-"} />
+          <ReadOnlyField label="Período desde" value={gasto.periodo_desde ? formatFrontendDate(gasto.periodo_desde) : "-"} />
+          <ReadOnlyField label="Período hasta" value={gasto.periodo_hasta ? formatFrontendDate(gasto.periodo_hasta) : "-"} />
+          <ReadOnlyField label="Proveedor / entidad" value={gasto.proveedor_nombre || gasto.entidad} />
+          <ReadOnlyField label="Nº comprobante" value={gasto.numero_comprobante} />
+        </div>
+
+        <div className="mt-5 space-y-2">
+          <label className="text-sm font-medium">Observaciones</label>
+          <div className="min-h-20 rounded-md border bg-gray-50 p-3 text-sm">
+            {gasto.observaciones || "-"}
           </div>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium">Fecha</label>
-              <div className="p-2 border rounded-md bg-gray-50">
-                {gasto.fecha || "-"}
-              </div>
+        </div>
+
+        <div className="mt-5 rounded-xl border bg-muted/20 p-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h3 className="font-semibold">Comprobante</h3>
+              <p className="text-sm text-muted-foreground">
+                {gasto.comprobante_nombre || gasto.comprobante_url || "Sin comprobante adjunto"}
+              </p>
             </div>
+            {gasto.comprobante_url ? (
+              <Button type="button" variant="outline" asChild>
+                <a href={gasto.comprobante_url} target="_blank" rel="noreferrer">
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  Abrir comprobante
+                </a>
+              </Button>
+            ) : null}
           </div>
         </div>
       </DialogContent>

--- a/src/components/modal/RutinaModalView.tsx
+++ b/src/components/modal/RutinaModalView.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/accordion";
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
 
 pdfMake.vfs = pdfFonts.vfs;
@@ -81,7 +82,7 @@ function EjerciciosModal({
         },
         defaultStyle: { font: "Roboto" },
       })
-      .download("ejercicios.pdf");
+      .download(buildTimestampedDownloadFileName("ejercicios-rutina", "pdf"));
     setExportando(false);
   };
 

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -104,7 +104,7 @@ export const sections: SidebarSectionType[] = [
       { title: 'Usuarios', link: '/dashboard/usuarios', level: 2 },
       { title: 'Productos', link: '/dashboard/productos', level: 2 },
       { title: 'Servicios', link: '/dashboard/servicios', level: 2 },
-      { title: 'Otros gastos', link: '/dashboard/otros-gastos', level: 2 },
+      { title: 'Gastos / Egresos', link: '/dashboard/otros-gastos', level: 2 },
       { title: 'Avisos', link: '/dashboard/avisos', level: 2 },
       { title: 'Equipamientos', link: '/dashboard/equipamientos', level: 2 },
     ],

--- a/src/components/tables/OtrosGastosTable.tsx
+++ b/src/components/tables/OtrosGastosTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pencil } from "lucide-react";
+import { Eye, Pencil, Trash2, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -13,22 +13,40 @@ import {
   TableRow,
   TableCaption,
 } from "@/components/ui/table";
+import { OtrosGastos } from "@/interfaces/otros_gastos.interface";
+import { formatFrontendDate } from "@/utils/dateFormat";
+import { formatCurrencyARS } from "@/lib/comercial/productos";
 
-export interface OtrosGastos {
-  id: string;
-  descripcion: string;
-  monto: number;
-  fecha: string;
+function getEstadoBadgeClass(estado?: string | null) {
+  switch (estado) {
+    case "pagado":
+      return "bg-emerald-50 text-emerald-700 border-emerald-200";
+    case "pendiente":
+      return "bg-amber-50 text-amber-700 border-amber-200";
+    case "vencido":
+      return "bg-red-50 text-red-700 border-red-200";
+    case "anulado":
+      return "bg-slate-100 text-slate-600 border-slate-200";
+    default:
+      return "bg-slate-50 text-slate-600 border-slate-200";
+  }
+}
+
+function getEstadoLabel(estado?: string | null) {
+  if (!estado) return "Sin estado";
+  return estado.charAt(0).toUpperCase() + estado.slice(1);
 }
 
 export default function OtrosGastosTable({
   gastos,
   loading,
+  onView,
   onEdit,
   onDelete,
 }: {
   gastos: OtrosGastos[];
   loading?: boolean;
+  onView?: (gasto: OtrosGastos) => void;
   onEdit: (gasto: OtrosGastos) => void;
   onDelete?: (gasto: OtrosGastos) => void;
 }) {
@@ -36,7 +54,7 @@ export default function OtrosGastosTable({
     return (
       <div className="space-y-2">
         {[...Array(5)].map((_, i) => (
-          <Skeleton key={i} className="w-full rounded-md h-9" />
+          <Skeleton key={i} className="h-9 w-full rounded-md" />
         ))}
       </div>
     );
@@ -50,54 +68,88 @@ export default function OtrosGastosTable({
     );
   }
 
+  const total = gastos.reduce((acc, gasto) => acc + Number(gasto.monto ?? 0), 0);
+
   return (
-    <Table className="w-full overflow-hidden text-sm border rounded-md border-border">
+    <Table className="w-full overflow-hidden rounded-md border border-border text-sm">
       <TableHeader>
         <TableRow className="bg-muted/50 text-muted-foreground">
           <TableHead>Descripción</TableHead>
-          <TableHead>Monto</TableHead>
+          <TableHead>Tipo</TableHead>
+          <TableHead>Entidad</TableHead>
+          <TableHead>Estado</TableHead>
+          <TableHead>Medio</TableHead>
+          <TableHead className="text-right">Monto</TableHead>
           <TableHead>Fecha</TableHead>
+          <TableHead>Vencimiento</TableHead>
+          <TableHead>Comprobante</TableHead>
           <TableHead>Acciones</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {gastos.map((g, i) => (
-          <TableRow
-            key={i}
-            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors"
-          >
-            <TableCell className="font-medium">{g.descripcion}</TableCell>
-            <TableCell>${g.monto}</TableCell>
-            <TableCell>{g.fecha}</TableCell>
-            <TableCell className="flex gap-2">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onEdit(g)}
-                title="Editar"
-              >
-                <Pencil className="w-4 h-4" />
-              </Button>
-              <Button
-                size="sm"
-                className="bg-red-500 hover:bg-red-600 text-white w-[100px]"
-                onClick={() => onDelete && onDelete(g)}
-              >
-                Eliminar
-              </Button>
+        {gastos.map((g) => (
+          <TableRow key={g.id} className="odd:bg-muted/40 transition-colors hover:bg-[#a8d9f9]">
+            <TableCell className="max-w-[220px] font-medium">
+              <div className="line-clamp-2">{g.descripcion}</div>
+              {g.numero_comprobante ? (
+                <div className="text-xs text-muted-foreground">Comp.: {g.numero_comprobante}</div>
+              ) : null}
+            </TableCell>
+            <TableCell>{g.tipo_gasto?.nombre ?? "Sin clasificar"}</TableCell>
+            <TableCell>{g.proveedor_nombre || g.entidad || "-"}</TableCell>
+            <TableCell>
+              <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${getEstadoBadgeClass(g.estado)}`}>
+                {getEstadoLabel(g.estado)}
+              </span>
+            </TableCell>
+            <TableCell>{g.medio_pago ? g.medio_pago.replace(/_/g, " ") : "-"}</TableCell>
+            <TableCell className="text-right font-semibold">{formatCurrencyARS(Number(g.monto ?? 0))}</TableCell>
+            <TableCell>{formatFrontendDate(g.fecha)}</TableCell>
+            <TableCell>{g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-"}</TableCell>
+            <TableCell>
+              {g.comprobante_url ? (
+                <Button size="sm" variant="outline" asChild>
+                  <a href={g.comprobante_url} target="_blank" rel="noreferrer" title="Abrir comprobante">
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                </Button>
+              ) : (
+                "-"
+              )}
+            </TableCell>
+            <TableCell>
+              <div className="flex flex-wrap gap-2">
+                {onView ? (
+                  <Button size="sm" variant="outline" onClick={() => onView(g)} title="Ver">
+                    <Eye className="h-4 w-4" />
+                  </Button>
+                ) : null}
+                <Button size="sm" variant="outline" onClick={() => onEdit(g)} title="Editar">
+                  <Pencil className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  className="bg-red-500 text-white hover:bg-red-600"
+                  onClick={() => onDelete && onDelete(g)}
+                  title="Anular"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
             </TableCell>
           </TableRow>
         ))}
       </TableBody>
       <TableFooter>
         <TableRow>
-          <TableCell colSpan={2}>Total de gastos</TableCell>
-          <TableCell className="text-right" colSpan={2}>
-            {gastos.length}
+          <TableCell colSpan={5}>Total de gastos filtrados</TableCell>
+          <TableCell className="text-right font-bold">{formatCurrencyARS(total)}</TableCell>
+          <TableCell colSpan={4} className="text-right">
+            {gastos.length} registros
           </TableCell>
         </TableRow>
       </TableFooter>
-      <TableCaption>Listado de otros gastos registrados.</TableCaption>
+      <TableCaption>Listado de gastos y egresos operativos registrados.</TableCaption>
     </Table>
   );
 }

--- a/src/interfaces/otros_gastos.interface.ts
+++ b/src/interfaces/otros_gastos.interface.ts
@@ -1,20 +1,74 @@
+export type OtrosGastosEstado = 'pendiente' | 'pagado' | 'vencido' | 'anulado';
+export type OtrosGastosMedioPago =
+  | 'efectivo'
+  | 'transferencia'
+  | 'tarjeta_debito'
+  | 'tarjeta_credito'
+  | 'mercado_pago'
+  | 'stripe'
+  | 'otro';
+
+export interface TipoGastoLite {
+  id: string;
+  codigo?: string | null;
+  nombre: string;
+  descripcion?: string | null;
+  activo?: boolean | null;
+}
+
 export interface OtrosGastos {
   id: string;
   descripcion: string;
   monto: number;
   fecha: string;
   activo: boolean;
+  id_tipo_gasto?: string | null;
+  estado?: OtrosGastosEstado | null;
+  medio_pago?: OtrosGastosMedioPago | null;
+  proveedor_nombre?: string | null;
+  entidad?: string | null;
+  numero_comprobante?: string | null;
+  comprobante_url?: string | null;
+  comprobante_nombre?: string | null;
+  comprobante_mime_type?: string | null;
+  fecha_vencimiento?: string | null;
+  fecha_pago?: string | null;
+  periodo_desde?: string | null;
+  periodo_hasta?: string | null;
+  observaciones?: string | null;
+  registrado_por?: string | null;
+  creado_en?: string | null;
+  actualizado_en?: string | null;
+  tipo_gasto?: TipoGastoLite | null;
 }
 
 export interface CreateOtrosGastosDto {
   descripcion: string;
   monto: number;
   fecha: string;
+  id_tipo_gasto?: string | null;
+  estado?: OtrosGastosEstado;
+  medio_pago?: OtrosGastosMedioPago;
+  proveedor_nombre?: string | null;
+  entidad?: string | null;
+  numero_comprobante?: string | null;
+  comprobante_url?: string | null;
+  comprobante_nombre?: string | null;
+  comprobante_mime_type?: string | null;
+  fecha_vencimiento?: string | null;
+  fecha_pago?: string | null;
+  periodo_desde?: string | null;
+  periodo_hasta?: string | null;
+  observaciones?: string | null;
 }
 
-export interface UpdateOtrosGastosDto {
-  descripcion?: string;
-  monto?: number;
-  fecha?: string;
+export interface UpdateOtrosGastosDto extends Partial<CreateOtrosGastosDto> {
   activo?: boolean;
+}
+
+export interface OtrosGastosComprobanteUploadResponse {
+  url: string;
+  originalName: string;
+  mimeType: string;
+  size: number;
 }

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -202,8 +202,8 @@ export const MENU_PERMISSION_GROUPS: Array<{
         roles: ['admin'],
       },
       {
-        key: 'Otros gastos',
-        label: 'Otros gastos',
+        key: 'Gastos / Egresos',
+        label: 'Gastos / Egresos',
         path: '/dashboard/otros-gastos',
         group: 'Administración',
         roles: ['admin'],

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1130,20 +1130,44 @@ const endpointDefinitions: EndpointDefinition[] = [
       "PUT",
       "DELETE"
     ],
-    "tag": "Catálogos y operación",
-    "summary": "Operaciones de otros gastos",
-    "description": "Consulta datos de otros gastos. Si el endpoint usa parámetros dinámicos, el identificador forma parte de la URL. Implementación relacionada: createOtrosGastos, deleteOtrosGastos, getAllOtrosGastos, updateOtrosGastos.",
-    "auth": false,
+    "tag": "Gastos / egresos",
+    "summary": "Gastos / egresos con comprobantes",
+    "description": "Consulta, registra, actualiza y anula gastos operativos del gimnasio con clasificación por tipo de gasto, estado, medio de pago, vencimientos, período cubierto y comprobante PDF/imagen.",
+    "auth": true,
     "admin": false,
     "notImplemented": false,
     "statuses": [
       200,
       201,
       400,
+      401,
+      500
+    ],
+    "queryParams": [
+      "estado",
+      "id_tipo_gasto"
+    ],
+    "source": "src/app/api/otros_gastos/route.ts"
+  },
+  {
+    "path": "/api/otros_gastos/comprobante-upload",
+    "methods": [
+      "POST"
+    ],
+    "tag": "Gastos / egresos",
+    "summary": "Carga de comprobante de gasto",
+    "description": "Sube un comprobante PDF o imagen a Cloudinary y devuelve URL, nombre original, MIME type y tamaño para asociarlo al gasto/egreso.",
+    "auth": true,
+    "admin": false,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      400,
+      401,
       500
     ],
     "queryParams": [],
-    "source": "src/app/api/otros_gastos/route.ts"
+    "source": "src/app/api/otros_gastos/comprobante-upload/route.ts"
   },
   {
     "path": "/api/pagar-cuota",

--- a/src/services/otrosGastosService.ts
+++ b/src/services/otrosGastosService.ts
@@ -1,28 +1,77 @@
-import { supabase } from "./supabaseClient";
-import { OtrosGastos, CreateOtrosGastosDto, UpdateOtrosGastosDto } from "../interfaces/otros_gastos.interface";
+import {
+  CreateOtrosGastosDto,
+  OtrosGastos,
+  OtrosGastosComprobanteUploadResponse,
+  UpdateOtrosGastosDto,
+} from '@/interfaces/otros_gastos.interface';
+import { authHeader } from '@/services/storageService';
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(payload?.error || 'Error al operar gastos');
+  }
+
+  return payload?.data as T;
+}
 
 export const getAllOtrosGastos = async (): Promise<OtrosGastos[]> => {
-  const { data, error } = await supabase.from("otros_gastos").select();
-  if (error) throw new Error(error.message);
-  return data as OtrosGastos[];
+  const response = await fetch('/api/otros_gastos', {
+    method: 'GET',
+    headers: authHeader(),
+    cache: 'no-store',
+  });
+
+  return parseJsonResponse<OtrosGastos[]>(response);
 };
 
-export const createOtrosGastos = async (payload: CreateOtrosGastosDto): Promise<OtrosGastos> => {
-  const { data, error } = await supabase.from("otros_gastos").insert(payload).select().single();
-  if (error) throw new Error(error.message);
-  return data as OtrosGastos;
+export const createOtrosGastos = async (
+  payload: CreateOtrosGastosDto
+): Promise<OtrosGastos> => {
+  const response = await fetch('/api/otros_gastos', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify(payload),
+  });
+
+  return parseJsonResponse<OtrosGastos>(response);
 };
 
-export const updateOtrosGastos = async (id: string, updateData: UpdateOtrosGastosDto): Promise<OtrosGastos> => {
-  const { data, error } = await supabase.from("otros_gastos").update(updateData).eq("id", id).select().single();
-  if (error) throw new Error(error.message);
-  if (!data || data.length === 0) throw new Error("No se encontró gasto con ese id");
-  return data as OtrosGastos;
+export const updateOtrosGastos = async (
+  id: string,
+  updateData: UpdateOtrosGastosDto
+): Promise<OtrosGastos> => {
+  const response = await fetch('/api/otros_gastos', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify({ id, updateData }),
+  });
+
+  return parseJsonResponse<OtrosGastos>(response);
 };
 
 export const deleteOtrosGastos = async (id: string): Promise<OtrosGastos> => {
-  const { data, error } = await supabase.from("otros_gastos").update({ activo: false }).eq("id", id).select().single();
-  if (error) throw new Error(error.message);
-  if (!data) throw new Error("No se encontró gasto con ese id");
-  return data as OtrosGastos;
+  const response = await fetch('/api/otros_gastos', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+    body: JSON.stringify({ id }),
+  });
+
+  return parseJsonResponse<OtrosGastos>(response);
 };
+
+export async function uploadOtrosGastosComprobante(
+  file: File
+): Promise<OtrosGastosComprobanteUploadResponse> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await fetch('/api/otros_gastos/comprobante-upload', {
+    method: 'POST',
+    headers: authHeader(),
+    body: formData,
+  });
+
+  return parseJsonResponse<OtrosGastosComprobanteUploadResponse>(response);
+}

--- a/src/utils/commercialReportPdf.ts
+++ b/src/utils/commercialReportPdf.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import jsPDF from "jspdf";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 
 export interface CommercialReportMetric {
   label: string;
@@ -301,5 +302,5 @@ export async function downloadCommercialReportPdf<T>({
     addFooter(doc, pageWidth, pageHeight);
   }
 
-  doc.save(`${safeFileName(fileName)}.pdf`);
+  doc.save(buildTimestampedDownloadFileName(fileName, "pdf"));
 }

--- a/src/utils/dietaPdf.ts
+++ b/src/utils/dietaPdf.ts
@@ -1,4 +1,5 @@
 import jsPDF from "jspdf";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDate } from '@/utils/dateFormat';
 import { Dieta } from "@/interfaces/dieta.interface";
 
@@ -401,5 +402,5 @@ export const descargarDietaPdf = async ({
   );
 
   addFooter(doc);
-  doc.save(`${safeFileName(`${titulo}-${nombreSocio}`)}.pdf`);
+  doc.save(buildTimestampedDownloadFileName(`${titulo}-${nombreSocio}`, "pdf"));
 };

--- a/src/utils/downloadFileName.ts
+++ b/src/utils/downloadFileName.ts
@@ -1,0 +1,31 @@
+export function sanitizeDownloadFileName(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}
+
+export function getDownloadTimestamp(date = new Date()): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const year = date.getFullYear();
+  const month = pad(date.getMonth() + 1);
+  const day = pad(date.getDate());
+  const hours = pad(date.getHours());
+  const minutes = pad(date.getMinutes());
+
+  return `${year}${month}${day}-${hours}${minutes}`;
+}
+
+export function buildTimestampedDownloadFileName(
+  baseName: string,
+  extension?: string,
+  date = new Date()
+): string {
+  const safeBaseName = sanitizeDownloadFileName(baseName || 'archivo');
+  const safeExtension = extension?.replace(/^\./, '').trim();
+  const name = `${getDownloadTimestamp(date)}-${safeBaseName}`;
+
+  return safeExtension ? `${name}.${safeExtension}` : name;
+}

--- a/src/utils/evolucionFisicaPdf.ts
+++ b/src/utils/evolucionFisicaPdf.ts
@@ -1,4 +1,5 @@
 import jsPDF from "jspdf";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDate, formatFrontendDateTime } from '@/utils/dateFormat';
 import { EvolucionSocio } from "@/interfaces/evolucionSocio.interface";
 
@@ -1405,8 +1406,5 @@ export const descargarEvolucionFisicaPdf = async ({
 
   addFooter(doc);
 
-  const datePart = new Date().toISOString().split("T")[0];
-  const fileName = `evolucion-fisica-${safeFileName(socioNombre || "socio")}-${datePart}.pdf`;
-
-  doc.save(fileName);
+  doc.save(buildTimestampedDownloadFileName(`evolucion-fisica-${socioNombre || "socio"}`, "pdf"));
 };

--- a/src/utils/pagoReciboPdf.ts
+++ b/src/utils/pagoReciboPdf.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { jsPDF } from "jspdf";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import QRCode from "qrcode";
 import { ResponsePago } from "@/interfaces/pago.interface";
 import { buildPagoVerificationCode } from "@/utils/pagoReciboCodigo";
@@ -394,5 +395,5 @@ export async function descargarPagoReciboPdf(pago: ResponsePago) {
     align: "right",
   });
 
-  doc.save(`recibo-gym-master-${codigo}.pdf`);
+  doc.save(buildTimestampedDownloadFileName(`recibo-gym-master-${codigo}`, "pdf"));
 }

--- a/src/utils/rutinaPdf.ts
+++ b/src/utils/rutinaPdf.ts
@@ -1,4 +1,5 @@
 import jsPDF from "jspdf";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDate } from '@/utils/dateFormat';
 import { Rutina } from "@/interfaces/rutina.interface";
 
@@ -232,7 +233,7 @@ export const descargarRutinaPdf = async ({
     doc.setTextColor(110, 110, 110);
     doc.text("Esta rutina no tiene ejercicios cargados o usa un formato no reconocido.", PAGE_MARGIN, y);
     addFooter(doc);
-    doc.save(`${safeFileName(titulo)}.pdf`);
+    doc.save(buildTimestampedDownloadFileName(titulo, "pdf"));
     return;
   }
 
@@ -301,5 +302,5 @@ export const descargarRutinaPdf = async ({
   }
 
   addFooter(doc);
-  doc.save(`${safeFileName(titulo)}-${safeFileName(socioNombre)}.pdf`);
+  doc.save(buildTimestampedDownloadFileName(`${titulo}-${socioNombre}`, "pdf"));
 };


### PR DESCRIPTION
# PR: Gastos / Egresos con comprobantes y mejoras de exportación

## Rama

`feature/gastos-egresos-comprobantes-gym`

## Resumen

Esta PR incorpora la evolución del módulo de **Otros gastos** hacia un flujo más completo de **Gastos / Egresos**, orientado a registrar egresos operativos del gimnasio con trazabilidad, comprobantes, filtros, exportación Excel y descarga PDF membretada.

También se incorporan ajustes de QA detectados durante la validación funcional:

- Filtro por rango de fecha desde/hasta en Gastos / Egresos.
- Card de acceso a Gastos / Egresos desde Comercial / Kiosco.
- Nombre de descarga de PDFs con fecha, hora y tipo de documento.
- Nombre de descarga de Excels con fecha, hora y tipo de listado.
- Corrección de fechas visibles en frontend al formato `dd/mm/yyyy` para español.
- Correcciones puntuales de build en componentes de ficha médica relacionados con formateo de fechas.

## Cambios principales

### Gastos / Egresos

- Se amplía el formulario de gastos/egresos con campos operativos:
  - tipo de gasto;
  - estado;
  - medio de pago;
  - proveedor / entidad;
  - número de comprobante;
  - fecha de gasto;
  - fecha de vencimiento;
  - fecha de pago;
  - período cubierto desde/hasta;
  - observaciones internas;
  - comprobante por URL o carga de archivo.
- Se agrega soporte para comprobantes PDF o imagen mediante Cloudinary.
- Se mejora la vista de detalle del gasto.
- Se agregan métricas del módulo.
- Se agrega anulación lógica para evitar pérdida de trazabilidad.

### Filtros y búsqueda

- Se mantiene búsqueda por descripción, tipo, entidad, comprobante, medio y fecha.
- Se agrega filtro por estado.
- Se agrega filtro por rango de fecha desde/hasta.
- Los filtros impactan en tabla, Excel y PDF.

### Exportaciones

- Exportación Excel del listado de Gastos / Egresos.
- PDF membretado de Gastos / Egresos.
- Nombres de archivos descargados con formato:
  - `YYYYMMDD-HHMM-listado-gastos-egresos.pdf`
  - `YYYYMMDD-HHMM-listado-gastos-egresos.xlsx`
- Se incorpora helper central para nombres de archivo descargables.

### Integración en navegación

- El menú lateral muestra **Gastos / Egresos**.
- Comercial / Kiosco incorpora card de acceso a **Gastos / Egresos**.

### Documentación y Swagger

- Se actualiza Swagger/OpenAPI para reflejar los endpoints y datos del módulo.
- Se agrega documentación técnica en `docs/comercial`.

## Base de datos

Se incluye migración privada/local para ampliar el modelo de gastos/egresos:

`202605310830_gastos_egresos_comprobantes_gym.sql`

La migración fue manejada según la política del proyecto: el SQL se usa local/remoto para Supabase CLI, pero no debe quedar versionado en el repositorio público.

## Validaciones realizadas

- Migración validada primero en base QA local.
- Script de validación local ejecutado correctamente.
- Backup remoto previo realizado.
- Migración aplicada en Supabase remoto con `npx supabase db push`.
- Schema cache remoto refrescado.
- Validación remota ejecutada correctamente en Supabase Studio.
- Pruebas funcionales completas del módulo.
- Build ejecutado correctamente.

## Checklist QA

- [x] Ingreso a `/dashboard/otros-gastos` sin error.
- [x] Menú lateral muestra **Gastos / Egresos**.
- [x] Crear gasto con datos mínimos.
- [x] Crear gasto completo con estado, medio de pago, entidad y comprobante.
- [x] Subir comprobante PDF o imagen.
- [x] Pegar URL manual de comprobante.
- [x] Abrir comprobante desde el detalle.
- [x] Editar gasto.
- [x] Filtrar por estado.
- [x] Filtrar por rango de fecha desde/hasta.
- [x] Buscar por descripción, tipo, entidad, comprobante o medio.
- [x] Exportar Excel con nombre timestamp.
- [x] Descargar PDF con nombre timestamp.
- [x] Anular gasto sin borrado físico.
- [x] Acceder desde card de Comercial / Kiosco.
- [x] Validar formato de fechas visibles `dd/mm/yyyy` en español.
- [x] `npm run build` exitoso.

## Notas

No se incluyen migraciones SQL ni scripts de validación en el commit público si están ignorados por `.gitignore`, manteniendo la política de protección del know-how de Gym Master.
