### PR TITLE
chore: clean production UI copy

### DIFF
--- a/docs/qa/ui-production-copy-cleanup-roadmap.md
+++ b/docs/qa/ui-production-copy-cleanup-roadmap.md
@@ -1,0 +1,184 @@
+# UI production copy cleanup - Roadmap de recorrido QA
+
+**Rama sugerida:** `feature/ui-production-copy-cleanup`  
+**Tipo:** UX / copy / limpieza visual de produccion.  
+**Migracion DB:** No requiere.
+
+## Objetivo
+
+Eliminar o controlar textos tecnicos visibles para el cliente final y dejar Gym Master con una presentacion mas limpia para demo comercial, preventa y uso real por gimnasios.
+
+Esta limpieza no modifica reglas de negocio, tablas ni flujos operativos. Se concentra en copy visible, badges tecnicos y documentacion de recorrido.
+
+## Cambios incluidos
+
+### 1. Badges tecnicos QA
+
+Los badges de archivo/ruta dejan de mostrarse por defecto. Solo aparecen cuando se habilita explicitamente:
+
+```bash
+NEXT_PUBLIC_QA_FILE_BADGES=true
+```
+
+Se evita que un cliente vea textos como `QA:` o rutas internas de codigo durante una demo o uso real.
+
+### 2. Rutas no mapeadas
+
+El componente global de rutas QA ya no muestra texto tecnico de ruta no mapeada. Si una ruta no existe en el mapa interno, no renderiza badge.
+
+### 3. Metadata general
+
+Se actualiza la descripcion principal de la aplicacion para usar un mensaje mas comercial:
+
+```txt
+ERP inteligente para la gestion integral de gimnasios
+```
+
+### 4. BI demografico
+
+Se elimina wording interno `activos/demo` en sugerencias comerciales de BI demografico, reemplazandolo por `socios activos`.
+
+### 5. Swagger / documentacion API
+
+El endpoint interno `/api/test-alertas` queda marcado como interno y no se expone en Swagger por defecto. Solo se muestra cuando:
+
+```bash
+NEXT_PUBLIC_EXPOSE_INTERNAL_TEST_ENDPOINTS=true
+```
+
+### 6. Parametrizacion de catalogos
+
+Se retira del hero la leyenda tecnica:
+
+```txt
+Consulta y administracion base de catalogos reales para eliminar progresivamente valores hardcodeados en formularios, reportes y procesos administrativos.
+```
+
+La pantalla queda con titulo directo y menos texto tecnico para demo comercial.
+
+## Roadmap de recorrido manual
+
+Despues de aplicar la feature, recorrer estas pantallas y confirmar que no aparezcan badges QA, rutas internas ni textos tecnicos visibles.
+
+### Auth
+
+- `/auth/login`
+- `/auth/login/admin`
+- `/auth/login/socio`
+
+Validar:
+
+- No aparece badge fijo de archivo.
+- Textos de entrada son claros para usuario final.
+- No aparece `QA:`.
+
+### Dashboard general
+
+- `/dashboard`
+
+Validar:
+
+- No aparece badge fijo arriba a la derecha.
+- Header, cards y textos se ven comerciales.
+
+### Socios
+
+- `/dashboard/socios`
+- modales de crear/ver/editar socio
+
+Validar:
+
+- No aparecen rutas de archivo sobre modales.
+- Botones y mensajes son entendibles para el cliente.
+
+### Pagos
+
+- `/dashboard/pagos`
+- modal de registro de pago manual
+
+Validar:
+
+- No aparecen badges sobre el modal.
+- Descuentos/bonificaciones se explican con copy comercial.
+
+### Actividades
+
+- `/dashboard/actividades`
+
+Validar:
+
+- No aparece badge QA en el encabezado.
+- Formulario de turno queda limpio.
+- Ubicaciones, cupos y lista de espera se entienden sin contexto tecnico.
+
+### Ranking y bonificacion
+
+- `/dashboard/socios-ranking-bonificacion`
+
+Validar:
+
+- No aparece badge de archivo.
+- Ranking mensual, bonificacion y bloqueo por pago se muestran con lenguaje de negocio.
+
+### Equipamientos
+
+- `/dashboard/equipamientos`
+
+Validar:
+
+- No aparecen rutas internas en filtros, tablas o modales.
+- Reporte PDF mantiene lenguaje comercial.
+
+### Parametrizacion
+
+- `/dashboard/parametrizacion`
+- `/dashboard/gimnasio-parametrizacion`
+
+Validar:
+
+- El hero de catalogos no muestra la leyenda tecnica removida.
+- Textos son entendibles para configuracion del gimnasio.
+- Stripe test/sandbox solo aparece donde corresponde como configuracion tecnica consciente.
+
+### Ventas
+
+- `/dashboard/ventas`
+
+Validar en esta feature solamente:
+
+- No aparecen badges QA ni rutas internas.
+
+Observacion funcional registrada para proxima correccion: el modulo carga ventas, pero no trae el historial/listado. Debe tratarse como fix separado para no mezclar limpieza de copy con comportamiento de datos.
+
+### Swagger
+
+- `/swagger`
+
+Validar:
+
+- No aparece `/api/test-alertas` por defecto.
+- No aparece copy de prueba o testing interno en endpoints publicos.
+
+## Validacion tecnica sugerida
+
+```bash
+npm run build
+npm run test:e2e
+```
+
+## Busquedas de control sugeridas
+
+```bash
+grep -R "QA:" -n src || echo "OK: sin QA visible"
+grep -R "Ruta no mapeada" -n src || echo "OK: sin ruta no mapeada visible"
+grep -R "activos/demo" -n src || echo "OK: sin wording demo visible"
+grep -R "Consulta y administración base de catálogos reales" -n src || echo "OK: sin leyenda tecnica de parametrizacion"
+```
+
+## Resultado esperado
+
+- Aplicacion sin badges tecnicos por defecto.
+- Swagger sin endpoint interno de pruebas por defecto.
+- Parametrizacion sin leyenda tecnica en el hero.
+- Copy general mas comercial.
+- Roadmap manual disponible para recorrer pantallas limpias.

