### PR TITLE
feat: add Dragon Pyramid support ticketing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ NEXTAUTH_SECRET=la-clave-secreta
 SUPABASE_SERVICE_ROLE_KEY=secrect-kery-supabase
 BREVO_API_KEY=brevo-api-key
 BREVO_SENDER_NAME=Gym Master
-BREVO_SENDER_EMAIL=no-reply@tudominio.comnpm 
+BREVO_SENDER_EMAIL=no-reply@tudominio.com
+DRAGON_PYRAMID_SUPPORT_EMAIL=soporte@dragonpyramid.com.ar
 
 JWT_SECRET=claveSecreta
 

--- a/docs/soporte/soporte-dragon-pyramid-ticketing.md
+++ b/docs/soporte/soporte-dragon-pyramid-ticketing.md
@@ -1,0 +1,77 @@
+# feature/soporte-dragon-pyramid-ticketing
+
+## Objetivo
+
+Implementar un canal de tickets desde administradores o usuarios internos del gimnasio cliente hacia Dragon Pyramid / Gym Master.
+
+## Alcance funcional
+
+- Nueva pantalla: `/dashboard/soporte-dragon-pyramid`.
+- Nuevo menú: `Soporte Dragon Pyramid` dentro de Administración.
+- Creación de tickets con categoría, prioridad, asunto, descripción y URL opcional de adjunto/captura.
+- Estados: `pendiente`, `en_revision`, `respondido`, `cerrado`.
+- Prioridades: `baja`, `media`, `alta`, `critica`.
+- Categorías: `fallas`, `dudas`, `problemas`, `sugerencias`, `otros`.
+- Historial de eventos del ticket.
+- Envío de email transaccional a Dragon Pyramid cuando se crea un ticket.
+- Trazabilidad de si el email fue enviado o si quedó pendiente por configuración.
+
+## Variables de entorno
+
+Para que el envío real funcione, además de la configuración Brevo existente, se debe definir al menos una de estas variables:
+
+```env
+DRAGON_PYRAMID_SUPPORT_EMAIL=soporte@dragonpyramid.com.ar
+```
+
+También se aceptan como fallback:
+
+```env
+GYM_MASTER_SUPPORT_EMAIL=
+SUPPORT_EMAIL=
+```
+
+Se pueden indicar varios destinatarios separados por coma.
+
+## Base de datos
+
+Migración privada/no versionada:
+
+```txt
+supabase/migrations/202606050700_soporte_dragon_pyramid_ticketing.sql
+```
+
+Tablas:
+
+- `soporte_ticket`
+- `soporte_ticket_evento`
+
+Script de validación:
+
+```txt
+database/scripts/validar_soporte_dragon_pyramid_ticketing.sql
+```
+
+## Seguridad
+
+Las API routes validan JWT mediante `authMiddleware`. Las operaciones contra Supabase se realizan desde backend con service role mediante `getSupabaseServerClient()`, sin exponer la clave al frontend.
+
+## Endpoints
+
+- `GET /api/soporte/tickets`
+- `POST /api/soporte/tickets`
+- `GET /api/soporte/tickets/{id}`
+- `PATCH /api/soporte/tickets/{id}`
+
+## QA sugerido
+
+1. Entrar como admin o usuario interno con permiso.
+2. Abrir `/dashboard/soporte-dragon-pyramid`.
+3. Crear ticket categoría `fallas`, prioridad `alta`.
+4. Confirmar que aparece en el listado.
+5. Confirmar que se crea historial.
+6. Confirmar email a Dragon Pyramid si la variable está configurada.
+7. Cambiar estado a `en_revision`.
+8. Registrar comentario.
+9. Marcar respondido.
+10. Cerrar ticket.

