### PR TITLE
feat: add first login password change flow

### DIFF
--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -26,7 +26,7 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   try {
     const { user } = await authMiddleware(req);
-    const { nombre, email, password, rol, dni, foto, permisos_menu } = await req.json();
+    const { nombre, email, password, rol, dni, foto, permisos_menu, use_initial_password } = await req.json();
 
     const creado = await createUsuarioServer(user, {
       nombre,
@@ -36,6 +36,7 @@ export async function POST(req: Request) {
       dni,
       foto,
       permisos_menu,
+      use_initial_password,
     });
 
     return NextResponse.json(

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -17,14 +17,14 @@ import {
 
 export default function LoginEntryPage() {
   const router = useRouter();
-  const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { isAuthenticated, initializeAuth, isInitialized, user } = useAuthStore();
 
   useEffect(() => {
     initializeAuth();
     if (isInitialized && isAuthenticated) {
-      router.push('/dashboard');
+      router.push(user?.must_change_password ? '/auth/change-password' : '/dashboard');
     }
-  }, [initializeAuth, isAuthenticated, isInitialized, router]);
+  }, [initializeAuth, isAuthenticated, isInitialized, router, user?.must_change_password]);
 
   return (
     <div className='flex min-h-screen flex-col items-center justify-center gap-6 bg-background px-4'>

--- a/src/components/auth/DashboardRouteGuard.tsx
+++ b/src/components/auth/DashboardRouteGuard.tsx
@@ -80,12 +80,22 @@ export default function DashboardRouteGuard({
     }
   }, [isAuthenticated, isInitialized, router]);
 
+  useEffect(() => {
+    if (isInitialized && isAuthenticated && user?.must_change_password) {
+      router.replace('/auth/change-password');
+    }
+  }, [isAuthenticated, isInitialized, router, user?.must_change_password]);
+
   if (!isInitialized) {
     return <DashboardRouteLoading />;
   }
 
   if (!isAuthenticated || !user) {
     return null;
+  }
+
+  if (user.must_change_password) {
+    return <DashboardRouteLoading />;
   }
 
   const canAccess = canAccessDashboardPath(

--- a/src/components/auth/GymMasterLoginForm.tsx
+++ b/src/components/auth/GymMasterLoginForm.tsx
@@ -143,7 +143,8 @@ export default function GymMasterLoginForm({
   useEffect(() => {
     initializeAuth();
     if (isInitialized && isAuthenticated) {
-      router.push('/dashboard');
+      const currentUser = useAuthStore.getState().user;
+      router.push(currentUser?.must_change_password ? '/auth/change-password' : '/dashboard');
     }
   }, [initializeAuth, isAuthenticated, isInitialized, router]);
 
@@ -181,13 +182,19 @@ export default function GymMasterLoginForm({
       return;
     }
 
-    const success = await authLogin({
+    const result = await authLogin({
       email: email.trim(),
       password: password.trim(),
       rol: selectedRole,
     });
 
-    if (success) {
+    if (result.success) {
+      if (result.mustChangePassword) {
+        toast.info('Por seguridad, debés cambiar tu contraseña inicial.');
+        router.push('/auth/change-password');
+        return;
+      }
+
       toast.success('Inicio de sesión exitoso');
       router.push('/dashboard');
     }

--- a/src/components/forms/UserForm.tsx
+++ b/src/components/forms/UserForm.tsx
@@ -19,6 +19,7 @@ import {
   getAvailableMenuPermissionsForRole,
   sanitizeMenuPermissionsForRole,
 } from '@/lib/permissions/menuPermissions';
+import { buildInitialPasswordFromDni, getPasswordPolicyChecks } from '@/utils/passwordPolicy';
 
 export interface UserFormProps {
   usuario?: Usuario | null;
@@ -33,6 +34,7 @@ const emptyForm = {
   confirmPassword: '',
   rol: 'socio',
   dni: '',
+  use_initial_password: true,
   permisos_menu: DEFAULT_MENU_PERMISSIONS_BY_ROLE.socio,
 };
 
@@ -59,7 +61,8 @@ export default function UserForm({
         rol: usuario.rol ?? 'socio',
         password: '',
         confirmPassword: '',
-        dni: '',
+        dni: usuario.dni ?? '',
+        use_initial_password: false,
         permisos_menu: getInitialPermissions(usuario.rol, usuario.permisos_menu),
       });
     } else {
@@ -136,19 +139,28 @@ export default function UserForm({
         toast.success('Usuario actualizado exitosamente.');
       } else {
         const rol = form.rol || 'socio';
+        const useInitialPassword = form.use_initial_password;
+        const initialPassword = buildInitialPasswordFromDni(form.dni);
         const createData: CreateUsuarioDto = {
           nombre: form.nombre,
           email: form.email,
-          password: form.password,
+          password: useInitialPassword ? initialPassword : form.password,
           rol,
+          dni: form.dni,
+          use_initial_password: useInitialPassword,
           permisos_menu:
             rol === 'admin'
               ? null
               : sanitizeMenuPermissionsForRole(rol, form.permisos_menu),
-          ...(rol === 'socio' && { dni: form.dni }),
         };
 
-        if (!createData.password) {
+        if (useInitialPassword && !form.dni.trim()) {
+          toast.error('El DNI es obligatorio para generar la contraseña inicial.');
+          setLoading(false);
+          return;
+        }
+
+        if (!useInitialPassword && !createData.password) {
           toast.error(
             'La contraseña es obligatoria para crear un nuevo usuario.'
           );
@@ -163,7 +175,11 @@ export default function UserForm({
         }
 
         await createUsuarioApi(createData);
-        toast.success('Usuario creado exitosamente.');
+        toast.success(
+          useInitialPassword
+            ? `Usuario creado. Contraseña inicial: ${initialPassword}`
+            : 'Usuario creado exitosamente.'
+        );
       }
       setForm(emptyForm);
       onCreated();
@@ -183,14 +199,13 @@ export default function UserForm({
   const isAdmin = form.rol === 'admin';
   const isInternalUser = form.rol === 'usuario';
   const availablePermissions = getAvailableMenuPermissionsForRole(form.rol);
-  const passwordChecks = {
-    minLength: form.password.length >= 8,
-    uppercase: /[A-Z]/.test(form.password),
-    lowercase: /[a-z]/.test(form.password),
-    number: /\d/.test(form.password),
-    symbol: /[^A-Za-z0-9]/.test(form.password),
-  };
-  const isPasswordRequired = !usuario || form.password.length > 0 || form.confirmPassword.length > 0;
+  const isInitialPasswordMode = !usuario && form.use_initial_password;
+  const normalizedDni = form.dni.replace(/\D/g, '');
+  const initialPasswordPreview = normalizedDni
+    ? buildInitialPasswordFromDni(normalizedDni)
+    : 'GymMaster + DNI';
+  const passwordChecks = getPasswordPolicyChecks(form.password);
+  const isPasswordRequired = !isInitialPasswordMode && (!usuario || form.password.length > 0 || form.confirmPassword.length > 0);
   const isPasswordValid = Object.values(passwordChecks).every(Boolean);
   const passwordsMatch = form.password === form.confirmPassword && form.confirmPassword.length > 0;
   const showPasswordRules = isPasswordRequired || form.password.length > 0 || form.confirmPassword.length > 0;
@@ -241,20 +256,49 @@ export default function UserForm({
         </select>
       </div>
 
-      {isSocio && !usuario && (
+      {!usuario && (
         <div className='flex flex-col gap-1.5'>
           <Label htmlFor='dni'>DNI</Label>
           <Input
             id='dni'
             name='dni'
-            placeholder='Ingrese DNI del socio'
+            placeholder='Ingrese DNI para contraseña inicial'
             value={form.dni}
             onChange={handleChange}
-            required={isSocio && !usuario}
+            required={isSocio || isInitialPasswordMode}
           />
         </div>
       )}
 
+      {!usuario && (
+        <div className='col-span-full rounded-lg border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-100'>
+          <label className='flex cursor-pointer items-start gap-2'>
+            <Checkbox
+              checked={form.use_initial_password}
+              onCheckedChange={(checked) =>
+                setForm((prev) => ({
+                  ...prev,
+                  use_initial_password: Boolean(checked),
+                  password: Boolean(checked) ? '' : prev.password,
+                  confirmPassword: Boolean(checked) ? '' : prev.confirmPassword,
+                }))
+              }
+            />
+            <span>
+              <span className='font-medium'>
+                Usar contraseña inicial automática
+              </span>
+              <span className='block text-xs'>
+                Patrón: <strong>{initialPasswordPreview}</strong>. En el primer
+                ingreso el usuario deberá cambiarla obligatoriamente.
+              </span>
+            </span>
+          </label>
+        </div>
+      )}
+
+      {!isInitialPasswordMode && (
+        <>
       <div className='flex flex-col gap-1.5'>
         <Label htmlFor='password'>Contraseña</Label>
         <div className='relative'>
@@ -306,6 +350,9 @@ export default function UserForm({
           </button>
         </div>
       </div>
+
+        </>
+      )}
 
       {showPasswordRules && (
         <div className='col-span-full rounded-md border bg-muted/20 p-3 text-sm'>

--- a/src/interfaces/jwtUser.interface.ts
+++ b/src/interfaces/jwtUser.interface.ts
@@ -7,6 +7,7 @@ export interface JwtUser {
   nombre?: string;
   foto?: string | null;
   permisos_menu?: string[] | null;
+  must_change_password?: boolean;
   exp?: number;
   iat?: number;
 }

--- a/src/interfaces/usuario.interface.ts
+++ b/src/interfaces/usuario.interface.ts
@@ -7,15 +7,21 @@ export interface Usuario {
   activo: boolean;
   creado_en?: Date;
   foto?: string;
+  dni?: string | null;
   permisos_menu?: string[] | null;
+  must_change_password?: boolean;
+  password_actualizado_en?: Date | string | null;
+  primer_login_en?: Date | string | null;
+  ultimo_login_en?: Date | string | null;
 }
 
 export interface CreateUsuarioDto {
   nombre: string;
   email: string;
-  password: string;
+  password?: string;
   rol?: string;
   dni?: string;
+  use_initial_password?: boolean;
   foto?: string;
   permisos_menu?: string[] | null;
 }
@@ -28,7 +34,9 @@ export interface UpdateUsuarioDto {
   rol?: string;
   activo?: boolean;
   foto?: string;
+  dni?: string | null;
   permisos_menu?: string[] | null;
+  must_change_password?: boolean;
 }
 
 export interface ResponseUsuario {
@@ -38,6 +46,11 @@ export interface ResponseUsuario {
   rol: string;
   activo: boolean;
   foto?: string;
+  dni?: string | null;
   creado_en?: Date;
   permisos_menu?: string[] | null;
+  must_change_password?: boolean;
+  password_actualizado_en?: Date | string | null;
+  primer_login_en?: Date | string | null;
+  ultimo_login_en?: Date | string | null;
 }

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -18,6 +18,27 @@ type OpenApiPathItem = Record<string, OpenApiOperation>;
 const endpointDefinitions: EndpointDefinition[] = [
 
   {
+    "path": "/api/auth/change-password",
+    "methods": [
+      "POST"
+    ],
+    "tag": "Auth",
+    "summary": "Cambio obligatorio de contraseña inicial",
+    "description": "Permite que un usuario autenticado cambie su contraseña temporal inicial y reciba un token actualizado sin la marca must_change_password.",
+    "auth": true,
+    "admin": false,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      400,
+      401,
+      500
+    ],
+    "queryParams": [],
+    "source": "src/app/api/auth/change-password/route.ts"
+  },
+
+  {
     "path": "/api/empleados",
     "methods": [
       "GET",

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -42,7 +42,7 @@ export const signIn = async (login: SignInDto) => {
   //BUSCO EN ESA BD, EL USUARIO
   const { data, error } = await supabase
     .from('usuario')
-    .select('id,nombre,email,password_hash,rol,activo,foto,permisos_menu')
+    .select('id,nombre,email,password_hash,rol,activo,foto,permisos_menu,must_change_password')
     .eq('email', email)
     .single();
 
@@ -105,6 +105,7 @@ export const signIn = async (login: SignInDto) => {
     nombre: data.nombre,
     foto: data.foto ? data.foto : null,
     permisos_menu: sanitizeMenuPermissionsForRole(data.rol, data.permisos_menu),
+    must_change_password: Boolean(data.must_change_password),
   };
 
   if (rol === 'socio') {
@@ -170,6 +171,11 @@ export const signIn = async (login: SignInDto) => {
 
     basePayload.id_socio = socio.id_socio;
   }
+
+  await supabase
+    .from('usuario')
+    .update({ ultimo_login_en: new Date().toISOString() })
+    .eq('id', data.id);
 
   const payload = basePayload;
   if (!process.env.JWT_SECRET) {

--- a/src/services/server/usuarioServerService.ts
+++ b/src/services/server/usuarioServerService.ts
@@ -9,9 +9,12 @@ import {
 import { sanitizeMenuPermissionsForRole } from '@/lib/permissions/menuPermissions';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+import { buildInitialPasswordFromDni } from '@/utils/passwordPolicy';
 
 const allowedManagerRoles = new Set(['admin', 'usuario']);
 const allowedRoles = new Set(['admin', 'usuario', 'socio']);
+const USUARIO_SELECT =
+  'id,nombre,email,rol,activo,foto,dni,permisos_menu,must_change_password,password_actualizado_en,primer_login_en,ultimo_login_en';
 
 function assertCanManageUsers(user: JwtUser) {
   if (!allowedManagerRoles.has(user.rol)) {
@@ -27,7 +30,12 @@ function toResponseUsuario(usuario: Usuario): ResponseUsuario {
     rol: usuario.rol,
     activo: usuario.activo,
     foto: usuario.foto,
+    dni: usuario.dni ?? null,
     permisos_menu: usuario.permisos_menu ?? null,
+    must_change_password: Boolean(usuario.must_change_password),
+    password_actualizado_en: usuario.password_actualizado_en ?? null,
+    primer_login_en: usuario.primer_login_en ?? null,
+    ultimo_login_en: usuario.ultimo_login_en ?? null,
   };
 }
 
@@ -47,7 +55,7 @@ export const fetchUsuariosServer = async (
 
   const { data, error } = await supabase
     .from('usuario')
-    .select('id,nombre,email,rol,activo,foto,permisos_menu')
+    .select(USUARIO_SELECT)
     .order('creado_en', { ascending: false });
 
   if (error) throw new Error(error.message);
@@ -64,16 +72,26 @@ export const createUsuarioServer = async (
   const rol = sanitizeRole(payload.rol);
   const email = payload.email?.trim().toLowerCase();
   const nombre = payload.nombre?.trim();
+  const dni = payload.dni?.trim() ?? '';
+  const useInitialPassword = payload.use_initial_password ?? true;
 
-  if (!nombre || !email || !payload.password?.trim()) {
-    throw new Error('Nombre, email y contraseña son obligatorios');
+  if (!nombre || !email) {
+    throw new Error('Nombre y email son obligatorios');
   }
 
-  if (rol === 'socio' && !payload.dni?.trim()) {
-    throw new Error('El DNI es obligatorio para crear un usuario socio');
+  if ((rol === 'socio' || useInitialPassword) && !dni) {
+    throw new Error('El DNI es obligatorio para generar la contraseña inicial');
   }
 
-  const password_hash = await bcrypt.hash(payload.password.trim(), 10);
+  const plainPassword = useInitialPassword
+    ? buildInitialPasswordFromDni(dni)
+    : payload.password?.trim();
+
+  if (!plainPassword) {
+    throw new Error('La contraseña es obligatoria para crear un usuario');
+  }
+
+  const password_hash = await bcrypt.hash(plainPassword, 10);
 
   const { data: usuarioCreado, error: usuarioError } = await supabase
     .from('usuario')
@@ -85,10 +103,13 @@ export const createUsuarioServer = async (
         rol,
         activo: true,
         foto: payload.foto ?? null,
+        dni: dni || null,
         permisos_menu: sanitizeMenuPermissionsForRole(rol, payload.permisos_menu),
+        must_change_password: useInitialPassword,
+        password_actualizado_en: null,
       },
     ])
-    .select('id,nombre,email,rol,activo,foto,permisos_menu')
+    .select(USUARIO_SELECT)
     .single();
 
   if (usuarioError) throw new Error(usuarioError.message);
@@ -98,7 +119,7 @@ export const createUsuarioServer = async (
       {
         usuario_id: usuarioCreado.id,
         nombre_completo: nombre,
-        dni: payload.dni?.trim(),
+        dni,
         email,
         activo: true,
         foto: payload.foto ?? null,
@@ -137,6 +158,10 @@ export const updateUsuarioServer = async (
     payload.nombre = updateData.nombre.trim();
   }
 
+  if (typeof updateData.dni === 'string') {
+    payload.dni = updateData.dni.trim() || null;
+  }
+
   const nextRole = typeof updateData.rol === 'string' ? sanitizeRole(updateData.rol) : undefined;
 
   if (nextRole) {
@@ -152,6 +177,8 @@ export const updateUsuarioServer = async (
 
   if (updateData.password) {
     payload.password_hash = await bcrypt.hash(updateData.password.trim(), 10);
+    payload.must_change_password = Boolean(updateData.must_change_password);
+    payload.password_actualizado_en = new Date().toISOString();
     delete payload.password;
   }
 
@@ -159,7 +186,7 @@ export const updateUsuarioServer = async (
     .from('usuario')
     .update(payload)
     .eq('id', id)
-    .select('id,nombre,email,rol,activo,foto,permisos_menu')
+    .select(USUARIO_SELECT)
     .single();
 
   if (error) throw new Error(error.message);
@@ -179,7 +206,7 @@ export const deactivateUsuarioServer = async (
     .from('usuario')
     .update({ activo: false })
     .eq('id', id)
-    .select('id,nombre,email,rol,activo,foto,permisos_menu')
+    .select(USUARIO_SELECT)
     .single();
 
   if (error) throw new Error(error.message);
@@ -199,7 +226,7 @@ export const getUsuarioByIdServer = async (
   const supabase = getSupabaseServerClient();
   const { data, error } = await supabase
     .from('usuario')
-    .select('id,nombre,email,rol,activo,foto,permisos_menu')
+    .select(USUARIO_SELECT)
     .eq('id', id)
     .single();
 

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -8,6 +8,7 @@ interface JwtPayload {
   rol: string;
   nombre?: string;
   permisos_menu?: string[] | null;
+  must_change_password?: boolean;
   exp?: number;
 }
 

--- a/src/services/usuarioService.ts
+++ b/src/services/usuarioService.ts
@@ -4,6 +4,7 @@ import { JwtUser } from '@/interfaces/jwtUser.interface';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 import { updateFotoSocioById } from './socioService';
 import { sanitizeMenuPermissionsForRole } from '@/lib/permissions/menuPermissions';
+import { buildInitialPasswordFromDni } from '@/utils/passwordPolicy';
 
 export const fetchUsuarios = async (_user?: JwtUser): Promise<ResponseUsuario[]> => {
   const supabase = conexionBD();
@@ -24,7 +25,12 @@ const responseUsuario = (data : Usuario[]) : ResponseUsuario[]=>{
     rol: usuario.rol,
     activo: usuario.activo,
     foto: usuario.foto,
+    dni: usuario.dni ?? null,
     permisos_menu: usuario.permisos_menu ?? null,
+    must_change_password: Boolean(usuario.must_change_password),
+    password_actualizado_en: usuario.password_actualizado_en ?? null,
+    primer_login_en: usuario.primer_login_en ?? null,
+    ultimo_login_en: usuario.ultimo_login_en ?? null,
   }))
 }
 
@@ -33,11 +39,20 @@ export const createUsuarios = async (_user: JwtUser | undefined, payload: Create
 
   const rol = payload.rol || 'socio';
 
-  if (rol === 'socio' && !payload.dni?.trim()) {
-    throw new Error('El DNI es obligatorio para crear un usuario socio.');
+  const dni = payload.dni?.trim() ?? '';
+  const useInitialPassword = payload.use_initial_password ?? true;
+
+  if ((rol === 'socio' || useInitialPassword) && !dni) {
+    throw new Error('El DNI es obligatorio para generar la contraseña inicial.');
   }
 
-  const password_hash = await bcrypt.hash(payload.password, 10);
+  const plainPassword = useInitialPassword ? buildInitialPasswordFromDni(dni) : payload.password?.trim();
+
+  if (!plainPassword) {
+    throw new Error('La contraseña es obligatoria para crear un usuario.');
+  }
+
+  const password_hash = await bcrypt.hash(plainPassword, 10);
 
   const { data: usuarioCreado, error: usuarioError } = await supabase
     .from('usuario')
@@ -48,7 +63,10 @@ export const createUsuarios = async (_user: JwtUser | undefined, payload: Create
       rol,
       activo: true,
       foto: payload.foto ?? null,
+      dni: dni || null,
       permisos_menu: sanitizeMenuPermissionsForRole(rol, payload.permisos_menu),
+      must_change_password: useInitialPassword,
+      password_actualizado_en: null,
     }])
     .select()
     .single();
@@ -61,7 +79,7 @@ export const createUsuarios = async (_user: JwtUser | undefined, payload: Create
       .insert([{
         usuario_id: usuarioCreado.id,
         nombre_completo: payload.nombre,
-        dni: payload.dni?.trim(),
+        dni,
         email: payload.email,
         activo: true,
         foto: payload.foto ?? null,

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -16,6 +16,7 @@ type StoreUser = Partial<Usuario> & {
   email?: string;
   rol?: string;
   permisos_menu?: string[] | null;
+  must_change_password?: boolean;
 };
 
 interface AuthState {
@@ -29,10 +30,11 @@ interface AuthState {
     email: string;
     password: string;
     rol: string;
-  }) => Promise<boolean>;
+  }) => Promise<{ success: boolean; mustChangePassword?: boolean }>;
   logout: () => void;
   initializeAuth: () => void;
   updateUser: (patch: Partial<StoreUser>) => void;
+  refreshSession: (token: string) => void;
   clearError: () => void;
 }
 
@@ -60,20 +62,20 @@ export const useAuthStore = create<AuthState>()(
               error: null,
               isInitialized: true,
             });
-            return true;
+            return { success: true, mustChangePassword: Boolean(decoded.must_change_password) };
           } else {
             set({
               error: result.message || 'Error de autenticación',
               isLoading: false,
             });
-            return false;
+            return { success: false };
           }
         } catch {
           set({
             error: 'Error de conexión',
             isLoading: false,
           });
-          return false;
+          return { success: false };
         }
       },
       logout: () => {
@@ -110,6 +112,18 @@ export const useAuthStore = create<AuthState>()(
         const currentUser = get().user;
         set({
           user: currentUser ? { ...currentUser, ...patch } : currentUser,
+        });
+      },
+      refreshSession: (token) => {
+        const decoded = jwtDecode<StoreUser>(token);
+        loginSession(token);
+        set({
+          user: decoded,
+          token,
+          isAuthenticated: true,
+          isLoading: false,
+          error: null,
+          isInitialized: true,
         });
       },
       clearError: () => {

--- a/src/utils/passwordPolicy.ts
+++ b/src/utils/passwordPolicy.ts
@@ -1,0 +1,154 @@
+export type PasswordPolicyCheckKey =
+  | 'minLength'
+  | 'lowercase'
+  | 'uppercase'
+  | 'number'
+  | 'symbol';
+
+export type PasswordPolicyChecks = Record<PasswordPolicyCheckKey, boolean>;
+
+export type PasswordPolicyCheck = {
+  key: PasswordPolicyCheckKey;
+  label: string;
+  valid: boolean;
+};
+
+export type PasswordPolicyResult = {
+  isValid: boolean;
+  valid: boolean;
+  score: number;
+  errors: string[];
+  checks: PasswordPolicyCheck[];
+  checksMap: PasswordPolicyChecks;
+};
+
+export const PASSWORD_POLICY = {
+  minLength: 8,
+  requireLowercase: true,
+  requireUppercase: true,
+  requireNumber: true,
+  requireSymbol: true,
+};
+
+export const PASSWORD_REQUIREMENTS = {
+  minLength: 'Mínimo 8 caracteres',
+  lowercase: 'Al menos una minúscula',
+  uppercase: 'Al menos una mayúscula',
+  number: 'Al menos un número',
+  symbol: 'Al menos un símbolo',
+};
+
+export function normalizeDniForPassword(dni: string | number | null | undefined): string {
+  return String(dni ?? '').replace(/\D/g, '').trim();
+}
+
+export function generateInitialPassword(dni: string | number | null | undefined): string {
+  return `GymMaster${normalizeDniForPassword(dni)}`;
+}
+
+export function buildInitialPasswordFromDni(dni: string | number | null | undefined): string {
+  return generateInitialPassword(dni);
+}
+
+export function buildInitialPassword(dni: string | number | null | undefined): string {
+  return generateInitialPassword(dni);
+}
+
+export function getInitialPassword(dni: string | number | null | undefined): string {
+  return generateInitialPassword(dni);
+}
+
+export function getTemporaryPasswordFromDni(dni: string | number | null | undefined): string {
+  return generateInitialPassword(dni);
+}
+
+export function getPasswordPolicyChecks(password: string | null | undefined): PasswordPolicyChecks {
+  const value = String(password ?? '');
+
+  return {
+    minLength: value.length >= PASSWORD_POLICY.minLength,
+    lowercase: /[a-záéíóúñ]/.test(value),
+    uppercase: /[A-ZÁÉÍÓÚÑ]/.test(value),
+    number: /\d/.test(value),
+    symbol: /[^A-Za-zÁÉÍÓÚáéíóúÑñ0-9]/.test(value),
+  };
+}
+
+export function getPasswordPolicyCheckList(password: string | null | undefined): PasswordPolicyCheck[] {
+  const checks = getPasswordPolicyChecks(password);
+
+  return [
+    {
+      key: 'minLength',
+      label: PASSWORD_REQUIREMENTS.minLength,
+      valid: checks.minLength,
+    },
+    {
+      key: 'lowercase',
+      label: PASSWORD_REQUIREMENTS.lowercase,
+      valid: checks.lowercase,
+    },
+    {
+      key: 'uppercase',
+      label: PASSWORD_REQUIREMENTS.uppercase,
+      valid: checks.uppercase,
+    },
+    {
+      key: 'number',
+      label: PASSWORD_REQUIREMENTS.number,
+      valid: checks.number,
+    },
+    {
+      key: 'symbol',
+      label: PASSWORD_REQUIREMENTS.symbol,
+      valid: checks.symbol,
+    },
+  ];
+}
+
+export function validatePasswordPolicy(password: string | null | undefined): PasswordPolicyResult {
+  const checksMap = getPasswordPolicyChecks(password);
+  const checks = getPasswordPolicyCheckList(password);
+  const errors = checks.filter((check) => !check.valid).map((check) => check.label);
+  const score = checks.filter((check) => check.valid).length;
+  const isValid = errors.length === 0;
+
+  return {
+    isValid,
+    valid: isValid,
+    score,
+    errors,
+    checks,
+    checksMap,
+  };
+}
+
+export function validatePasswordStrength(password: string | null | undefined): PasswordPolicyResult {
+  return validatePasswordPolicy(password);
+}
+
+export function passwordMeetsPolicy(password: string | null | undefined): boolean {
+  return validatePasswordPolicy(password).isValid;
+}
+
+export function isStrongPassword(password: string | null | undefined): boolean {
+  return validatePasswordPolicy(password).isValid;
+}
+
+export function getPasswordPolicyErrors(password: string | null | undefined): string[] {
+  return validatePasswordPolicy(password).errors;
+}
+
+export function getPasswordPolicyMessage(password?: string | null): string {
+  if (password === undefined || password === null) {
+    return 'La contraseña debe tener mínimo 8 caracteres, una minúscula, una mayúscula, un número y un símbolo.';
+  }
+
+  const errors = getPasswordPolicyErrors(password);
+
+  if (errors.length === 0) {
+    return 'La contraseña cumple con los requisitos de seguridad.';
+  }
+
+  return `La contraseña no cumple con los requisitos: ${errors.join(', ')}.`;
+}


### PR DESCRIPTION
# PR — Auth first login password change

## Rama

`feature/auth-first-login-password-change`

## Objetivo

Implementar un flujo seguro para usuarios creados por administración con contraseña inicial temporal, obligando el cambio de contraseña en el primer ingreso antes de permitir el uso normal del dashboard.

## Alcance implementado

- Contraseña inicial automática con patrón `GymMaster + DNI`.
- Nuevo control en `UserForm` para usar contraseña inicial automática.
- DNI requerido cuando se utiliza contraseña inicial.
- Visualización informativa de la contraseña inicial generada durante el alta.
- Nuevo campo lógico `must_change_password` para forzar cambio obligatorio.
- Nuevo flujo `/auth/change-password`.
- Nuevo endpoint `POST /api/auth/change-password`.
- Redirección automática al cambio de contraseña cuando el usuario inicia sesión con contraseña temporal.
- Bloqueo del dashboard mientras `must_change_password = true`.
- Actualización de sesión/JWT para contemplar `must_change_password`.
- Registro de fechas de primer login, último login y actualización de contraseña.
- Swagger/OpenAPI actualizado.
- Documentación técnica agregada en `docs/auth`.

## Cambios de base de datos

Migración privada/local aplicada y validada:

`202606011745_auth_first_login_password_change.sql`

Campos incorporados en `usuario`:

- `dni`
- `must_change_password`
- `password_actualizado_en`
- `primer_login_en`
- `ultimo_login_en`

Script de validación:

`database/scripts/validar_auth_first_login_password_change.sql`

> Nota: los archivos SQL/migraciones se mantienen fuera del commit público según la política del proyecto.

## Validaciones realizadas

- Migración validada primero en Supabase local usando base QA restaurada desde dump.
- Script de validación local OK.
- Backup remoto previo realizado antes del `db push`.
- Migración aplicada en remoto con Supabase CLI.
- Schema cache remoto refrescado.
- Script de validación remoto OK.
- Pruebas funcionales completas exitosas.
- `npm run build` ejecutado correctamente.

## Checklist funcional probado

- Crear usuario nuevo con DNI.
- Usar contraseña inicial automática `GymMaster + DNI`.
- Guardar usuario correctamente.
- Cerrar sesión.
- Ingresar con email y contraseña inicial.
- Confirmar redirección automática a `/auth/change-password`.
- Confirmar bloqueo del dashboard hasta cambiar contraseña.
- Cambiar contraseña por una contraseña fuerte.
- Confirmar acceso normal al dashboard después del cambio.
- Cerrar sesión.
- Reingresar con la nueva contraseña.
- Confirmar que ya no solicita cambio obligatorio.

## Seguridad

- No se guardan contraseñas en texto plano.
- La contraseña inicial se utiliza como valor temporal y debe quedar hasheada por el flujo actual de usuarios.
- El usuario queda obligado a cambiar la contraseña en el primer ingreso.
- No se expone la contraseña en listados, PDFs, Excel ni logs.
- El cambio de contraseña exige validaciones de seguridad.

## Impacto

Esta feature mejora el alta segura de usuarios internos, empleados y futuros socios con login, preparando el sistema para:

- flujo de empleados con RBAC;
- futura recuperación de contraseña por email;
- auditoría de accesos;
- mayor seguridad operativa en instalaciones reales de Gym Master.

## Commit sugerido

`feat: add first login password change flow`