--- a/src/app/api/socios/demografia-promociones-bi/route.ts
+++ b/src/app/api/socios/demografia-promociones-bi/route.ts
@@ -219,7 +219,7 @@ function buildPromotions(params: {
   if (franjaDominante) {
     promociones.push({
       titulo: 'Oferta principal para la franja demográfica dominante',
-      descripcion: `${franjaDominante.franja} reúne ${franjaDominante.cantidad_socios} socios activos/demo.`,
+      descripcion: `${franjaDominante.franja} reúne ${franjaDominante.cantidad_socios} socios activos.`,
       segmento: franjaDominante.franja,
       accion_sugerida: 'Ajustar comunicación, horarios y beneficios comerciales a la franja con mayor presencia.',
       prioridad: 'media',

--- a/src/app/dashboard/parametrizacion/page.tsx
+++ b/src/app/dashboard/parametrizacion/page.tsx
@@ -451,9 +451,6 @@ export default function ParametrizacionPage() {
                           Configuración administrativa
                         </div>
                         <h1 className="mt-2 text-2xl font-bold">Parametrización de catálogos</h1>
-                        <p className="mt-2 max-w-3xl text-sm leading-relaxed text-slate-200">
-                          Consulta y administración base de catálogos reales para eliminar progresivamente valores hardcodeados en formularios, reportes y procesos administrativos.
-                        </p>
                       </div>
                       <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm backdrop-blur">
                         <p className="font-semibold">Última lectura</p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: 'Gym Master',
-  description: 'Sistema de administración de gimnasios',
+  description: 'ERP inteligente para la gestion integral de gimnasios',
 };
 
 export default function RootLayout({

--- a/src/components/qa/QaCurrentPageBadge.tsx
+++ b/src/components/qa/QaCurrentPageBadge.tsx
@@ -87,8 +87,11 @@ export function QaCurrentPageBadge() {
   const file =
     PAGE_FILES[normalizedPath] ??
     DYNAMIC_PAGE_FILES.find((entry) => entry.pattern.test(normalizedPath))
-      ?.file ??
-    `Ruta no mapeada: ${normalizedPath}`;
+      ?.file;
+
+  if (!file) {
+    return null;
+  }
 
   return <QaFileNameBadge file={file} position="fixed" />;
 }

--- a/src/components/qa/QaFileNameBadge.tsx
+++ b/src/components/qa/QaFileNameBadge.tsx
@@ -6,12 +6,16 @@ interface QaFileNameBadgeProps {
   position?: "inline" | "fixed";
 }
 
+function shouldShowQaBadges() {
+  return process.env.NEXT_PUBLIC_QA_FILE_BADGES === "true";
+}
+
 export function QaFileNameBadge({
   file,
   className = "",
   position = "inline",
 }: QaFileNameBadgeProps) {
-  if (process.env.NEXT_PUBLIC_QA_FILE_BADGES === "false") {
+  if (!shouldShowQaBadges()) {
     return null;
   }
 
@@ -21,7 +25,7 @@ export function QaFileNameBadge({
       title={file}
       data-qa-file-badge={file}
     >
-      QA: {file}
+      Archivo: {file}
     </span>
   );
 

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -10,6 +10,7 @@ type EndpointDefinition = {
   statuses: number[];
   queryParams: string[];
   source: string;
+  internal?: boolean;
 };
 
 type OpenApiOperation = Record<string, unknown>;
@@ -1656,15 +1657,16 @@ const endpointDefinitions: EndpointDefinition[] = [
     path: "/api/test-alertas",
     methods: ["POST"],
     tag: "Alertas",
-    summary: "Prueba de alertas de deuda",
+    summary: "Validacion interna de alertas de deuda",
     description:
-      "Endpoint técnico para probar alertas o desactivación de socios con deuda.",
+      "Endpoint interno para validar alertas o desactivacion de socios con deuda en ambientes controlados.",
     auth: false,
     admin: false,
     notImplemented: false,
     statuses: [200, 500],
     queryParams: [],
     source: "src/app/api/test-alertas/route.ts",
+    internal: true,
   },
   {
     path: "/api/usuarios/{id}/perfil",
@@ -2418,8 +2420,14 @@ function buildOperation(endpoint: EndpointDefinition, method: string) {
 
 function buildPaths() {
   const paths: Record<string, OpenApiPathItem> = {};
+  const exposeInternalEndpoints =
+    process.env.NEXT_PUBLIC_EXPOSE_INTERNAL_TEST_ENDPOINTS === "true";
 
   for (const endpoint of endpointDefinitions) {
+    if (endpoint.internal && !exposeInternalEndpoints) {
+      continue;
+    }
+
     const pathItem = paths[endpoint.path] ?? {};
 
     for (const method of endpoint.methods) {


### PR DESCRIPTION
# PR - Gym Master - UI Production Copy Cleanup

## Rama

`feature/ui-production-copy-cleanup`

## Tipo de cambio

- [x] UX / Copywriting de producto
- [x] Limpieza visual para producción/demo
- [x] Hardening de exposición técnica
- [x] Documentación QA de recorrido
- [ ] Migración DB
- [ ] Cambio funcional de negocio

## Objetivo

Limpiar textos técnicos visibles en la interfaz de Gym Master para dejar el producto más prolijo para demo comercial, preventa y uso real por gimnasios.

La feature se concentra en reducir exposición de detalles internos, badges QA y wording técnico que no debe aparecer frente a un cliente final.

## Alcance implementado

### 1. Badges técnicos QA

Se ajustó `src/components/qa/QaFileNameBadge.tsx` para que los badges de archivo/ruta no aparezcan por defecto.

Antes podían verse textos técnicos como:

```txt
QA: src/app/dashboard/...
```

Ahora solo se muestran si se habilita explícitamente:

```bash
NEXT_PUBLIC_QA_FILE_BADGES=true
```

Además, cuando se habilitan internamente, el prefijo visual pasa de `QA:` a `Archivo:`.

### 2. Rutas no mapeadas

Se ajustó `src/components/qa/QaCurrentPageBadge.tsx` para evitar que una ruta no mapeada muestre un texto técnico en pantalla.

Si la ruta no existe en el mapa interno, el componente no renderiza badge.

### 3. Metadata general de la app

Se actualizó la descripción general de la aplicación en `src/app/layout.tsx`:

```txt
ERP inteligente para la gestión integral de gimnasios
```

### 4. BI demográfico

Se limpió wording interno en `src/app/api/socios/demografia-promociones-bi/route.ts`.

Se reemplazó el texto:

```txt
socios activos/demo
```

por:

```txt
socios activos
```

### 5. Swagger / endpoint interno

Se marcó `/api/test-alertas` como endpoint interno dentro de `src/lib/swagger/openApiSpec.ts`.

Por defecto ya no aparece en Swagger. Solo se expone si se habilita:

```bash
NEXT_PUBLIC_EXPOSE_INTERNAL_TEST_ENDPOINTS=true
```

### 6. Parametrización de catálogos

Se retiró del hero de `/dashboard/parametrizacion` la leyenda técnica:

```txt
Consulta y administración base de catálogos reales para eliminar progresivamente valores hardcodeados en formularios, reportes y procesos administrativos.
```

La pantalla queda con una presentación más directa para demo comercial.

### 7. Roadmap de recorrido QA

Se agregó:

```txt
docs/qa/ui-production-copy-cleanup-roadmap.md
```

El documento deja un recorrido manual para revisar visualmente las pantallas limpiadas y confirmar que no aparezcan badges, rutas internas o copy técnico innecesario.

## Roadmap de revisión incluido

Pantallas sugeridas para recorrer:

- `/auth/login`
- `/auth/login/admin`
- `/auth/login/socio`
- `/dashboard`
- `/dashboard/socios`
- `/dashboard/pagos`
- `/dashboard/actividades`
- `/dashboard/socios-ranking-bonificacion`
- `/dashboard/equipamientos`
- `/dashboard/parametrizacion`
- `/dashboard/gimnasio-parametrizacion`
- `/dashboard/ventas`
- `/swagger`

## Hallazgos registrados durante el recorrido

Durante la revisión manual se detectaron oportunidades y fallas para próximas ramas:

### Innovación futura

```txt
feature/header-notifications-bell-center
```

Objetivo: campanita con contador rojo de notificaciones sin resolver, popup con resumen de notificaciones y navegación hacia el módulo correspondiente.

### Fix funcional futuro

```txt
fix/ventas-historial-listado
```

Problema: el módulo ventas carga la venta, pero no trae el historial/listado.

## Archivos modificados/agregados

```txt
src/components/qa/QaFileNameBadge.tsx
src/components/qa/QaCurrentPageBadge.tsx
src/app/layout.tsx
src/app/api/socios/demografia-promociones-bi/route.ts
src/lib/swagger/openApiSpec.ts
src/app/dashboard/parametrizacion/page.tsx
docs/qa/ui-production-copy-cleanup-roadmap.md
```

## Validación

Validación manual reportada:

```txt
Recorrido visual OK. La limpieza quedó correcta.
```

Comandos recomendados para control final:

```bash
npm run build
npm run test:e2e
```

Búsquedas sugeridas:

```bash
grep -R "QA:" -n src || echo "OK: sin QA visible"
grep -R "Ruta no mapeada" -n src || echo "OK: sin ruta no mapeada visible"
grep -R "activos/demo" -n src || echo "OK: sin wording demo visible"
grep -R "Consulta y administración base de catálogos reales" -n src || echo "OK: sin leyenda técnica de parametrización"
```

## Checklist

- [x] Badges QA ocultos por defecto.
- [x] Ruta no mapeada no se muestra al cliente.
- [x] Metadata general de la app pulida.
- [x] Wording `activos/demo` eliminado.
- [x] Endpoint interno `/api/test-alertas` oculto por defecto en Swagger.
- [x] Leyenda técnica de parametrización removida.
- [x] Roadmap manual de recorrido agregado.
- [x] Hallazgo de notificaciones registrado para feature futura.
- [x] Falla de ventas registrada para fix futuro.
- [x] Sin migración DB.
- [x] Sin SQL privado para commitear.

## Riesgo

Bajo. Los cambios son de presentación, exposición técnica y documentación. No se modifican reglas de negocio, tablas, pagos, asistencia, ventas ni permisos.

## Impacto esperado

- UI más limpia para demo comercial.
- Menor exposición de rutas internas y textos QA.
- Mejor presentación ante clientes.
- Roadmap claro para repetir el recorrido de validación.
- Nuevas oportunidades detectadas para próximas features.
