### PR TITLE
feat: add employee menu permission guards

### DIFF
--- a/docs/comercial/empleados-rbac-menu-permissions.md
+++ b/docs/comercial/empleados-rbac-menu-permissions.md
@@ -1,0 +1,35 @@
+# Empleados RBAC: permisos de menú y bloqueo por ruta
+
+## Feature
+
+`feature/empleados-rbac-menu-permissions`
+
+## Objetivo
+
+Fortalecer el esquema de permisos para usuarios internos/empleados administrativos. El administrador conserva acceso total, pero puede delegar módulos específicos a usuarios internos desde el formulario de usuarios.
+
+## Alcance implementado
+
+- Se amplía el catálogo de permisos disponibles para rol `usuario`.
+- El formulario de usuarios permite marcar módulos operativos para empleados administrativos.
+- El menú lateral sigue siendo dinámico: solo muestra opciones habilitadas para el usuario.
+- El guard global del dashboard bloquea rutas no autorizadas aunque el usuario intente acceder manualmente por URL.
+- Se agrega mensaje explícito de bloqueo: `USTED NO TIENE ACCESO A ESTE MENÚ`.
+- Se corrige la sanitización de permisos para que no elimine permisos válidos que no formen parte del set default.
+- Se habilita herencia de permisos para rutas hijas/dinámicas de módulos como gestión de rutinas, dietas y evolución física.
+
+## Criterio de seguridad
+
+La seguridad no depende solo del sidebar. Aunque el menú oculte opciones no permitidas, `DashboardRouteGuard` valida el acceso por path y bloquea la navegación no autorizada.
+
+## Permisos sensibles
+
+Por seguridad, los módulos `Usuarios` y `Parametrización` siguen reservados para administradores.
+
+## Pendiente futuro
+
+- Relacionar formalmente usuarios internos con empleados.
+- Crear presets de permisos por puesto/responsabilidad.
+- Integrar permisos con catálogos parametrizables de empleados.
+- Agregar auditoría de cambios de permisos.
+- Mejorar el flujo de contraseña inicial y primer cambio obligatorio.

