### PR TITLE
feat: add gym Stripe payments parametrization

### DIFF
--- a/docs/gimnasio-parametrizacion/gimnasio-parametrizacion-stripe-flag-sync.md
+++ b/docs/gimnasio-parametrizacion/gimnasio-parametrizacion-stripe-flag-sync.md
@@ -1,0 +1,21 @@
+# Gym Master — Fix sincronización bandera Stripe
+
+## Rama
+
+`feature/gimnasio-parametrizacion-stripe-payments`
+
+## Ajuste
+
+Se corrige la sincronización entre la bandera `stripe_habilitado` y el estado operativo `stripe_estado`.
+
+## Regla funcional
+
+- Si el administrador activa “Habilitar pagos online con Stripe”, el estado pasa automáticamente a `activo`.
+- Si el administrador desactiva Stripe, el estado pasa automáticamente a `inactivo`.
+- Si selecciona estado `activo`, la bandera queda habilitada.
+- Si selecciona `no_configurado`, `configurado` o `inactivo`, la bandera queda deshabilitada.
+- El backend vuelve a normalizar la consistencia para evitar estados contradictorios.
+
+## Motivo
+
+Durante QA se detectó que al deshabilitar Stripe el socio quedaba correctamente bloqueado, pero al volver a habilitarlo el pago online seguía bloqueado porque el estado no quedaba sincronizado como `activo`.

--- a/docs/gimnasio-parametrizacion/gimnasio-parametrizacion-stripe-payments.md
+++ b/docs/gimnasio-parametrizacion/gimnasio-parametrizacion-stripe-payments.md
@@ -1,0 +1,26 @@
+# Gym Master — Parametrización Stripe por gimnasio
+
+## Alcance
+
+La feature `feature/gimnasio-parametrizacion-stripe-payments` agrega control funcional para habilitar o deshabilitar pagos online con Stripe por gimnasio.
+
+## Reglas principales
+
+- Los pagos manuales administrativos siguen funcionando siempre.
+- Si Stripe no está habilitado y activo, el socio no puede iniciar checkout online.
+- El endpoint `/api/pagar-cuota` bloquea la vista previa y la creación de sesión Stripe cuando la configuración no está activa.
+- La pantalla `/dashboard/mi-cuenta/pagar-cuota` muestra un mensaje claro cuando los pagos online no están disponibles.
+- La configuración vive dentro de `gimnasio_parametrizacion` y no guarda claves secretas.
+
+## Campos agregados
+
+- `stripe_habilitado`
+- `stripe_estado`
+- `stripe_modo`
+- `stripe_public_key`
+- `stripe_account_reference`
+- `stripe_observaciones`
+
+## Seguridad
+
+Las claves secretas de Stripe deben seguir en variables de entorno seguras. No se guardan secrets en base de datos ni se exponen al frontend.

--- a/src/app/api/gimnasio-parametrizacion/stripe-status/route.ts
+++ b/src/app/api/gimnasio-parametrizacion/stripe-status/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getGimnasioStripeStatus } from '@/services/gimnasioParametrizacionServerService';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    await authMiddleware(req);
+    const data = await getGimnasioStripeStatus();
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    const status = message.includes('Token') || message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/pagar-cuota/route.ts
+++ b/src/app/api/pagar-cuota/route.ts
@@ -29,9 +29,11 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ data: preview }, { status: 200 });
   } catch (error: any) {
     console.error('Error al obtener vista previa de pago:', error);
+    const message = error.message || 'Error al obtener vista previa de pago';
+    const status = message.includes('pagos online') || message.includes('no están habilitados') ? 403 : 500;
     return NextResponse.json(
-      { error: error.message || 'Error al obtener vista previa de pago' },
-      { status: 500 }
+      { error: message },
+      { status }
     );
   }
 }
@@ -66,9 +68,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ url: session.url }, { status: 200 });
   } catch (error: any) {
     console.error('Error al crear la sesión de pago:', error);
+    const message = error.message || 'Error al crear la sesión de pago';
+    const status = message.includes('pagos online') || message.includes('no están habilitados') ? 403 : 500;
     return NextResponse.json(
-      { error: error.message || 'Error al crear la sesión de pago' },
-      { status: 500 }
+      { error: message },
+      { status }
     );
   }
 }