--- a/src/app/api/soporte/tickets/[id]/route.ts
+++ b/src/app/api/soporte/tickets/[id]/route.ts
@@ -1,0 +1,37 @@
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  getSoporteTicketById,
+  updateSoporteTicket,
+} from '@/services/soporteTicketService';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const { user } = await authMiddleware(_req);
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const ticket = await getSoporteTicketById(params.id, user);
+    return NextResponse.json({ data: ticket });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const status = message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  try {
+    const { user } = await authMiddleware(req);
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await req.json();
+    const ticket = await updateSoporteTicket(params.id, body, user);
+    return NextResponse.json({ data: ticket });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const status = message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/soporte/tickets/route.ts
+++ b/src/app/api/soporte/tickets/route.ts
@@ -1,0 +1,42 @@
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  createSoporteTicket,
+  getSoporteTickets,
+} from '@/services/soporteTicketService';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const url = new URL(req.url);
+    const tickets = await getSoporteTickets(user, {
+      estado: url.searchParams.get('estado'),
+      q: url.searchParams.get('q'),
+    });
+
+    return NextResponse.json({ data: tickets });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const status = message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const body = await req.json();
+    const ticket = await createSoporteTicket(body, user);
+    return NextResponse.json({ data: ticket }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const status = message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/dashboard/soporte-dragon-pyramid/page.tsx
+++ b/src/app/dashboard/soporte-dragon-pyramid/page.tsx
@@ -1,0 +1,507 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  LifeBuoy,
+  MailWarning,
+  MessageSquarePlus,
+  Search,
+  Send,
+} from 'lucide-react';
+import { AppFooter } from '@/components/footer/AppFooter';
+import { AppHeader } from '@/components/header/AppHeader';
+import { AppSidebar } from '@/components/sidebar/AppSidebar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import {
+  SoporteTicket,
+  SoporteTicketCategoria,
+  SoporteTicketEstado,
+  SoporteTicketPrioridad,
+} from '@/interfaces/soporteTicket.interface';
+import {
+  actualizarSoporteTicket,
+  crearSoporteTicket,
+  getSoporteTicket,
+  getSoporteTickets,
+} from '@/services/apiClient';
+import { useAuthStore } from '@/stores/authStore';
+import { formatFrontendDateTime } from '@/utils/dateFormat';
+
+const categorias: Array<{ value: SoporteTicketCategoria; label: string }> = [
+  { value: 'fallas', label: 'Fallas' },
+  { value: 'dudas', label: 'Dudas' },
+  { value: 'problemas', label: 'Problemas' },
+  { value: 'sugerencias', label: 'Sugerencias' },
+  { value: 'otros', label: 'Otros' },
+];
+
+const prioridades: Array<{ value: SoporteTicketPrioridad; label: string }> = [
+  { value: 'baja', label: 'Baja' },
+  { value: 'media', label: 'Media' },
+  { value: 'alta', label: 'Alta' },
+  { value: 'critica', label: 'Crítica' },
+];
+
+const estados: Array<{ value: SoporteTicketEstado | 'todos'; label: string }> = [
+  { value: 'todos', label: 'Todos' },
+  { value: 'pendiente', label: 'Pendientes' },
+  { value: 'en_revision', label: 'En revisión' },
+  { value: 'respondido', label: 'Respondidos' },
+  { value: 'cerrado', label: 'Cerrados' },
+];
+
+const estadoLabel: Record<SoporteTicketEstado, string> = {
+  pendiente: 'Pendiente',
+  en_revision: 'En revisión',
+  respondido: 'Respondido',
+  cerrado: 'Cerrado',
+};
+
+const prioridadLabel: Record<SoporteTicketPrioridad, string> = {
+  baja: 'Baja',
+  media: 'Media',
+  alta: 'Alta',
+  critica: 'Crítica',
+};
+
+const initialForm = {
+  categoria: 'fallas' as SoporteTicketCategoria,
+  prioridad: 'media' as SoporteTicketPrioridad,
+  asunto: '',
+  descripcion: '',
+  adjunto_url: '',
+};
+
+export default function SoporteDragonPyramidPage() {
+  const { isAuthenticated, initializeAuth, isInitialized, user } = useAuthStore();
+  const [tickets, setTickets] = useState<SoporteTicket[]>([]);
+  const [selected, setSelected] = useState<SoporteTicket | null>(null);
+  const [form, setForm] = useState(initialForm);
+  const [estadoFilter, setEstadoFilter] = useState<SoporteTicketEstado | 'todos'>('todos');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [comentario, setComentario] = useState('');
+  const [respuesta, setRespuesta] = useState('');
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
+  const loadTickets = async () => {
+    setLoading(true);
+    try {
+      const response = await getSoporteTickets({
+        estado: estadoFilter,
+        q: searchTerm.trim(),
+      });
+      if (!response.ok) throw new Error(response.error || 'No se pudieron cargar los tickets');
+      const nextTickets = response.data ?? [];
+      setTickets(nextTickets);
+      if (selected) {
+        const refreshed = nextTickets.find((ticket) => ticket.id === selected.id) ?? null;
+        setSelected(refreshed);
+      }
+    } catch (error) {
+      setTickets([]);
+      toast.error(error instanceof Error ? error.message : 'Error al cargar tickets');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isAuthenticated) loadTickets();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, estadoFilter]);
+
+  const totals = useMemo(() => {
+    return tickets.reduce(
+      (acc, ticket) => {
+        acc.total += 1;
+        acc.abiertos += ticket.estado === 'pendiente' || ticket.estado === 'en_revision' ? 1 : 0;
+        acc.criticos += ticket.prioridad === 'critica' ? 1 : 0;
+        acc.cerrados += ticket.estado === 'cerrado' ? 1 : 0;
+        return acc;
+      },
+      { total: 0, abiertos: 0, criticos: 0, cerrados: 0 }
+    );
+  }, [tickets]);
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCreate = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!form.asunto.trim()) {
+      toast.error('El asunto es obligatorio.');
+      return;
+    }
+
+    if (!form.descripcion.trim()) {
+      toast.error('La descripción es obligatoria.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await crearSoporteTicket({
+        categoria: form.categoria,
+        prioridad: form.prioridad,
+        asunto: form.asunto,
+        descripcion: form.descripcion,
+        adjunto_url: form.adjunto_url || null,
+      });
+
+      if (!response.ok || !response.data) {
+        throw new Error(response.error || 'No se pudo crear el ticket');
+      }
+
+      toast.success('Ticket enviado a Dragon Pyramid');
+      setForm(initialForm);
+      setSelected(response.data);
+      await loadTickets();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al crear ticket');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSearchSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    loadTickets();
+  };
+
+  const handleUpdateTicket = async (payload: { estado?: SoporteTicketEstado; comentario?: string; respuesta?: string }) => {
+    if (!selected) return;
+    setSaving(true);
+    try {
+      const response = await actualizarSoporteTicket(selected.id, payload);
+      if (!response.ok || !response.data) throw new Error(response.error || 'No se pudo actualizar el ticket');
+      toast.success('Ticket actualizado');
+      const detail = await getSoporteTicket(selected.id);
+      setSelected(detail.ok && detail.data ? detail.data : response.data);
+      setComentario('');
+      setRespuesta('');
+      await loadTickets();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al actualizar ticket');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isAuthenticated) return null;
+
+  return (
+    <SidebarProvider>
+      <div className='flex min-h-screen w-full'>
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader title='Soporte Dragon Pyramid' />
+          <main className='flex-1 space-y-6 p-6'>
+            <section className='grid gap-4 md:grid-cols-4'>
+              <Card>
+                <CardContent className='flex items-center gap-3 p-4'>
+                  <LifeBuoy className='h-8 w-8 text-sky-600' />
+                  <div>
+                    <p className='text-sm text-muted-foreground'>Tickets</p>
+                    <p className='text-2xl font-bold'>{totals.total}</p>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className='flex items-center gap-3 p-4'>
+                  <MessageSquarePlus className='h-8 w-8 text-amber-600' />
+                  <div>
+                    <p className='text-sm text-muted-foreground'>Abiertos</p>
+                    <p className='text-2xl font-bold'>{totals.abiertos}</p>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className='flex items-center gap-3 p-4'>
+                  <AlertTriangle className='h-8 w-8 text-red-600' />
+                  <div>
+                    <p className='text-sm text-muted-foreground'>Críticos</p>
+                    <p className='text-2xl font-bold'>{totals.criticos}</p>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className='flex items-center gap-3 p-4'>
+                  <CheckCircle2 className='h-8 w-8 text-emerald-600' />
+                  <div>
+                    <p className='text-sm text-muted-foreground'>Cerrados</p>
+                    <p className='text-2xl font-bold'>{totals.cerrados}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </section>
+
+            <div className='grid gap-6 xl:grid-cols-[0.9fr_1.1fr]'>
+              <Card>
+                <CardHeader className='border-b p-4'>
+                  <h2 className='text-xl font-bold'>Nuevo ticket</h2>
+                  <p className='text-sm text-muted-foreground'>Reportá fallas, dudas, problemas o sugerencias al soporte de Dragon Pyramid.</p>
+                </CardHeader>
+                <CardContent className='p-4'>
+                  <form className='space-y-4' onSubmit={handleCreate}>
+                    <div className='grid gap-3 md:grid-cols-2'>
+                      <div className='space-y-2'>
+                        <Label htmlFor='categoria'>Categoría</Label>
+                        <select
+                          id='categoria'
+                          name='categoria'
+                          className='h-10 w-full rounded-md border border-input bg-background px-3 text-sm'
+                          value={form.categoria}
+                          onChange={handleChange}
+                        >
+                          {categorias.map((categoria) => (
+                            <option key={categoria.value} value={categoria.value}>{categoria.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className='space-y-2'>
+                        <Label htmlFor='prioridad'>Prioridad</Label>
+                        <select
+                          id='prioridad'
+                          name='prioridad'
+                          className='h-10 w-full rounded-md border border-input bg-background px-3 text-sm'
+                          value={form.prioridad}
+                          onChange={handleChange}
+                        >
+                          {prioridades.map((prioridad) => (
+                            <option key={prioridad.value} value={prioridad.value}>{prioridad.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
+
+                    <div className='space-y-2'>
+                      <Label htmlFor='asunto'>Asunto</Label>
+                      <Input
+                        id='asunto'
+                        name='asunto'
+                        value={form.asunto}
+                        onChange={handleChange}
+                        placeholder='Ejemplo: error al registrar pagos manuales'
+                      />
+                    </div>
+
+                    <div className='space-y-2'>
+                      <Label htmlFor='descripcion'>Descripción</Label>
+                      <textarea
+                        id='descripcion'
+                        name='descripcion'
+                        rows={6}
+                        value={form.descripcion}
+                        onChange={handleChange}
+                        className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                        placeholder='Describí qué pasó, qué usuario lo reportó, pasos para reproducirlo y cualquier dato relevante.'
+                      />
+                    </div>
+
+                    <div className='space-y-2'>
+                      <Label htmlFor='adjunto_url'>Adjunto / captura URL opcional</Label>
+                      <Input
+                        id='adjunto_url'
+                        name='adjunto_url'
+                        value={form.adjunto_url}
+                        onChange={handleChange}
+                        placeholder='https://...'
+                      />
+                    </div>
+
+                    <div className='rounded-lg bg-muted p-3 text-xs text-muted-foreground'>
+                      Usuario emisor: {user?.nombre ?? user?.email ?? 'Usuario actual'}. El sistema enviará notificación por email si el soporte de Dragon Pyramid está configurado.
+                    </div>
+
+                    <Button type='submit' disabled={saving} className='w-full gap-2'>
+                      <Send className='h-4 w-4' />
+                      {saving ? 'Enviando...' : 'Enviar ticket'}
+                    </Button>
+                  </form>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader className='border-b p-4'>
+                  <div className='flex flex-wrap items-center justify-between gap-3'>
+                    <div>
+                      <h2 className='text-xl font-bold'>Tickets enviados</h2>
+                      <p className='text-sm text-muted-foreground'>Seguimiento y trazabilidad de tickets enviados a Dragon Pyramid.</p>
+                    </div>
+                    <form className='flex flex-wrap gap-2' onSubmit={handleSearchSubmit}>
+                      <select
+                        value={estadoFilter}
+                        onChange={(event) => setEstadoFilter(event.target.value as SoporteTicketEstado | 'todos')}
+                        className='h-10 rounded-md border border-input bg-background px-3 text-sm'
+                      >
+                        {estados.map((estado) => (
+                          <option key={estado.value} value={estado.value}>{estado.label}</option>
+                        ))}
+                      </select>
+                      <div className='relative'>
+                        <Search className='absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground' />
+                        <Input
+                          type='search'
+                          className='w-64 pl-8'
+                          placeholder='Buscar ticket...'
+                          value={searchTerm}
+                          onChange={(event) => setSearchTerm(event.target.value)}
+                        />
+                      </div>
+                      <Button type='submit' variant='outline'>Buscar</Button>
+                    </form>
+                  </div>
+                </CardHeader>
+                <CardContent className='grid gap-4 p-4 xl:grid-cols-[0.95fr_1.05fr]'>
+                  <div className='space-y-3'>
+                    {loading ? (
+                      <div className='py-8 text-center text-muted-foreground'>Cargando tickets...</div>
+                    ) : tickets.length === 0 ? (
+                      <div className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>No hay tickets para el filtro seleccionado.</div>
+                    ) : (
+                      tickets.map((ticket) => (
+                        <button
+                          key={ticket.id}
+                          type='button'
+                          onClick={async () => {
+                            setSelected(ticket);
+                            const response = await getSoporteTicket(ticket.id);
+                            if (response.ok && response.data) setSelected(response.data);
+                          }}
+                          className={`w-full rounded-xl border p-4 text-left transition hover:bg-muted/60 ${selected?.id === ticket.id ? 'border-primary bg-muted' : ''}`}
+                        >
+                          <div className='flex flex-wrap items-start justify-between gap-3'>
+                            <div>
+                              <h3 className='font-semibold'>{ticket.asunto}</h3>
+                              <p className='text-xs text-muted-foreground'>{ticket.codigo} · {formatFrontendDateTime(ticket.creado_en)}</p>
+                            </div>
+                            <span className='rounded-full bg-background px-3 py-1 text-xs font-medium'>{estadoLabel[ticket.estado]}</span>
+                          </div>
+                          <p className='mt-2 line-clamp-2 text-sm text-muted-foreground'>{ticket.descripcion}</p>
+                          <div className='mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground'>
+                            <span className='rounded-full bg-muted px-2 py-1'>{ticket.categoria}</span>
+                            <span className='rounded-full bg-muted px-2 py-1'>Prioridad {prioridadLabel[ticket.prioridad]}</span>
+                            {!ticket.email_notificacion_enviado && (
+                              <span className='inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-amber-700'>
+                                <MailWarning className='h-3 w-3' /> Email no confirmado
+                              </span>
+                            )}
+                          </div>
+                        </button>
+                      ))
+                    )}
+                  </div>
+
+                  <div className='rounded-xl border p-4'>
+                    {selected ? (
+                      <div className='space-y-4'>
+                        <div>
+                          <p className='text-xs text-muted-foreground'>Ticket</p>
+                          <h3 className='text-lg font-bold'>{selected.codigo}</h3>
+                          <p className='text-sm text-muted-foreground'>{selected.asunto}</p>
+                        </div>
+                        <div className='grid gap-2 text-sm md:grid-cols-2'>
+                          <p><strong>Estado:</strong> {estadoLabel[selected.estado]}</p>
+                          <p><strong>Prioridad:</strong> {prioridadLabel[selected.prioridad]}</p>
+                          <p><strong>Categoría:</strong> {selected.categoria}</p>
+                          <p><strong>Creado:</strong> {formatFrontendDateTime(selected.creado_en)}</p>
+                          <p className='md:col-span-2'><strong>Email soporte:</strong> {selected.email_notificacion_enviado ? 'enviado' : selected.email_notificacion_error || 'pendiente/no configurado'}</p>
+                        </div>
+                        <div className='rounded-lg bg-muted p-3 text-sm whitespace-pre-wrap'>{selected.descripcion}</div>
+                        {selected.adjunto_url && (
+                          <a href={selected.adjunto_url} target='_blank' rel='noreferrer' className='text-sm font-medium text-primary underline'>Abrir adjunto / captura</a>
+                        )}
+
+                        <div className='space-y-2'>
+                          <Label htmlFor='comentario'>Comentario interno / seguimiento</Label>
+                          <textarea
+                            id='comentario'
+                            rows={3}
+                            value={comentario}
+                            onChange={(event) => setComentario(event.target.value)}
+                            className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            placeholder='Agregar nota de seguimiento...'
+                          />
+                          <Button
+                            type='button'
+                            variant='outline'
+                            disabled={saving || !comentario.trim()}
+                            onClick={() => handleUpdateTicket({ comentario })}
+                          >
+                            Guardar comentario
+                          </Button>
+                        </div>
+
+                        <div className='space-y-2'>
+                          <Label htmlFor='respuesta'>Respuesta / resolución</Label>
+                          <textarea
+                            id='respuesta'
+                            rows={3}
+                            value={respuesta}
+                            onChange={(event) => setRespuesta(event.target.value)}
+                            className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            placeholder='Registrar respuesta o resolución recibida de Dragon Pyramid...'
+                          />
+                          <Button
+                            type='button'
+                            disabled={saving || !respuesta.trim()}
+                            onClick={() => handleUpdateTicket({ respuesta })}
+                          >
+                            Marcar respondido
+                          </Button>
+                        </div>
+
+                        <div className='flex flex-wrap gap-2'>
+                          <Button type='button' variant='outline' disabled={saving || selected.estado === 'en_revision'} onClick={() => handleUpdateTicket({ estado: 'en_revision' })}>En revisión</Button>
+                          <Button type='button' variant='outline' disabled={saving || selected.estado === 'cerrado'} onClick={() => handleUpdateTicket({ estado: 'cerrado' })}>Cerrar</Button>
+                        </div>
+
+                        <div className='space-y-2 border-t pt-4'>
+                          <h4 className='font-semibold'>Historial</h4>
+                          {selected.eventos && selected.eventos.length > 0 ? (
+                            selected.eventos.map((evento) => (
+                              <div key={evento.id} className='rounded-lg border p-3 text-sm'>
+                                <div className='flex flex-wrap justify-between gap-2'>
+                                  <span className='font-medium'>{evento.tipo}</span>
+                                  <span className='text-xs text-muted-foreground'>{formatFrontendDateTime(evento.creado_en)}</span>
+                                </div>
+                                <p className='mt-1 whitespace-pre-wrap text-muted-foreground'>{evento.mensaje || 'Evento sin detalle.'}</p>
+                              </div>
+                            ))
+                          ) : (
+                            <p className='text-sm text-muted-foreground'>El historial se verá al abrir el detalle después de crear o actualizar el ticket.</p>
+                          )}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className='flex min-h-[320px] items-center justify-center rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>Seleccioná un ticket para ver detalle e historial.</div>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </main>
+          <AppFooter />
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/qa/QaCurrentPageBadge.tsx
+++ b/src/components/qa/QaCurrentPageBadge.tsx
@@ -43,6 +43,7 @@ const PAGE_FILES: Record<string, string> = {
   "/dashboard/rutinas": "src/app/dashboard/rutinas/page.tsx",
   "/dashboard/servicios": "src/app/dashboard/servicios/page.tsx",
   "/dashboard/socios": "src/app/dashboard/socios/page.tsx",
+  "/dashboard/soporte-dragon-pyramid": "src/app/dashboard/soporte-dragon-pyramid/page.tsx",
   "/dashboard/usuarios": "src/app/dashboard/usuarios/page.tsx",
   "/dashboard/ventas": "src/app/dashboard/ventas/page.tsx",
   "/dashboard/ventas-detalle": "src/app/dashboard/ventas-detalle/page.tsx",

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -119,6 +119,7 @@ export const sections: SidebarSectionType[] = [
       { title: 'Sueldos', link: '/dashboard/empleados-sueldos', level: 2 },
       { title: 'Notificaciones', link: '/dashboard/notificaciones', level: 2 },
       { title: 'Mensajes Socios', link: '/dashboard/mensajes-admin', level: 2 },
+      { title: 'Soporte Dragon Pyramid', link: '/dashboard/soporte-dragon-pyramid', level: 2 },
       { title: 'Avisos', link: '/dashboard/avisos', level: 2 },
       { title: 'Equipamientos', link: '/dashboard/equipamientos', level: 2 },
     ],

--- a/src/interfaces/soporteTicket.interface.ts
+++ b/src/interfaces/soporteTicket.interface.ts
@@ -1,0 +1,81 @@
+export type SoporteTicketCategoria =
+  | 'fallas'
+  | 'dudas'
+  | 'problemas'
+  | 'sugerencias'
+  | 'otros';
+
+export type SoporteTicketPrioridad = 'baja' | 'media' | 'alta' | 'critica';
+
+export type SoporteTicketEstado =
+  | 'pendiente'
+  | 'en_revision'
+  | 'respondido'
+  | 'cerrado';
+
+export type SoporteTicketEventoTipo =
+  | 'creado'
+  | 'estado'
+  | 'comentario'
+  | 'respuesta'
+  | 'email'
+  | 'cerrado';
+
+export interface SoporteTicketUsuarioResumen {
+  id: string;
+  nombre: string | null;
+  email: string | null;
+  rol?: string | null;
+}
+
+export interface SoporteTicketEvento {
+  id: string;
+  ticket_id: string;
+  usuario_id?: string | null;
+  tipo: SoporteTicketEventoTipo;
+  mensaje?: string | null;
+  estado_anterior?: SoporteTicketEstado | null;
+  estado_nuevo?: SoporteTicketEstado | null;
+  creado_en: string;
+  usuario?: SoporteTicketUsuarioResumen | null;
+}
+
+export interface SoporteTicket {
+  id: string;
+  codigo: string;
+  categoria: SoporteTicketCategoria;
+  prioridad: SoporteTicketPrioridad;
+  estado: SoporteTicketEstado;
+  asunto: string;
+  descripcion: string;
+  adjunto_url?: string | null;
+  gimnasio_nombre?: string | null;
+  usuario_id?: string | null;
+  usuario_email?: string | null;
+  usuario_nombre?: string | null;
+  email_notificacion_enviado: boolean;
+  email_notificacion_error?: string | null;
+  respondido_por?: string | null;
+  respondido_en?: string | null;
+  cerrado_en?: string | null;
+  activo: boolean;
+  creado_en: string;
+  actualizado_en?: string | null;
+  usuario?: SoporteTicketUsuarioResumen | null;
+  respondedor?: SoporteTicketUsuarioResumen | null;
+  eventos?: SoporteTicketEvento[];
+}
+
+export interface CreateSoporteTicketDto {
+  categoria: SoporteTicketCategoria;
+  prioridad: SoporteTicketPrioridad;
+  asunto: string;
+  descripcion: string;
+  adjunto_url?: string | null;
+}
+
+export interface UpdateSoporteTicketDto {
+  estado?: SoporteTicketEstado;
+  comentario?: string;
+  respuesta?: string;
+}

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -236,6 +236,13 @@ export const MENU_PERMISSION_GROUPS: Array<{
         roles: ['admin', 'usuario'],
       },
       {
+        key: 'Soporte Dragon Pyramid',
+        label: 'Soporte Dragon Pyramid',
+        path: '/dashboard/soporte-dragon-pyramid',
+        group: 'Administración',
+        roles: ['admin', 'usuario'],
+      },
+      {
         key: 'Notificaciones',
         label: 'Notificaciones',
         path: '/dashboard/notificaciones',
@@ -308,6 +315,7 @@ export const DEFAULT_MENU_PERMISSIONS_BY_ROLE: Record<AppRole, string[]> = {
     'Ventas',
     'Notificaciones',
     'Mensajes Socios',
+    'Soporte Dragon Pyramid',
     'Perfil',
     'Preferencias',
   ],

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -19,6 +19,56 @@ const endpointDefinitions: EndpointDefinition[] = [
 
 
   {
+    "path": "/api/soporte/tickets",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "tag": "Soporte Dragon Pyramid",
+    "summary": "Tickets de soporte hacia Dragon Pyramid",
+    "description": "Permite a administradores y usuarios internos consultar y crear tickets de soporte dirigidos a Dragon Pyramid / Gym Master, con categoría, prioridad, estado y notificación por email.",
+    "auth": true,
+    "admin": true,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      201,
+      400,
+      401,
+      403,
+      500
+    ],
+    "queryParams": [
+      "estado",
+      "q"
+    ],
+    "source": "src/app/api/soporte/tickets/route.ts"
+  },
+  {
+    "path": "/api/soporte/tickets/{id}",
+    "methods": [
+      "GET",
+      "PATCH"
+    ],
+    "tag": "Soporte Dragon Pyramid",
+    "summary": "Detalle, estado e historial de ticket de soporte",
+    "description": "Permite consultar detalle de un ticket, cambiar estado, registrar comentario, marcar respuesta o cerrar el ticket de soporte.",
+    "auth": true,
+    "admin": true,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      400,
+      401,
+      403,
+      404,
+      500
+    ],
+    "queryParams": [],
+    "source": "src/app/api/soporte/tickets/[id]/route.ts"
+  },
+
+  {
     "path": "/api/socios/mensajes",
     "methods": [
       "GET",

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -5,6 +5,12 @@ import type {
   SocioMensajeEstado,
   UpdateSocioMensajeAdminDto,
 } from '@/interfaces/socioMensaje.interface';
+import type {
+  CreateSoporteTicketDto,
+  SoporteTicket,
+  SoporteTicketEstado,
+  UpdateSoporteTicketDto,
+} from '@/interfaces/soporteTicket.interface';
 
 export async function login({
   email,
@@ -1051,4 +1057,65 @@ export async function actualizarMensajeSocioAdmin(
   });
   const data = await res.json();
   return { ok: res.ok, ...data } as { ok: boolean; data?: SocioMensaje; error?: string };
+}
+
+export async function getSoporteTickets(filters?: {
+  estado?: SoporteTicketEstado | 'todos';
+  q?: string;
+}) {
+  const token = getToken();
+  const params = new URLSearchParams();
+  if (filters?.estado && filters.estado !== 'todos') params.set('estado', filters.estado);
+  if (filters?.q) params.set('q', filters.q);
+  const query = params.toString() ? `?${params.toString()}` : '';
+
+  const res = await fetch(`/api/soporte/tickets${query}`, {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    cache: 'no-store',
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data } as { ok: boolean; data?: SoporteTicket[]; error?: string };
+}
+
+export async function crearSoporteTicket(payload: CreateSoporteTicketDto) {
+  const token = getToken();
+  const res = await fetch('/api/soporte/tickets', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data } as { ok: boolean; data?: SoporteTicket; error?: string };
+}
+
+export async function getSoporteTicket(id: string) {
+  const token = getToken();
+  const res = await fetch(`/api/soporte/tickets/${id}`, {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    cache: 'no-store',
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data } as { ok: boolean; data?: SoporteTicket; error?: string };
+}
+
+export async function actualizarSoporteTicket(
+  id: string,
+  payload: UpdateSoporteTicketDto
+) {
+  const token = getToken();
+  const res = await fetch(`/api/soporte/tickets/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data } as { ok: boolean; data?: SoporteTicket; error?: string };
 }

--- a/src/services/soporteTicketService.ts
+++ b/src/services/soporteTicketService.ts
@@ -1,0 +1,380 @@
+import { JwtUser } from '@/interfaces/jwtUser.interface';
+import {
+  CreateSoporteTicketDto,
+  SoporteTicket,
+  SoporteTicketCategoria,
+  SoporteTicketEstado,
+  SoporteTicketEvento,
+  SoporteTicketEventoTipo,
+  SoporteTicketPrioridad,
+  UpdateSoporteTicketDto,
+} from '@/interfaces/soporteTicket.interface';
+import { sendEmail } from '@/lib/brevo';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+
+const ticketSelect = `
+  *,
+  usuario:usuario_id(id,nombre,email,rol),
+  respondedor:respondido_por(id,nombre,email,rol)
+`;
+
+const ticketWithEventosSelect = `
+  *,
+  usuario:usuario_id(id,nombre,email,rol),
+  respondedor:respondido_por(id,nombre,email,rol),
+  eventos:soporte_ticket_evento(
+    *,
+    usuario:usuario_id(id,nombre,email,rol)
+  )
+`;
+
+const allowedCategorias: SoporteTicketCategoria[] = [
+  'fallas',
+  'dudas',
+  'problemas',
+  'sugerencias',
+  'otros',
+];
+
+const allowedPrioridades: SoporteTicketPrioridad[] = [
+  'baja',
+  'media',
+  'alta',
+  'critica',
+];
+
+const allowedEstados: SoporteTicketEstado[] = [
+  'pendiente',
+  'en_revision',
+  'respondido',
+  'cerrado',
+];
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeCategoria(value: unknown): SoporteTicketCategoria {
+  const raw = normalizeString(value) as SoporteTicketCategoria | null;
+  return raw && allowedCategorias.includes(raw) ? raw : 'otros';
+}
+
+function normalizePrioridad(value: unknown): SoporteTicketPrioridad {
+  const raw = normalizeString(value) as SoporteTicketPrioridad | null;
+  return raw && allowedPrioridades.includes(raw) ? raw : 'media';
+}
+
+function normalizeEstado(value: unknown): SoporteTicketEstado | null {
+  const raw = normalizeString(value) as SoporteTicketEstado | null;
+  return raw && allowedEstados.includes(raw) ? raw : null;
+}
+
+function assertAdminOrUsuario(user: JwtUser) {
+  if (user.rol !== 'admin' && user.rol !== 'usuario') {
+    throw new Error('No autorizado para gestionar soporte Dragon Pyramid');
+  }
+}
+
+function getGymName() {
+  return (
+    process.env.GYM_MASTER_CLIENT_NAME ||
+    process.env.NEXT_PUBLIC_GYM_NAME ||
+    'Gimnasio cliente Gym Master'
+  );
+}
+
+function getSupportRecipients() {
+  const raw =
+    process.env.DRAGON_PYRAMID_SUPPORT_EMAIL ||
+    process.env.GYM_MASTER_SUPPORT_EMAIL ||
+    process.env.SUPPORT_EMAIL ||
+    '';
+
+  return raw
+    .split(',')
+    .map((email) => email.trim())
+    .filter(Boolean)
+    .map((email) => ({ email, name: 'Soporte Dragon Pyramid' }));
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function buildTicketEmailHtml(ticket: SoporteTicket) {
+  const safeDescription = escapeHtml(ticket.descripcion).replace(/\n/g, '<br/>');
+  const safeSubject = escapeHtml(ticket.asunto);
+  const safeGym = escapeHtml(ticket.gimnasio_nombre || getGymName());
+  const safeUserName = escapeHtml(ticket.usuario_nombre || 'Usuario del gimnasio');
+  const safeUserEmail = escapeHtml(ticket.usuario_email || 'sin email');
+
+  return `
+    <div style="font-family: Arial, sans-serif; color: #111827; line-height: 1.5;">
+      <h2 style="margin: 0 0 16px;">Nuevo ticket de soporte - Gym Master</h2>
+      <p>Se registró un nuevo ticket desde una instancia cliente de Gym Master.</p>
+      <div style="border:1px solid #e5e7eb;border-radius:10px;padding:16px;margin:16px 0;background:#f9fafb;">
+        <p style="margin:0 0 8px;"><strong>Código:</strong> ${ticket.codigo}</p>
+        <p style="margin:0 0 8px;"><strong>Gimnasio:</strong> ${safeGym}</p>
+        <p style="margin:0 0 8px;"><strong>Usuario:</strong> ${safeUserName} (${safeUserEmail})</p>
+        <p style="margin:0 0 8px;"><strong>Categoría:</strong> ${ticket.categoria}</p>
+        <p style="margin:0 0 8px;"><strong>Prioridad:</strong> ${ticket.prioridad}</p>
+        <p style="margin:0 0 8px;"><strong>Asunto:</strong> ${safeSubject}</p>
+        <p style="margin:0;"><strong>Descripción:</strong><br/>${safeDescription}</p>
+        ${ticket.adjunto_url ? `<p style="margin:12px 0 0;"><strong>Adjunto / captura:</strong> ${escapeHtml(ticket.adjunto_url)}</p>` : ''}
+      </div>
+      <p>Revisar y responder por los canales definidos con el cliente.</p>
+    </div>
+  `;
+}
+
+async function createTicketEvent(
+  ticketId: string,
+  userId: string | null,
+  tipo: SoporteTicketEventoTipo,
+  mensaje: string | null,
+  estadoAnterior?: SoporteTicketEstado | null,
+  estadoNuevo?: SoporteTicketEstado | null
+) {
+  const supabase = getSupabaseServerClient();
+  const { error } = await supabase.from('soporte_ticket_evento').insert({
+    ticket_id: ticketId,
+    usuario_id: userId,
+    tipo,
+    mensaje,
+    estado_anterior: estadoAnterior ?? null,
+    estado_nuevo: estadoNuevo ?? null,
+  });
+
+  if (error) throw new Error(error.message);
+}
+
+async function notifyDragonPyramid(ticket: SoporteTicket) {
+  const recipients = getSupportRecipients();
+
+  if (recipients.length === 0) {
+    return {
+      sent: false,
+      error: 'No se configuró DRAGON_PYRAMID_SUPPORT_EMAIL / GYM_MASTER_SUPPORT_EMAIL.',
+    };
+  }
+
+  try {
+    await sendEmail({
+      to: recipients,
+      subject: `[Gym Master][${ticket.prioridad.toUpperCase()}] ${ticket.codigo} - ${ticket.asunto}`,
+      htmlContent: buildTicketEmailHtml(ticket),
+    });
+
+    return { sent: true, error: null };
+  } catch (error) {
+    return {
+      sent: false,
+      error: error instanceof Error ? error.message : 'Error enviando email de soporte',
+    };
+  }
+}
+
+export async function getSoporteTickets(
+  user: JwtUser,
+  params?: { estado?: string | null; q?: string | null }
+): Promise<SoporteTicket[]> {
+  assertAdminOrUsuario(user);
+  const supabase = getSupabaseServerClient();
+  const estado = normalizeEstado(params?.estado);
+  const term = normalizeString(params?.q);
+
+  let query = supabase
+    .from('soporte_ticket')
+    .select(ticketSelect)
+    .eq('activo', true)
+    .order('creado_en', { ascending: false });
+
+  if (estado) query = query.eq('estado', estado);
+
+  if (term) {
+    const pattern = `%${term.replace(/[%_]/g, '')}%`;
+    query = query.or(
+      `codigo.ilike.${pattern},asunto.ilike.${pattern},descripcion.ilike.${pattern},gimnasio_nombre.ilike.${pattern}`
+    );
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+
+  return (data ?? []) as SoporteTicket[];
+}
+
+export async function getSoporteTicketById(
+  id: string,
+  user: JwtUser
+): Promise<SoporteTicket> {
+  assertAdminOrUsuario(user);
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('soporte_ticket')
+    .select(ticketWithEventosSelect)
+    .eq('id', id)
+    .eq('activo', true)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const ticket = data as SoporteTicket;
+  if (Array.isArray(ticket.eventos)) {
+    ticket.eventos = [...ticket.eventos].sort(
+      (a: SoporteTicketEvento, b: SoporteTicketEvento) =>
+        new Date(a.creado_en).getTime() - new Date(b.creado_en).getTime()
+    );
+  }
+
+  return ticket;
+}
+
+export async function createSoporteTicket(
+  payload: CreateSoporteTicketDto,
+  user: JwtUser
+): Promise<SoporteTicket> {
+  assertAdminOrUsuario(user);
+  const supabase = getSupabaseServerClient();
+  const asunto = normalizeString(payload.asunto);
+  const descripcion = normalizeString(payload.descripcion);
+
+  if (!asunto) throw new Error('El asunto es obligatorio');
+  if (!descripcion) throw new Error('La descripción es obligatoria');
+
+  const insertPayload = {
+    categoria: normalizeCategoria(payload.categoria),
+    prioridad: normalizePrioridad(payload.prioridad),
+    asunto,
+    descripcion,
+    adjunto_url: normalizeString(payload.adjunto_url),
+    gimnasio_nombre: getGymName(),
+    usuario_id: user.id,
+    usuario_email: user.email,
+    usuario_nombre: user.nombre ?? user.email,
+    estado: 'pendiente' as SoporteTicketEstado,
+  };
+
+  const { data, error } = await supabase
+    .from('soporte_ticket')
+    .insert(insertPayload)
+    .select(ticketSelect)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const ticket = data as SoporteTicket;
+  await createTicketEvent(
+    ticket.id,
+    user.id,
+    'creado',
+    `Ticket creado por ${user.nombre ?? user.email}.`,
+    null,
+    'pendiente'
+  );
+
+  const emailResult = await notifyDragonPyramid(ticket);
+
+  const { data: finalData, error: finalError } = await supabase
+    .from('soporte_ticket')
+    .update({
+      email_notificacion_enviado: emailResult.sent,
+      email_notificacion_error: emailResult.error,
+      actualizado_en: new Date().toISOString(),
+    })
+    .eq('id', ticket.id)
+    .select(ticketSelect)
+    .single();
+
+  if (finalError) throw new Error(finalError.message);
+
+  await createTicketEvent(
+    ticket.id,
+    user.id,
+    'email',
+    emailResult.sent
+      ? 'Notificación enviada a Dragon Pyramid por email.'
+      : `No se pudo enviar email a Dragon Pyramid: ${emailResult.error}`,
+    null,
+    null
+  );
+
+  return finalData as SoporteTicket;
+}
+
+export async function updateSoporteTicket(
+  id: string,
+  payload: UpdateSoporteTicketDto,
+  user: JwtUser
+): Promise<SoporteTicket> {
+  assertAdminOrUsuario(user);
+  const supabase = getSupabaseServerClient();
+  const current = await getSoporteTicketById(id, user);
+  const now = new Date().toISOString();
+  const estado = normalizeEstado(payload.estado);
+  const comentario = normalizeString(payload.comentario);
+  const respuesta = normalizeString(payload.respuesta);
+  const updatePayload: Record<string, unknown> = { actualizado_en: now };
+
+  if (estado && estado !== current.estado) {
+    updatePayload.estado = estado;
+
+    if (estado === 'respondido') {
+      updatePayload.respondido_por = user.id;
+      updatePayload.respondido_en = now;
+    }
+
+    if (estado === 'cerrado') {
+      updatePayload.cerrado_en = now;
+    }
+  }
+
+  if (respuesta) {
+    updatePayload.estado = 'respondido';
+    updatePayload.respondido_por = user.id;
+    updatePayload.respondido_en = now;
+  }
+
+  if (!estado && !comentario && !respuesta) {
+    throw new Error('No hay cambios para aplicar');
+  }
+
+  const { data, error } = await supabase
+    .from('soporte_ticket')
+    .update(updatePayload)
+    .eq('id', id)
+    .select(ticketSelect)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const updated = data as SoporteTicket;
+
+  if (estado && estado !== current.estado) {
+    await createTicketEvent(
+      id,
+      user.id,
+      estado === 'cerrado' ? 'cerrado' : 'estado',
+      `Estado actualizado de ${current.estado} a ${estado}.`,
+      current.estado,
+      estado
+    );
+  }
+
+  if (respuesta) {
+    await createTicketEvent(id, user.id, 'respuesta', respuesta, current.estado, 'respondido');
+  }
+
+  if (comentario) {
+    await createTicketEvent(id, user.id, 'comentario', comentario, null, null);
+  }
+
+  return updated;
+}


### PR DESCRIPTION
# PR - Gym Master: Soporte Dragon Pyramid Ticketing

## Rama

`feature/soporte-dragon-pyramid-ticketing`

## Tipo de cambio

- [x] Nueva funcionalidad
- [x] Backend / API Routes
- [x] Frontend / Dashboard
- [x] Base de datos / migración Supabase
- [x] Swagger / OpenAPI
- [x] Email transaccional vía Brevo
- [x] Documentación técnica

## Objetivo

Implementar un sistema de tickets de soporte para que el administrador o usuario interno del gimnasio pueda enviar solicitudes a Dragon Pyramid / Gym Master desde el propio dashboard administrativo.

La feature permite reportar fallas, dudas, problemas, sugerencias u otros casos, asignar prioridad, registrar historial de eventos, cambiar estados y enviar notificación por email al canal de soporte configurado por Dragon Pyramid.

## Alcance implementado

### UI / Frontend

- Nueva pantalla administrativa: `/dashboard/soporte-dragon-pyramid`.
- Nuevo acceso de menú: `Soporte Dragon Pyramid`.
- Formulario de alta de ticket con:
  - categoría;
  - prioridad;
  - asunto;
  - descripción.
- Listado de tickets creados.
- Visualización del historial de eventos por ticket.
- Acciones para actualizar estado y agregar comentarios.
- Estados operativos:
  - `pendiente`;
  - `en_revision`;
  - `respondido`;
  - `cerrado`.
- Prioridades:
  - `baja`;
  - `media`;
  - `alta`;
  - `critica`.
- Categorías:
  - `fallas`;
  - `dudas`;
  - `problemas`;
  - `sugerencias`;
  - `otros`.

### Backend / API

- Nueva API para gestión de tickets:
  - `GET /api/soporte/tickets`;
  - `POST /api/soporte/tickets`;
  - `GET /api/soporte/tickets/{id}`;
  - `PATCH /api/soporte/tickets/{id}`.
- Validación de usuario autenticado mediante el flujo existente.
- Registro del usuario emisor del ticket.
- Registro de eventos/historial asociado al ticket.
- Envío de email automático a `DRAGON_PYRAMID_SUPPORT_EMAIL` al crear un ticket.
- Uso server-side de las credenciales necesarias, sin exponer secretos al frontend.

### Base de datos

Se agregó la migración privada/no versionada:

`202606050700_soporte_dragon_pyramid_ticketing.sql`

Tablas nuevas:

- `soporte_ticket`;
- `soporte_ticket_evento`.

La migración fue validada localmente contra dump QA y aplicada exitosamente en Supabase remoto.

### Swagger / OpenAPI

Se actualizó `src/lib/swagger/openApiSpec.ts` con la documentación de los endpoints nuevos/modificados de soporte.

### Configuración

Nueva variable de entorno:

```env
DRAGON_PYRAMID_SUPPORT_EMAIL=soporte@dragonpyramid.com.ar
```

Para QA se puede usar el email real de Gustavo o el correo operativo configurado para Dragon Pyramid.

## Validaciones realizadas

- Migración local validada con script QA sobre dump actualizado.
- Migración remota aplicada correctamente con Supabase CLI.
- Schema cache remoto refrescado con `select pg_notify('pgrst', 'reload schema');`.
- Validación remota ejecutada desde Supabase Studio.
- Prueba funcional en `/dashboard/soporte-dragon-pyramid`.
- Creación de ticket validada.
- Historial de eventos validado.
- Cambios de estado validados.
- Email automático a `DRAGON_PYRAMID_SUPPORT_EMAIL` validado.
- Swagger validado en `/swagger`.
- Build local validado con `npm run build`.

## Comandos relevantes

```bash
npx supabase db push --dry-run
npx supabase db push
npx supabase migration list
npm run build
```

## Consideraciones de seguridad

- Los scripts SQL y migraciones reales se mantienen ignorados por Git para no exponer lógica sensible del modelo de datos en el repositorio público.
- El email de soporte se configura por variable de entorno.
- La gestión de tickets queda disponible dentro del dashboard autenticado.
- Esta feature no implementa todavía el dashboard madre exclusivo de Dragon Pyramid; deja la base de tickets necesaria para integrarlo más adelante.

## Relación con roadmap

Esta rama corresponde al bloque:

`feature/soporte-dragon-pyramid-ticketing`

Y prepara el camino para futuras features:

- `feature/saas-provider-master-dashboard`;
- `feature/saas-license-subscription-lock`;
- `feature/saas-client-offboarding-export`.

## Commit sugerido

```bash
git commit -m "feat: add Dragon Pyramid support ticketing"
```