--- a/src/components/auth/DashboardRouteGuard.tsx
+++ b/src/components/auth/DashboardRouteGuard.tsx
@@ -25,16 +25,16 @@ function DashboardRouteUnauthorized({
 }) {
   return (
     <main className='flex min-h-screen items-center justify-center bg-background px-4 py-8'>
-      <section className='w-full max-w-lg rounded-2xl border border-red-200 bg-card p-6 text-center shadow-sm dark:border-red-900/60'>
+      <section className='w-full max-w-xl rounded-2xl border border-red-300 bg-red-50/95 p-6 text-center shadow-lg shadow-red-900/10 dark:border-red-900/70 dark:bg-red-950/80'>
         <div className='mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-300'>
           <ShieldAlert className='h-7 w-7' aria-hidden='true' />
         </div>
 
-        <h1 className='text-2xl font-semibold tracking-tight text-foreground'>
-          Acceso no autorizado
+        <h1 className='text-2xl font-bold tracking-tight text-red-700 dark:text-red-200'>
+          USTED NO TIENE ACCESO A ESTE MENÚ
         </h1>
 
-        <p className='mt-3 text-sm leading-6 text-muted-foreground'>
+        <p className='mt-3 text-sm leading-6 text-red-900/80 dark:text-red-100/80'>
           Tu usuario no tiene permisos para ingresar a esta sección del panel.
           {permissionLabel
             ? ` Se requiere el módulo “${permissionLabel}”.`

--- a/src/components/forms/UserForm.tsx
+++ b/src/components/forms/UserForm.tsx
@@ -181,6 +181,7 @@ export default function UserForm({
 
   const isSocio = form.rol === 'socio';
   const isAdmin = form.rol === 'admin';
+  const isInternalUser = form.rol === 'usuario';
   const availablePermissions = getAvailableMenuPermissionsForRole(form.rol);
   const passwordChecks = {
     minLength: form.password.length >= 8,
@@ -333,8 +334,17 @@ export default function UserForm({
             El rol administrador tiene control total del panel.
           </div>
         ) : (
-          <div className='grid gap-4 md:grid-cols-2'>
-            {availablePermissions.map((group) => (
+          <>
+            {isInternalUser && (
+              <div className='mb-4 rounded-md border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-100'>
+                Este usuario interno puede representar a un empleado administrativo.
+                Marcá solo los módulos que podrá ver y utilizar. El menú lateral
+                mostrará únicamente las opciones habilitadas y las rutas no
+                permitidas quedarán bloqueadas por seguridad.
+              </div>
+            )}
+            <div className='grid gap-4 md:grid-cols-2'>
+              {availablePermissions.map((group) => (
               <div key={group.group} className='rounded-md border bg-background p-3'>
                 <p className='mb-2 text-sm font-semibold'>{group.group}</p>
                 <div className='space-y-2'>
@@ -361,8 +371,9 @@ export default function UserForm({
                   })}
                 </div>
               </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </>
         )}
       </div>
 

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -86,18 +86,17 @@ export const MENU_PERMISSION_GROUPS: Array<{
         label: 'Actividades',
         path: '/dashboard/actividades',
         group: 'Gestión de gimnasio',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Empleados',
         label: 'Empleados',
         path: '/dashboard/empleados',
         group: 'Gestión de gimnasio',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       // Opciones legacy deshabilitadas del selector de permisos: Rutinas y Dietas.
       // La operación actual se concentra en Gestión de Rutinas y Gestión de Dietas.
-
     ],
   },
   {
@@ -115,28 +114,28 @@ export const MENU_PERMISSION_GROUPS: Array<{
         label: 'Gestión de Rutinas',
         path: '/dashboard/gestor-rutinas',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Gestión de Dietas',
         label: 'Gestión de Dietas',
         path: '/dashboard/gestor-dietas',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Gestión Evolución Física',
         label: 'Gestión Evolución Física',
         path: '/dashboard/gestor-evolucion-fisica',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Media de Ejercicios',
         label: 'Media de Ejercicios',
         path: '/dashboard/rutinas/media',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Pagos',
@@ -164,21 +163,21 @@ export const MENU_PERMISSION_GROUPS: Array<{
         label: 'Compras',
         path: '/dashboard/compras',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Cuotas',
         label: 'Cuota - Precio',
         path: '/dashboard/cuotas',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Proveedores',
         label: 'Proveedores',
         path: '/dashboard/proveedores',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Usuarios',
@@ -192,49 +191,49 @@ export const MENU_PERMISSION_GROUPS: Array<{
         label: 'Productos',
         path: '/dashboard/productos',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Servicios',
         label: 'Servicios',
         path: '/dashboard/servicios',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Gastos / Egresos',
         label: 'Gastos / Egresos',
         path: '/dashboard/otros-gastos',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Finanzas / BI',
         label: 'Finanzas / BI',
         path: '/dashboard/finanzas',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Sueldos',
         label: 'Sueldos',
         path: '/dashboard/empleados-sueldos',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Avisos',
         label: 'Avisos',
         path: '/dashboard/avisos',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Equipamientos',
         label: 'Equipamientos',
         path: '/dashboard/equipamientos',
         group: 'Administración',
-        roles: ['admin'],
+        roles: ['admin', 'usuario'],
       },
       {
         key: 'Parametrización',
@@ -268,16 +267,17 @@ export const MENU_PERMISSION_GROUPS: Array<{
 
 export const DEFAULT_MENU_PERMISSIONS_BY_ROLE: Record<AppRole, string[]> = {
   admin: MENU_PERMISSION_GROUPS.flatMap((group) =>
-    group.items.filter((item) => item.roles.includes('admin')).map((item) => item.key)
+    group.items
+      .filter((item) => item.roles.includes('admin'))
+      .map((item) => item.key)
   ),
   usuario: [
     'Inicio',
-    'Asistencias',
     'Socios',
+    'Asistencias',
     'Pagos',
+    'Comercial / Kiosco',
     'Ventas',
-    'Rutinas',
-    'Dietas',
     'Perfil',
     'Preferencias',
   ],
@@ -288,14 +288,11 @@ export const DEFAULT_MENU_PERMISSIONS_BY_ROLE: Record<AppRole, string[]> = {
     'Asistente de Rutinas',
     'Pagar cuota',
     'Historial de pagos',
-    'Rutinas',
-    'Dietas',
     'Evolución Física',
     'Perfil',
     'Preferencias',
   ],
 };
-
 
 export type DashboardRoutePermission = {
   path: string;
@@ -310,7 +307,7 @@ const MENU_DASHBOARD_ROUTE_PERMISSIONS: DashboardRoutePermission[] =
       path: item.path,
       permissionKey: item.key,
       roles: item.roles,
-      exact: true,
+      exact: item.path === '/dashboard',
     }))
   );
 
@@ -325,14 +322,14 @@ export const DASHBOARD_ROUTE_PERMISSIONS: DashboardRoutePermission[] = [
   {
     path: '/dashboard/bi-cuotas-pagos',
     permissionKey: 'Pagos',
-    roles: ['admin'],
+    roles: ['admin', 'usuario'],
     exact: true,
   },
   {
     path: '/dashboard/gestion-dietas',
     permissionKey: 'Gestión de Dietas',
-    roles: ['admin'],
-    exact: true,
+    roles: ['admin', 'usuario'],
+    exact: false,
   },
   {
     path: '/dashboard/asistencias/terminal',
@@ -363,11 +360,23 @@ function normalizeAppRole(role?: string | null): AppRole | null {
   return null;
 }
 
+function getAllowedPermissionKeysForRole(role: AppRole) {
+  return new Set(
+    MENU_PERMISSION_GROUPS.flatMap((group) =>
+      group.items
+        .filter((item) => item.roles.includes(role))
+        .map((item) => item.key)
+    )
+  );
+}
+
 export function getDashboardRoutePermission(pathname?: string | null) {
   const normalizedPath = normalizeDashboardPath(pathname);
 
   const exactMatch = DASHBOARD_ROUTE_PERMISSIONS.find(
-    (route) => normalizeDashboardPath(route.path) === normalizedPath
+    (route) =>
+      normalizeDashboardPath(route.path) === normalizedPath &&
+      route.exact !== false
   );
 
   if (exactMatch) return exactMatch;
@@ -377,7 +386,10 @@ export function getDashboardRoutePermission(pathname?: string | null) {
     .sort((a, b) => b.path.length - a.path.length)
     .find((route) => {
       const normalizedRoutePath = normalizeDashboardPath(route.path);
-      return normalizedPath.startsWith(`${normalizedRoutePath}/`);
+      return (
+        normalizedPath === normalizedRoutePath ||
+        normalizedPath.startsWith(`${normalizedRoutePath}/`)
+      );
     });
 }
 
@@ -428,10 +440,16 @@ export function sanitizeMenuPermissionsForRole(
     return null;
   }
 
-  const allowed = new Set(DEFAULT_MENU_PERMISSIONS_BY_ROLE[normalizedRole] ?? []);
+  if (!['usuario', 'socio'].includes(normalizedRole)) {
+    return [];
+  }
+
+  const allowed = getAllowedPermissionKeysForRole(normalizedRole);
 
   if (!Array.isArray(permissions)) {
-    return [...allowed];
+    return [...(DEFAULT_MENU_PERMISSIONS_BY_ROLE[normalizedRole] ?? [])].filter(
+      (item) => allowed.has(item)
+    );
   }
 
   const clean = permissions
@@ -451,9 +469,15 @@ export function getEffectiveMenuPermissions(
     return DEFAULT_MENU_PERMISSIONS_BY_ROLE.admin;
   }
 
-  if (Array.isArray(permissions)) {
-    return permissions;
+  if (normalizedRole === 'usuario' || normalizedRole === 'socio') {
+    const allowed = getAllowedPermissionKeysForRole(normalizedRole);
+
+    if (Array.isArray(permissions)) {
+      return permissions.filter((item) => allowed.has(item));
+    }
+
+    return DEFAULT_MENU_PERMISSIONS_BY_ROLE[normalizedRole] ?? [];
   }
 
-  return DEFAULT_MENU_PERMISSIONS_BY_ROLE[normalizedRole] ?? [];
+  return [];
 }


### PR DESCRIPTION
# PR: Empleados RBAC - permisos de menú y bloqueo por ruta

## Rama

`feature/empleados-rbac-menu-permissions`

## Resumen

Esta feature fortalece el esquema de permisos para usuarios internos y empleados administrativos. El administrador conserva acceso total, mientras que los usuarios internos pueden recibir permisos específicos por menú desde el formulario de usuarios.

El cambio mantiene un sidebar dinámico, pero agrega una capa de seguridad adicional mediante `DashboardRouteGuard`, bloqueando rutas no autorizadas incluso si el usuario intenta acceder manualmente por URL.

## Cambios principales

- Se amplió el catálogo de permisos disponibles para usuarios internos.
- Se ajustó `UserForm` para permitir marcar módulos operativos delegables.
- Se mantiene el sidebar dinámico mostrando solo los módulos habilitados.
- Se reforzó `DashboardRouteGuard` para bloquear accesos manuales por URL.
- Se agregó el mensaje de bloqueo: `USTED NO TIENE ACCESO A ESTE MENÚ`.
- Se corrigió la sanitización de permisos para no eliminar permisos válidos fuera del set default.
- Se agregó herencia de permisos para rutas hijas y dinámicas.
- Se mantuvieron `Usuarios` y `Parametrización` como módulos reservados para administradores.
- Se agregó documentación técnica en `docs/comercial/empleados-rbac-menu-permissions.md`.

## Módulos delegables validados

- Socios
- Asistencias
- Pagos
- Comercial / Kiosco
- Ventas
- Compras
- Productos
- Proveedores
- Gastos / Egresos
- Finanzas / BI
- Sueldos

## Módulos reservados

- Usuarios: solo administrador.
- Parametrización: solo administrador.

## Archivos principales modificados

- `src/lib/permissions/menuPermissions.ts`
- `src/components/auth/DashboardRouteGuard.tsx`
- `src/components/forms/UserForm.tsx`
- `docs/comercial/empleados-rbac-menu-permissions.md`

## Base de datos

No requiere migración.

La feature reutiliza la columna existente:

`usuario.permisos_menu`

Por este motivo no se ejecutó `db push` ni backup remoto para esta rama.

## Validaciones realizadas

- Edición de usuario interno con permisos de menú.
- Sidebar con módulos habilitados.
- Ocultamiento de módulos no permitidos.
- Bloqueo por URL manual con mensaje de acceso denegado.
- Rutas hijas/dinámicas heredando permiso del módulo padre.
- Módulos sensibles reservados para admin.
- `npm run build` exitoso.

## Checklist

- [x] Permisos ampliados para usuarios internos / empleados administrativos.
- [x] Sidebar dinámico validado.
- [x] Bloqueo por ruta manual validado.
- [x] Mensaje de acceso denegado implementado.
- [x] Usuarios y Parametrización reservados para admin.
- [x] Documentación técnica agregada.
- [x] Sin migración de base de datos.
- [x] Build exitoso.

## Pendientes futuros relacionados

- Relacionar formalmente usuarios internos con empleados.
- Crear presets de permisos por puesto/responsabilidad.
- Integrar permisos con catálogos parametrizables de empleados.
- Agregar auditoría de cambios de permisos.
- Implementar contraseña inicial `GymMaster + DNI` con cambio obligatorio en primer ingreso.
- Implementar flujo `¿Olvidaste tu contraseña?` para administrador, usuario interno/empleado y socio.