--- a/src/app/dashboard/gimnasio-parametrizacion/page.tsx
+++ b/src/app/dashboard/gimnasio-parametrizacion/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { Building2, CheckCircle2, Loader2, Palette, ReceiptText, Save, ShieldCheck, UploadCloud } from 'lucide-react';
+import { Building2, CheckCircle2, CreditCard, Loader2, Palette, ReceiptText, Save, ShieldCheck, UploadCloud } from 'lucide-react';
 import { AppFooter } from '@/components/footer/AppFooter';
 import { AppHeader } from '@/components/header/AppHeader';
 import { AppSidebar } from '@/components/sidebar/AppSidebar';
@@ -46,6 +46,12 @@ const emptyForm: GimnasioParametrizacionPayload = {
   texto_legal_recibos: '',
   texto_legal_reportes: '',
   pie_pagina_documentos: 'Documento generado por Gym Master.',
+  stripe_habilitado: false,
+  stripe_estado: 'no_configurado',
+  stripe_modo: 'test',
+  stripe_public_key: '',
+  stripe_account_reference: '',
+  stripe_observaciones: '',
   activo: true,
 };
 
@@ -72,6 +78,12 @@ function formFromData(data: GimnasioParametrizacion): GimnasioParametrizacionPay
     texto_legal_recibos: data.texto_legal_recibos ?? '',
     texto_legal_reportes: data.texto_legal_reportes ?? '',
     pie_pagina_documentos: data.pie_pagina_documentos ?? 'Documento generado por Gym Master.',
+    stripe_habilitado: data.stripe_habilitado === true,
+    stripe_estado: data.stripe_estado ?? 'no_configurado',
+    stripe_modo: data.stripe_modo ?? 'test',
+    stripe_public_key: data.stripe_public_key ?? '',
+    stripe_account_reference: data.stripe_account_reference ?? '',
+    stripe_observaciones: data.stripe_observaciones ?? '',
     activo: data.activo,
   };
 }
