### PR TITLE
feat: add global gym locations catalog

### DIFF
--- a/docs/parametrizacion/catalogo-ubicaciones-gimnasio.md
+++ b/docs/parametrizacion/catalogo-ubicaciones-gimnasio.md
@@ -1,0 +1,48 @@
+# Gym Master — Catálogo global de ubicaciones del gimnasio
+
+## Rama
+
+`feature/catalogo-ubicaciones-gimnasio`
+
+## Objetivo
+
+Convertir el campo de ubicación de los turnos de actividades en un catálogo parametrizable de zonas, salas y sectores físicos del gimnasio.
+
+La ubicación deja de depender de texto libre y pasa a administrarse desde Parametrización, con reutilización progresiva en actividades, equipamiento, mantenimiento, asistencia/aforo y reportes BI.
+
+## Alcance
+
+- Nueva tabla `public.ubicacion_gimnasio`.
+- Catálogo editable desde `/dashboard/parametrizacion`.
+- API existente de catálogos ampliada con `ubicacion_gimnasio`.
+- Selector de ubicación en `/dashboard/actividades` para crear/editar turnos.
+- Fallback a texto libre si el catálogo no existe o todavía no fue migrado.
+- Seed inicial de ubicaciones frecuentes: sala principal, funcional, spinning, cardio, fuerza, box, wellness, recepción, depósito, bar/snack y vestuarios.
+- Seed adicional desde ubicaciones existentes de equipamiento y turnos.
+
+## Módulos impactados
+
+- Parametrización.
+- Actividades / turnos / cupos.
+- Swagger/OpenAPI.
+
+## Módulos preparados para integración futura
+
+- Equipamiento.
+- Mantenimiento.
+- Asistencia / aforo.
+- Reportes BI por zona/sala.
+
+## Seguridad
+
+La tabla queda con RLS habilitado. Las operaciones administrativas de catálogo continúan pasando por API Routes server-side con service role, respetando el patrón de parametrización actual.
+
+## Validación esperada
+
+1. Aplicar migración privada `202606130801_ubicaciones_gimnasio_catalogo.sql`.
+2. Ejecutar script de validación privado.
+3. Abrir `/dashboard/parametrizacion` y verificar el catálogo “Ubicaciones del gimnasio”.
+4. Crear/editar una ubicación.
+5. Abrir `/dashboard/actividades` y verificar que el formulario de turnos muestre selector de ubicación.
+6. Crear un turno usando una ubicación parametrizada.
+7. Confirmar que el turno queda guardado y reflejado en BI/listado.

--- a/src/app/api/actividades/turnos-cupos/route.ts
+++ b/src/app/api/actividades/turnos-cupos/route.ts
@@ -8,6 +8,7 @@ import type {
   ActividadTurno,
   ActividadTurnoInscripcion,
   ActividadTurnosCuposDashboard,
+  ActividadUbicacionOption,
 } from "@/interfaces/actividadTurnosCupos.interface";
 
 export const dynamic = "force-dynamic";