@@ -146,6 +158,26 @@ export default function GimnasioParametrizacionPage() {
     setSuccessMessage(null);
     setLogoBroken(false);
     setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const updateStripeEnabled = (enabled: boolean) => {
+    setSuccessMessage(null);
+    setLogoBroken(false);
+    setForm((prev) => ({
+      ...prev,
+      stripe_habilitado: enabled,
+      stripe_estado: enabled ? 'activo' : 'inactivo',
+    }));
+  };
+
+  const updateStripeEstado = (estado: string) => {
+    setSuccessMessage(null);
+    setLogoBroken(false);
+    setForm((prev) => ({
+      ...prev,
+      stripe_estado: estado,
+      stripe_habilitado: estado === 'activo',
+    }));
   };
 
   const handleLogoFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -383,6 +415,90 @@ export default function GimnasioParametrizacionPage() {
                   <Card>
                     <CardHeader>
                       <div className='flex items-center gap-2 text-lg font-semibold'>
+                        <CreditCard className='h-5 w-5 text-sky-600' />
+                        Pagos online Stripe
+                      </div>
+                    </CardHeader>
+                    <CardContent className='grid gap-4 md:grid-cols-2'>
+                      <div className='space-y-2 md:col-span-2'>
+                        <label className='flex items-start gap-3 rounded-xl border border-sky-100 bg-sky-50 p-4 text-sm dark:border-sky-900/60 dark:bg-sky-950/30'>
+                          <input
+                            type='checkbox'
+                            checked={form.stripe_habilitado === true}
+                            onChange={(e) => updateStripeEnabled(e.target.checked)}
+                            className='mt-1 h-4 w-4 rounded border-slate-300'
+                          />
+                          <span>
+                            <span className='block font-semibold text-slate-900 dark:text-white'>Habilitar pagos online con Stripe</span>
+                            <span className='mt-1 block text-xs leading-5 text-slate-600 dark:text-slate-300'>
+                              Si está desactivado, los socios no verán disponible el checkout online y deberán abonar por medios manuales registrados por administración.
+                            </span>
+                          </span>
+                        </label>
+                      </div>
+                      <div className='space-y-2'>
+                        <Label htmlFor='stripe_estado'>Estado de integración</Label>
+                        <select
+                          id='stripe_estado'
+                          value={textValue(form.stripe_estado) || 'no_configurado'}
+                          onChange={(e) => updateStripeEstado(e.target.value)}
+                          className='h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+                        >
+                          <option value='no_configurado'>No configurado</option>
+                          <option value='configurado'>Configurado</option>
+                          <option value='activo'>Activo</option>
+                          <option value='inactivo'>Inactivo</option>
+                        </select>
+                      </div>
+                      <div className='space-y-2'>
+                        <Label htmlFor='stripe_modo'>Modo</Label>
+                        <select
+                          id='stripe_modo'
+                          value={textValue(form.stripe_modo) || 'test'}
+                          onChange={(e) => updateField('stripe_modo', e.target.value)}
+                          className='h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+                        >
+                          <option value='test'>Test / sandbox</option>
+                          <option value='live'>Producción</option>
+                        </select>
+                      </div>
+                      <div className='space-y-2 md:col-span-2'>
+                        <Label htmlFor='stripe_public_key'>Publishable key / referencia pública</Label>
+                        <Input
+                          id='stripe_public_key'
+                          placeholder='Opcional. No guardar claves secretas acá.'
+                          value={textValue(form.stripe_public_key)}
+                          onChange={(e) => updateField('stripe_public_key', e.target.value)}
+                        />
+                        <p className='text-xs text-muted-foreground'>
+                          Las claves secretas y webhooks se manejan por variables de entorno seguras. Este campo es solo referencia operativa.
+                        </p>
+                      </div>
+                      <div className='space-y-2 md:col-span-2'>
+                        <Label htmlFor='stripe_account_reference'>Referencia de cuenta Stripe</Label>
+                        <Input
+                          id='stripe_account_reference'
+                          placeholder='Ej: cuenta conectada, cliente, alias o identificador interno'
+                          value={textValue(form.stripe_account_reference)}
+                          onChange={(e) => updateField('stripe_account_reference', e.target.value)}
+                        />
+                      </div>
+                      <div className='space-y-2 md:col-span-2'>
+                        <Label htmlFor='stripe_observaciones'>Observaciones Stripe</Label>
+                        <textarea
+                          id='stripe_observaciones'
+                          value={textValue(form.stripe_observaciones)}
+                          onChange={(e) => updateField('stripe_observaciones', e.target.value)}
+                          className='min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm'
+                          placeholder='Notas internas sobre configuración, estado comercial o validaciones pendientes.'
+                        />
+                      </div>
+                    </CardContent>
+                  </Card>
+
+                  <Card>
+                    <CardHeader>
+                      <div className='flex items-center gap-2 text-lg font-semibold'>
                         <ReceiptText className='h-5 w-5 text-sky-600' />
                         Textos legales para documentos
                       </div>
@@ -429,6 +545,17 @@ export default function GimnasioParametrizacionPage() {
 
                       <div className='rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-800'>
                         La parametrización se usa como fuente única para recibos, reportes PDF comerciales y exportaciones. Los nuevos documentos deben consumir estos datos del gimnasio.
+                      </div>
+
+                      <div className={`rounded-xl border px-4 py-3 text-xs leading-5 ${
+                        form.stripe_habilitado && form.stripe_estado === 'activo'
+                          ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+                          : 'border-slate-200 bg-slate-50 text-slate-700'
+                      }`}>
+                        <strong>Stripe:</strong>{' '}
+                        {form.stripe_habilitado && form.stripe_estado === 'activo'
+                          ? 'pagos online habilitados para socios.'
+                          : 'pagos online deshabilitados o pendientes de activación.'}
                       </div>
 
                       <Button type='submit' disabled={saving} className='w-full'>

--- a/src/app/dashboard/mi-cuenta/pagar-cuota/page.tsx
+++ b/src/app/dashboard/mi-cuenta/pagar-cuota/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { CreditCard, Loader2, ShieldCheck } from 'lucide-react';
+import { AlertTriangle, CreditCard, Loader2, ShieldCheck } from 'lucide-react';
 import { AppHeader } from '@/components/header/AppHeader';
 import { AppFooter } from '@/components/footer/AppFooter';
 import { AppSidebar } from '@/components/sidebar/AppSidebar';
@@ -14,6 +14,7 @@ import { getToken } from '@/services/storageService';
 import type { PagoDescuentoPreview } from '@/interfaces/pago.interface';
 import { useAuthStore } from '@/stores/authStore';
 import { formatFrontendDate } from '@/utils/dateFormat';
+import { getGimnasioStripeStatus } from '@/services/gimnasioParametrizacionService';
 
 type EstadoCuota = {
   id_socio: string;
@@ -64,6 +65,8 @@ export default function PagarCuotaSocioPage() {
   const [meses, setMeses] = useState(1);
   const [preview, setPreview] = useState<PagoDescuentoPreview | null>(null);
   const [loadingPreview, setLoadingPreview] = useState(false);
+  const [stripeDisponible, setStripeDisponible] = useState<boolean | null>(null);
+  const [stripeMensaje, setStripeMensaje] = useState<string | null>(null);
 
   useEffect(() => {
     initializeAuth();
@@ -76,6 +79,17 @@ export default function PagarCuotaSocioPage() {
   }, [isAuthenticated, isInitialized, router]);
 
   const puedePagar = user?.rol === 'socio';
+
+  const loadStripeStatus = async () => {
+    try {
+      const status = await getGimnasioStripeStatus();
+      setStripeDisponible(status.pagos_online_disponibles);
+      setStripeMensaje(status.mensaje);
+    } catch (error: any) {
+      setStripeDisponible(false);
+      setStripeMensaje(error.message || 'No se pudo verificar si el gimnasio tiene pagos online habilitados.');
+    }
+  };
 
   const loadEstado = async () => {
     try {
@@ -108,6 +122,8 @@ export default function PagarCuotaSocioPage() {
       setPreview(json.data ?? null);
     } catch (error: any) {
       setPreview(null);
+      setStripeDisponible(false);
+      setStripeMensaje(error.message || 'El gimnasio no tiene pagos online habilitados.');
       toast.error(error.message || 'Error al calcular el pago');
     } finally {
       setLoadingPreview(false);
@@ -117,14 +133,18 @@ export default function PagarCuotaSocioPage() {
   useEffect(() => {
     if (isInitialized && isAuthenticated) {
       loadEstado();
+      loadStripeStatus();
     }
   }, [isInitialized, isAuthenticated]);
 
   useEffect(() => {
-    if (isInitialized && isAuthenticated && user?.rol === 'socio') {
+    if (isInitialized && isAuthenticated && user?.rol === 'socio' && stripeDisponible === true) {
       loadPreview(meses);
     }
-  }, [isInitialized, isAuthenticated, user?.rol, meses]);
+    if (stripeDisponible === false) {
+      setPreview(null);
+    }
+  }, [isInitialized, isAuthenticated, user?.rol, meses, stripeDisponible]);
 
   const detallePago = useMemo(() => {
     const suffix = meses === 1 ? 'mes' : 'meses';
@@ -132,6 +152,11 @@ export default function PagarCuotaSocioPage() {
   }, [meses]);
 
   const handlePagar = async () => {
+    if (stripeDisponible !== true) {
+      toast.error(stripeMensaje || 'El gimnasio no tiene pagos online habilitados.');
+      return;
+    }
+
     try {
       setPaying(true);
       const token = getToken();
@@ -172,12 +197,12 @@ export default function PagarCuotaSocioPage() {
                   <div>
                     <h2 className='text-2xl font-bold'>Mi cuenta</h2>
                     <p className='text-sm text-muted-foreground'>
-                      Pagá tu cuota online con Stripe. Los pagos en efectivo los registra el administrador.
+                      Consultá el estado de tu cuota y aboná online si el gimnasio tiene Stripe habilitado.
                     </p>
                   </div>
                   <div className='flex items-center gap-2 text-sm text-muted-foreground'>
                     <ShieldCheck className='w-4 h-4' />
-                    Pago seguro vía Stripe
+                    {stripeDisponible ? 'Pago seguro vía Stripe' : 'Pagos online no disponibles'}
                   </div>
                 </div>
               </CardHeader>
@@ -211,6 +236,16 @@ export default function PagarCuotaSocioPage() {
                       {estado?.estado_cuota === 'vencido' && (
                         <p className='mt-1 text-xs text-red-600'>{estado.dias_vencido} día(s) vencido</p>
                       )}
+                    </div>
+                  </div>
+                )}
+
+                {stripeDisponible === false && (
+                  <div className='flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800'>
+                    <AlertTriangle className='mt-0.5 h-4 w-4 flex-none' />
+                    <div>
+                      <p className='font-semibold'>Pagos online no habilitados</p>
+                      <p className='mt-1'>{stripeMensaje || 'Este gimnasio no tiene Stripe activo. Comunicate con administración para abonar por medios manuales.'}</p>
                     </div>
                   </div>
                 )}
@@ -269,7 +304,7 @@ export default function PagarCuotaSocioPage() {
                       </div>
                     ) : null}
                     <p className='mt-3 text-xs text-muted-foreground'>
-                      Al finalizar el checkout, Stripe notificará el pago al webhook y se actualizará tu estado de cuota.
+                      Si Stripe está activo, al finalizar el checkout se notificará el pago al webhook y se actualizará tu estado de cuota.
                     </p>
                   </div>
                 </div>
@@ -279,7 +314,7 @@ export default function PagarCuotaSocioPage() {
                     Ver historial de pagos
                   </Button>
                   <Button
-                    disabled={!puedePagar || paying || loadingPreview}
+                    disabled={!puedePagar || paying || loadingPreview || stripeDisponible !== true}
                     onClick={handlePagar}
                     className='bg-[#02a8e1] hover:bg-[#0288b1] text-white'
                   >

--- a/src/interfaces/gimnasioParametrizacion.interface.ts
+++ b/src/interfaces/gimnasioParametrizacion.interface.ts
@@ -22,6 +22,12 @@ export interface GimnasioParametrizacion {
   texto_legal_recibos: string | null;
   texto_legal_reportes: string | null;
   pie_pagina_documentos: string | null;
+  stripe_habilitado: boolean;
+  stripe_estado: 'no_configurado' | 'configurado' | 'activo' | 'inactivo' | string;
+  stripe_modo: 'test' | 'live' | string;
+  stripe_public_key: string | null;
+  stripe_account_reference: string | null;
+  stripe_observaciones: string | null;
   activo: boolean;
   creado_en: string | null;
   actualizado_en: string | null;
@@ -52,6 +58,12 @@ export type GimnasioParametrizacionPayload = Partial<
     | 'texto_legal_recibos'
     | 'texto_legal_reportes'
     | 'pie_pagina_documentos'
+    | 'stripe_habilitado'
+    | 'stripe_estado'
+    | 'stripe_modo'
+    | 'stripe_public_key'
+    | 'stripe_account_reference'
+    | 'stripe_observaciones'
     | 'activo'
   >
 >;
@@ -70,4 +82,17 @@ export interface GimnasioLogoUploadResponse {
     mimeType: string;
     size: number;
   };
+}
+
+
+export interface GimnasioStripeStatus {
+  stripe_habilitado: boolean;
+  stripe_estado: string;
+  stripe_modo: string;
+  pagos_online_disponibles: boolean;
+  mensaje: string | null;
+}
+
+export interface GimnasioStripeStatusResponse {
+  data: GimnasioStripeStatus;
 }

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -26,7 +26,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     ],
     "tag": "Parametrización",
     "summary": "Branding y datos legales del gimnasio",
-    "description": "Consulta y actualiza la parametrización comercial, legal y visual del gimnasio cliente para recibos, PDFs, reportes, exportaciones y futuras pantallas con branding propio.",
+    "description": "Consulta y actualiza la parametrización comercial, legal y visual del gimnasio cliente, incluyendo configuración operativa de pagos online Stripe.",
     "auth": true,
     "admin": true,
     "notImplemented": false,
@@ -61,6 +61,27 @@ const endpointDefinitions: EndpointDefinition[] = [
     ],
     "queryParams": [],
     "source": "src/app/api/gimnasio-parametrizacion/logo-upload/route.ts"
+  },
+
+  {
+    "path": "/api/gimnasio-parametrizacion/stripe-status",
+    "methods": [
+      "GET"
+    ],
+    "tag": "Parametrización",
+    "summary": "Estado de pagos online Stripe del gimnasio",
+    "description": "Devuelve si el gimnasio tiene habilitados los pagos online con Stripe para condicionar la experiencia del socio y los endpoints de checkout.",
+    "auth": true,
+    "admin": false,
+    "notImplemented": false,
+    "statuses": [
+      200,
+      401,
+      403,
+      500
+    ],
+    "queryParams": [],
+    "source": "src/app/api/gimnasio-parametrizacion/stripe-status/route.ts"
   },
 
 
@@ -1671,7 +1692,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     ],
     "tag": "Cuotas y pagos",
     "summary": "Vista previa y sesión de pago de cuota",
-    "description": "GET devuelve vista previa de pago con subtotal, descuento por pago adelantado y total. POST crea una sesión Stripe con la misma parametrización de descuento vigente.",
+    "description": "GET devuelve vista previa de pago con subtotal, descuento por pago adelantado y total solo si el gimnasio tiene Stripe activo. POST crea una sesión Stripe con la misma parametrización de descuento vigente y bloquea el checkout si los pagos online están deshabilitados.",
     "auth": true,
     "admin": false,
     "notImplemented": false,

--- a/src/services/gimnasioParametrizacionServerService.ts
+++ b/src/services/gimnasioParametrizacionServerService.ts
@@ -33,6 +33,12 @@ const DEFAULT_BRANDING: Omit<
   texto_legal_recibos: null,
   texto_legal_reportes: null,
   pie_pagina_documentos: 'Documento generado por Gym Master.',
+  stripe_habilitado: false,
+  stripe_estado: 'no_configurado',
+  stripe_modo: 'test',
+  stripe_public_key: null,
+  stripe_account_reference: null,
+  stripe_observaciones: null,
   activo: true,
 };
 
@@ -60,6 +66,12 @@ const EMPTY_BRANDING: GimnasioParametrizacion = {
   texto_legal_recibos: null,
   texto_legal_reportes: null,
   pie_pagina_documentos: null,
+  stripe_habilitado: false,
+  stripe_estado: 'no_configurado',
+  stripe_modo: 'test',
+  stripe_public_key: null,
+  stripe_account_reference: null,
+  stripe_observaciones: null,
   activo: true,
   creado_en: null,
   actualizado_en: null,
@@ -124,6 +136,9 @@ function normalizePayload(input: GimnasioParametrizacionPayload, user: JwtUser) 
     'texto_legal_recibos',
     'texto_legal_reportes',
     'pie_pagina_documentos',
+    'stripe_public_key',
+    'stripe_account_reference',
+    'stripe_observaciones',
   ];
 
   for (const field of stringFields) {
@@ -131,6 +146,51 @@ function normalizePayload(input: GimnasioParametrizacionPayload, user: JwtUser) 
       const value = trimString(input[field]);
       payload[field] = field === 'nombre_comercial' ? value || DEFAULT_BRANDING.nombre_comercial : value;
     }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'stripe_habilitado')) {
+    payload.stripe_habilitado = input.stripe_habilitado === true;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'stripe_estado')) {
+    const estado = trimString(input.stripe_estado) || 'no_configurado';
+    payload.stripe_estado = ['no_configurado', 'configurado', 'activo', 'inactivo'].includes(estado)
+      ? estado
+      : 'no_configurado';
+  }
+
+  if (Object.prototype.hasOwnProperty.call(input, 'stripe_modo')) {
+    const modo = trimString(input.stripe_modo) || 'test';
+    payload.stripe_modo = ['test', 'live'].includes(modo) ? modo : 'test';
+  }
+
+  const tieneStripeHabilitado = Object.prototype.hasOwnProperty.call(input, 'stripe_habilitado');
+  const tieneStripeEstado = Object.prototype.hasOwnProperty.call(input, 'stripe_estado');
+
+  if (tieneStripeEstado && payload.stripe_estado === 'activo') {
+    payload.stripe_habilitado = true;
+  }
+
+  if (tieneStripeEstado && ['no_configurado', 'inactivo'].includes(String(payload.stripe_estado))) {
+    payload.stripe_habilitado = false;
+  }
+
+  if (tieneStripeHabilitado && payload.stripe_habilitado === true) {
+    const estadoActual = String(payload.stripe_estado || '');
+    if (!estadoActual || ['no_configurado', 'inactivo'].includes(estadoActual)) {
+      payload.stripe_estado = 'activo';
+    }
+  }
+
+  if (tieneStripeHabilitado && payload.stripe_habilitado === false) {
+    const estadoActual = String(payload.stripe_estado || '');
+    if (!estadoActual || estadoActual === 'activo') {
+      payload.stripe_estado = 'inactivo';
+    }
+  }
+
+  if (payload.stripe_estado === 'configurado') {
+    payload.stripe_habilitado = false;
   }
 
   if (Object.prototype.hasOwnProperty.call(input, 'sitio_web')) {
@@ -197,6 +257,12 @@ function normalizeRow(row: Record<string, unknown>): GimnasioParametrizacion {
     texto_legal_recibos: row.texto_legal_recibos ? String(row.texto_legal_recibos) : null,
     texto_legal_reportes: row.texto_legal_reportes ? String(row.texto_legal_reportes) : null,
     pie_pagina_documentos: row.pie_pagina_documentos ? String(row.pie_pagina_documentos) : null,
+    stripe_habilitado: row.stripe_habilitado === true,
+    stripe_estado: row.stripe_estado ? String(row.stripe_estado) : 'no_configurado',
+    stripe_modo: row.stripe_modo ? String(row.stripe_modo) : 'test',
+    stripe_public_key: row.stripe_public_key ? String(row.stripe_public_key) : null,
+    stripe_account_reference: row.stripe_account_reference ? String(row.stripe_account_reference) : null,
+    stripe_observaciones: row.stripe_observaciones ? String(row.stripe_observaciones) : null,
     activo: row.activo !== false,
     creado_en: row.creado_en ? String(row.creado_en) : null,
     actualizado_en: row.actualizado_en ? String(row.actualizado_en) : null,
@@ -222,6 +288,38 @@ export async function getGimnasioParametrizacion(): Promise<GimnasioParametrizac
   // el sistema debe poder detectar parametrización incompleta y bloquear
   // documentos comerciales hasta que el administrador cargue el gimnasio real.
   return EMPTY_BRANDING;
+}
+
+
+export function buildGimnasioStripeStatus(parametrizacion: GimnasioParametrizacion) {
+  const stripeHabilitado = parametrizacion.stripe_habilitado === true;
+  const stripeActivo = parametrizacion.stripe_estado === 'activo';
+  const pagosOnlineDisponibles = stripeHabilitado && stripeActivo && parametrizacion.activo !== false;
+
+  return {
+    stripe_habilitado: stripeHabilitado,
+    stripe_estado: parametrizacion.stripe_estado || 'no_configurado',
+    stripe_modo: parametrizacion.stripe_modo || 'test',
+    pagos_online_disponibles: pagosOnlineDisponibles,
+    mensaje: pagosOnlineDisponibles
+      ? null
+      : 'El gimnasio no tiene pagos online habilitados. Consulte en administración para abonar por medios manuales.',
+  };
+}
+
+export async function getGimnasioStripeStatus() {
+  const parametrizacion = await getGimnasioParametrizacion();
+  return buildGimnasioStripeStatus(parametrizacion);
+}
+
+export async function assertGimnasioStripeDisponible() {
+  const status = await getGimnasioStripeStatus();
+
+  if (!status.pagos_online_disponibles) {
+    throw new Error(status.mensaje || 'Los pagos online no están habilitados para este gimnasio.');
+  }
+
+  return status;
 }
 
 export async function updateGimnasioParametrizacion(

--- a/src/services/gimnasioParametrizacionService.ts
+++ b/src/services/gimnasioParametrizacionService.ts
@@ -3,6 +3,7 @@ import type {
   GimnasioParametrizacionPayload,
   GimnasioParametrizacionResponse,
   GimnasioLogoUploadResponse,
+  GimnasioStripeStatusResponse,
 } from '@/interfaces/gimnasioParametrizacion.interface';
 import { authHeader } from '@/services/storageService';
 
@@ -52,5 +53,17 @@ export async function uploadGimnasioLogo(file: File): Promise<GimnasioLogoUpload
   });
 
   const payload = await parseJsonResponse<GimnasioLogoUploadResponse>(response);
+  return payload.data;
+}
+
+
+export async function getGimnasioStripeStatus() {
+  const response = await fetch('/api/gimnasio-parametrizacion/stripe-status', {
+    method: 'GET',
+    headers: authHeader(),
+    cache: 'no-store',
+  });
+
+  const payload = await parseJsonResponse<GimnasioStripeStatusResponse>(response);
   return payload.data;
 }

--- a/src/services/stripeService.ts
+++ b/src/services/stripeService.ts
@@ -6,6 +6,7 @@ import { getSocioByIdUsuario } from "./socioService";
 import { calcularDescuentoPago } from "@/lib/cuotas/descuentoPago";
 import { fetchCuotaDescuentoConfig } from "@/services/cuotaDescuentoService";
 import type { PagoDescuentoPreview } from "@/interfaces/pago.interface";
+import { assertGimnasioStripeDisponible } from "@/services/gimnasioParametrizacionServerService";
 
 type CreateSessionPagoOptions = {
   meses_cubiertos?: number;
@@ -126,6 +127,7 @@ export const previewSessionPago = async (
   user: JwtUser,
   options: CreateSessionPagoOptions = {}
 ): Promise<PagoDescuentoPreview> => {
+  await assertGimnasioStripeDisponible();
   const context = await buildPagoCuotaContext(user, options);
   return context.preview;
 };
@@ -134,6 +136,7 @@ export const createSessionPago = async (
   user: JwtUser,
   options: CreateSessionPagoOptions = {}
 ): Promise<{ url: string }> => {
+  await assertGimnasioStripeDisponible();
   const context = await buildPagoCuotaContext(user, options);
 
   const unitAmount = Math.round(context.preview.total * 100);


### PR DESCRIPTION
# PR — Gym Master: Parametrización Stripe Payments

## Rama

`feature/gimnasio-parametrizacion-stripe-payments`

## Resumen

Esta feature agrega la parametrización de pagos online Stripe dentro de **Datos del Gimnasio**, permitiendo activar o desactivar el pago online por gimnasio y sincronizar correctamente el estado funcional de Stripe con la bandera de habilitación.

El objetivo es que cada gimnasio pueda operar con pagos manuales siempre disponibles, y que los pagos online para socios solo estén habilitados cuando Stripe esté expresamente activo y correctamente parametrizado.

## Alcance implementado

- Configuración Stripe dentro de `Datos del Gimnasio`.
- Activación/desactivación de pagos online por gimnasio.
- Estados soportados: `no_configurado`, `configurado`, `activo`, `inactivo`.
- Modo Stripe: `test` / `live`.
- Campos de referencia pública y cuenta Stripe.
- Observaciones internas de integración.
- Endpoint `GET /api/gimnasio-parametrizacion/stripe-status`.
- Bloqueo backend en `/api/pagar-cuota` cuando Stripe no está activo.
- Bloqueo frontend en `/dashboard/mi-cuenta/pagar-cuota` cuando Stripe está deshabilitado.
- Sincronización entre bandera de habilitación y estado Stripe.
- Pagos manuales administrativos sin cambios.
- Swagger/OpenAPI actualizado.
- Documentación técnica agregada.

## Ajuste QA incluido

Durante la prueba funcional se detectó que al deshabilitar Stripe el socio quedaba correctamente bloqueado, pero al volver a habilitarlo no se actualizaba de forma consistente la bandera/estado funcional. Se agregó un fix de sincronización:

- Si el admin activa pagos online: `stripe_habilitado = true` y `stripe_estado = activo`.
- Si el admin desactiva pagos online: `stripe_habilitado = false` y `stripe_estado = inactivo`.
- Si el admin selecciona estado `activo`: la bandera queda habilitada.
- Si selecciona `no_configurado`, `configurado` o `inactivo`: la bandera queda deshabilitada.
- El backend normaliza estados contradictorios antes de persistir.

## Base de datos

Migración privada/no versionada en el repo público:

```txt
supabase/migrations/202606061700_gimnasio_parametrizacion_stripe_payments.sql
```

Script de validación privado/no versionado:

```txt
database/scripts/validar_gimnasio_parametrizacion_stripe_payments.sql
```

La validación local requirió ejecutar la cadena de migraciones de parametrización del gimnasio porque el dump usado como baseline no contenía todavía `public.gimnasio_parametrizacion`:

```txt
202606061100_gimnasio_parametrizacion_branding_legal.sql
202606061130_gimnasio_condicion_fiscal_catalog_cloudinary.sql
202606061700_gimnasio_parametrizacion_stripe_payments.sql
```

## Validaciones realizadas

- Validación local QA de DB ejecutada correctamente.
- Migración remota aplicada correctamente.
- Prueba funcional con Stripe deshabilitado: socio no puede pagar online.
- Prueba funcional con Stripe habilitado/activo: socio puede acceder al flujo de pago online.
- Confirmación de que pagos manuales administrativos siguen funcionando.
- Swagger revisado.
- `npm run build` ejecutado correctamente.

## Checklist

- [x] Rama creada desde `main` actualizado.
- [x] Migración DB validada localmente.
- [x] Migración DB aplicada en remoto.
- [x] Schema cache refrescado cuando correspondió.
- [x] Frontend probado como admin.
- [x] Frontend probado como socio.
- [x] Backend bloquea checkout si Stripe no está activo.
- [x] UI socio bloquea pago online si Stripe no está habilitado.
- [x] Pagos manuales no afectados.
- [x] Swagger/OpenAPI actualizado.
- [x] `npm run build` OK.

## Notas

Esta feature no configura secretos Stripe reales en el frontend ni expone claves sensibles. Los campos agregados son de parametrización operativa y referencias públicas/controladas. La integración con claves secretas y cuenta real debe mantenerse en backend/variables seguras cuando corresponda.