@@ -73,6 +74,7 @@ function buildEmptyDashboard(params: {
   actividades: ActividadBaseOption[];
   socios: ActividadSocioOption[];
   empleados: ActividadEmpleadoOption[];
+  ubicaciones: ActividadUbicacionOption[];
   warnings: string[];
   schemaReady: boolean;
 }): ActividadTurnosCuposDashboard {
@@ -83,6 +85,7 @@ function buildEmptyDashboard(params: {
     actividades: params.actividades,
     socios: params.socios,
     empleados: params.empleados,
+    ubicaciones: params.ubicaciones,
     turnos: [],
     inscripciones: [],
     kpis: {
@@ -142,6 +145,32 @@ export async function GET(req: Request) {
     const socios = (sociosResult.data ?? []) as ActividadSocioOption[];
     const empleados = empleadosResult.error ? [] : ((empleadosResult.data ?? []) as ActividadEmpleadoOption[]);
 
+    const ubicacionesResult = await selectOptional<BasicRow[]>(
+      supabase
+        .from("ubicacion_gimnasio")
+        .select("id, codigo, nombre, descripcion, activo, orden")
+        .eq("activo", true)
+        .order("orden", { ascending: true })
+        .order("nombre", { ascending: true }),
+    );
+
+    const ubicaciones: ActividadUbicacionOption[] = ubicacionesResult.missing
+      ? []
+      : ((ubicacionesResult.data ?? []) as BasicRow[]).map((ubicacion) => ({
+          id: String(ubicacion.id),
+          codigo: String(ubicacion.codigo ?? ""),
+          nombre: String(ubicacion.nombre ?? ""),
+          descripcion: ubicacion.descripcion ? String(ubicacion.descripcion) : null,
+          activo: ubicacion.activo !== false,
+          orden: ubicacion.orden == null ? null : Number(ubicacion.orden),
+        }));
+
+    if (ubicacionesResult.missing) {
+      warnings.push(
+        "El catálogo global de ubicaciones todavía no existe. Aplicá la migración de ubicaciones para usar el selector parametrizable.",
+      );
+    }
+
     const turnosResult = await selectOptional<BasicRow[]>(
       supabase
         .from("actividad_turno")
@@ -168,7 +197,7 @@ export async function GET(req: Request) {
       );
 
       return NextResponse.json(
-        buildEmptyDashboard({ actividades, socios, empleados, warnings, schemaReady: false }),
+        buildEmptyDashboard({ actividades, socios, empleados, ubicaciones, warnings, schemaReady: false }),
         { status: 200 },
       );
     }
@@ -279,6 +308,7 @@ export async function GET(req: Request) {
       actividades,
       socios,
       empleados,
+      ubicaciones,
       turnos,
       inscripciones,
       kpis: {

--- a/src/app/api/parametrizacion/catalogos/route.ts
+++ b/src/app/api/parametrizacion/catalogos/route.ts
@@ -150,6 +150,17 @@ const catalogDefinitions: CatalogDefinition[] = [
     priority: "Alta",
     editable: true,
   },
+
+  {
+    key: "ubicacion_gimnasio",
+    table: "ubicacion_gimnasio",
+    title: "Ubicaciones del gimnasio",
+    description:
+      "Catálogo global de zonas, salas y sectores físicos del gimnasio para actividades, equipamiento, mantenimiento, asistencia y BI.",
+    status: "Disponible",
+    priority: "Alta",
+    editable: true,
+  },
   {
     key: "tipo_mantenimiento",
     table: "tipo_mantenimiento",

--- a/src/app/dashboard/actividades/page.tsx
+++ b/src/app/dashboard/actividades/page.tsx
@@ -323,6 +323,7 @@ export default function ActividadesPage() {
   const actividadesOptions = dashboard?.actividades ?? actividades;
   const sociosOptions = dashboard?.socios ?? [];
   const empleadosOptions = dashboard?.empleados ?? [];
+  const ubicacionesOptions = dashboard?.ubicaciones ?? [];
 
   const selectedSocio = useMemo(
     () => sociosOptions.find((socio) => socio.id_socio === inscripcionForm.socio_id) ?? null,
@@ -818,7 +819,33 @@ export default function ActividadesPage() {
                       </div>
                       <div className="space-y-1.5">
                         <Label>Ubicación</Label>
-                        <Input value={turnoForm.ubicacion} onChange={(event) => setTurnoForm((prev) => ({ ...prev, ubicacion: event.target.value }))} placeholder="Sala 1 / Box / Spinning" />
+                        {ubicacionesOptions.length ? (
+                          <select
+                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            value={turnoForm.ubicacion}
+                            onChange={(event) =>
+                              setTurnoForm((prev) => ({ ...prev, ubicacion: event.target.value }))
+                            }
+                          >
+                            <option value="">Seleccionar ubicación</option>
+                            {ubicacionesOptions.map((ubicacion) => (
+                              <option key={ubicacion.id} value={ubicacion.nombre}>
+                                {ubicacion.nombre}
+                              </option>
+                            ))}
+                          </select>
+                        ) : (
+                          <Input
+                            value={turnoForm.ubicacion}
+                            onChange={(event) =>
+                              setTurnoForm((prev) => ({ ...prev, ubicacion: event.target.value }))
+                            }
+                            placeholder="Sala 1 / Box / Spinning"
+                          />
+                        )}
+                        <p className="text-xs text-muted-foreground">
+                          Las ubicaciones se administran desde Parametrización → Ubicaciones del gimnasio.
+                        </p>
                       </div>
                       <div className="space-y-1.5">
                         <Label>Vigencia desde</Label>

--- a/src/app/dashboard/parametrizacion/page.tsx
+++ b/src/app/dashboard/parametrizacion/page.tsx
@@ -152,6 +152,12 @@ const catalogUiDefinitions: Record<CatalogoParametrizableKey, CatalogUiDefinitio
     href: "/dashboard/equipamientos",
     tags: ["zonas", "sala", "depósito", "bar/snack"],
   },
+
+  ubicacion_gimnasio: {
+    icon: Database,
+    href: "/dashboard/actividades",
+    tags: ["sala principal", "funcional", "spinning", "cardio", "fuerza"],
+  },
   tipo_mantenimiento: {
     icon: Wrench,
     href: "/dashboard/equipamientos",

--- a/src/interfaces/actividadTurnosCupos.interface.ts
+++ b/src/interfaces/actividadTurnosCupos.interface.ts
@@ -29,6 +29,15 @@ export interface ActividadEmpleadoOption {
   activo?: boolean | null;
 }
 
+export interface ActividadUbicacionOption {
+  id: string;
+  codigo: string;
+  nombre: string;
+  descripcion?: string | null;
+  activo?: boolean | null;
+  orden?: number | null;
+}
+
 export interface ActividadTurno {
   id: string;
   actividad_id: string;
@@ -98,6 +107,7 @@ export interface ActividadTurnosCuposDashboard {
   actividades: ActividadBaseOption[];
   socios: ActividadSocioOption[];
   empleados: ActividadEmpleadoOption[];
+  ubicaciones: ActividadUbicacionOption[];
   turnos: ActividadTurno[];
   inscripciones: ActividadTurnoInscripcion[];
   kpis: ActividadTurnosCuposKpis;

--- a/src/interfaces/parametrizacion.interface.ts
+++ b/src/interfaces/parametrizacion.interface.ts
@@ -12,6 +12,7 @@ export type CatalogoParametrizableKey =
   | "categoria_producto"
   | "tipo_equipamiento"
   | "ubicacion_equipamiento"
+  | "ubicacion_gimnasio"
   | "tipo_mantenimiento";
 
 export type CatalogoParametrizableStatus = "Disponible" | "Planificado" | "Base existente";

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1350,7 +1350,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     tag: "Parametrización",
     summary: "Catálogos parametrizables",
     description:
-      "Consulta, crea y actualiza registros de catálogos parametrizables. GET lista tipos de empleado, medios de pago, gastos, ingresos, categorías de producto, tipos/ubicaciones de equipamiento y tipos de mantenimiento. POST crea nuevos registros con código, nombre, descripción, orden y campos específicos. PATCH edita, activa o desactiva registros sin hard delete.",
+      "Consulta, crea y actualiza registros de catálogos parametrizables. GET lista tipos de empleado, medios de pago, gastos, ingresos, categorías de producto, tipos/ubicaciones de equipamiento, ubicaciones globales del gimnasio y tipos de mantenimiento. POST crea nuevos registros con código, nombre, descripción, orden y campos específicos. PATCH edita, activa o desactiva registros sin hard delete.",
     auth: false,
     admin: false,
     notImplemented: false,
@@ -2204,6 +2204,17 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
                 es_online: true,
               },
             },
+            ubicacionGimnasio: {
+              summary: "Crear ubicación global del gimnasio",
+              value: {
+                catalogo: "ubicacion_gimnasio",
+                codigo: "sala_funcional",
+                nombre: "Sala funcional",
+                descripcion: "Zona destinada a clases funcionales y entrenamiento grupal.",
+                activo: true,
+                orden: 20,
+              },
+            },
             desactivar: {
               summary: "Desactivar registro sin hard delete",
               value: {
@@ -2678,6 +2689,7 @@ export const openApiSpec = {
               "categoria_producto",
               "tipo_equipamiento",
               "ubicacion_equipamiento",
+              "ubicacion_gimnasio",
               "tipo_mantenimiento",
             ],
           },


### PR DESCRIPTION
# PR — Gym Master — Catálogo global de ubicaciones del gimnasio

## Rama

`feature/catalogo-ubicaciones-gimnasio`

## Resumen

Este PR incorpora un catálogo global de ubicaciones, zonas y salas del gimnasio para que Gym Master deje de depender de texto libre en los turnos de actividades y avance hacia una parametrización ERP reutilizable.

La feature permite administrar ubicaciones desde Parametrización y utiliza ese catálogo en Actividades / Turnos, sentando la base para futuras integraciones con equipamiento, mantenimiento, asistencia/aforo y reportes BI.

## Alcance funcional

- Nuevo catálogo parametrizable: **Ubicaciones del gimnasio**.
- Administración desde `/dashboard/parametrizacion`.
- Alta, edición, activación/inactivación y orden de ubicaciones.
- Integración inicial con `/dashboard/actividades`.
- El campo `Ubicación` del formulario de turnos pasa a selector cuando el catálogo está disponible.
- Fallback a texto libre si el catálogo todavía no existe, evitando romper la pantalla antes de aplicar migración.
- Seed inicial con ubicaciones frecuentes del gimnasio:
  - Sala principal.
  - Sala funcional.
  - Sala spinning.
  - Zona cardio.
  - Zona fuerza.
  - Peso libre.
  - Box entrenamiento.
  - Sala wellness.
  - Recepción.
  - Depósito.
  - Bar / Snack.
  - Vestuarios.
- Importación inicial desde ubicaciones existentes de equipamiento y turnos.

## Alcance técnico

### Base de datos

Se agrega migración privada/no versionada en commit público:

- `202606130801_ubicaciones_gimnasio_catalogo.sql`

La migración crea:

- `public.ubicacion_gimnasio`

Incluye:

- PK UUID.
- Código único.
- Nombre único.
- Descripción.
- Estado activo/inactivo.
- Orden visual.
- Timestamps.
- Constraints.
- Índice operativo por activo/orden/nombre.
- RLS habilitado.
- Policies y grants.
- Seed base.
- Import desde `ubicacion_equipamiento`.
- Import desde `actividad_turno.ubicacion`.

### Parametrización

Se amplía:

- `src/interfaces/parametrizacion.interface.ts`
- `src/app/api/parametrizacion/catalogos/route.ts`
- `src/app/dashboard/parametrizacion/page.tsx`

Nuevo key:

`ubicacion_gimnasio`

### Actividades / turnos

Se amplía:

- `src/interfaces/actividadTurnosCupos.interface.ts`
- `src/app/api/actividades/turnos-cupos/route.ts`
- `src/app/dashboard/actividades/page.tsx`

El dashboard de turnos ahora recibe `ubicaciones` desde el catálogo y el formulario usa selector parametrizable.

### Swagger / documentación

Se actualiza:

- `src/lib/swagger/openApiSpec.ts`
- `docs/parametrizacion/catalogo-ubicaciones-gimnasio.md`

## Validaciones realizadas

- Patch aplicado correctamente.
- Migración privada validada con flujo QA/local.
- Catálogo visible en Parametrización.
- Selector de ubicación disponible en Actividades / Turnos.
- Creación/edición de turno con ubicación parametrizada validada.
- Build validado.
- Verificación de que no quedan SQL, scripts privados ni `supabase/config.toml` para commitear.

## Archivos modificados/agregados

- `src/interfaces/parametrizacion.interface.ts`
- `src/app/api/parametrizacion/catalogos/route.ts`
- `src/app/dashboard/parametrizacion/page.tsx`
- `src/interfaces/actividadTurnosCupos.interface.ts`
- `src/app/api/actividades/turnos-cupos/route.ts`
- `src/app/dashboard/actividades/page.tsx`
- `src/lib/swagger/openApiSpec.ts`
- `docs/parametrizacion/catalogo-ubicaciones-gimnasio.md`

## No incluido en el commit

No se deben commitear:

- `supabase/migrations/*.sql`
- `database/scripts/*.sql`
- `database/private/*.sql`
- `supabase/config.toml` si fue modificado localmente por puertos Supabase.
- Dumps/backups SQL.

## Impacto comercial / ERP

Esta feature refuerza la visión de Gym Master como ERP para gimnasios: la ubicación física deja de ser texto libre y pasa a convertirse en una entidad administrable, reutilizable y medible.

A futuro permitirá reportar y decidir por zona/sala:

- Qué espacios tienen más actividad.
- Qué salas tienen más ocupación.
- Qué zonas concentran mantenimiento.
- Qué sectores consumen más equipamiento.
- Cómo se distribuye el aforo.

## Próximos pasos sugeridos

- Integrar `ubicacion_gimnasio` con Equipamiento.
- Integrar `ubicacion_gimnasio` con Mantenimiento.
- Integrar `ubicacion_gimnasio` con Aforo/Asistencia.
- Crear BI por zona/sala.
- Evaluar relación FK futura sin romper compatibilidad con el campo legacy texto.

## Checklist de cierre

- [x] Feature implementada.
- [x] DB QA/local validada.
- [x] Pantalla de Parametrización actualizada.
- [x] Actividades / Turnos integrado con selector de ubicación.
- [x] Swagger/OpenAPI actualizado.
- [x] Documentación técnica agregada.
- [x] Sin SQL/config privados para commitear.
