### PR TITLE
fix: load sales history details in batches

### DIFF
--- a/docs/comercial/fix-ventas-historial-listado.md
+++ b/docs/comercial/fix-ventas-historial-listado.md
@@ -1,0 +1,95 @@
+# Fix — Ventas: historial/listado y relación con stock
+
+## Rama
+
+`fix/ventas-historial-listado`
+
+## Problema detectado
+
+En el recorrido manual de producción se detectó que el módulo **Ventas** permitía registrar una venta, pero el historial/listado quedaba vacío y mostraba un error genérico tipo `Bad Request`.
+
+Al revisar el repositorio y el dump se confirmó que el dump contiene un historial grande de ventas y detalles:
+
+- `venta`: más de 1.300 registros.
+- `venta_detalle`: más de 1.600 registros.
+- `producto_stock_movimiento`: historial de movimientos asociado a ventas, ajustes, devoluciones y reversiones.
+
+El listado recuperaba todas las ventas y luego intentaba traer todos los detalles con un único filtro `.in('venta_id', ventaIds)`. En historiales grandes, PostgREST arma ese filtro en la URL; con cientos o miles de UUID puede producir un `400 Bad Request` por longitud/tamaño de consulta.
+
+## Solución aplicada
+
+Se ajustó `src/services/ventaService.ts` para que el detalle del historial de ventas se recupere por tandas.
+
+Cambios principales:
+
+- Se agregó `VENTA_DETALLE_BATCH_SIZE`.
+- Se agregó helper `chunkArray`.
+- `getDetallesByVentaIds` ahora consulta `venta_detalle` en grupos de UUIDs y luego agrupa el resultado en memoria por `venta_id`.
+- Se mejoró el mensaje técnico de error del listado de ventas.
+- Al crear una venta se guarda `registrado_por` con el usuario autenticado cuando está disponible.
+
+## Revisión de lógica de negocio
+
+La lógica central de ventas y stock se mantiene.
+
+### Alta de venta
+
+- Crea cabecera de venta.
+- Crea detalle de productos/servicios.
+- Si el ítem es producto, valida stock disponible.
+- Descuenta stock del producto.
+- Registra movimiento `producto_stock_movimiento` con tipo `venta`.
+- Actualiza total de la venta.
+
+### Error durante el alta
+
+Si falla alguna parte del alta:
+
+- Revierte stock de productos ya afectados.
+- Borra detalles creados.
+- Borra la cabecera de venta.
+
+### Anulación de venta
+
+- No elimina físicamente la venta.
+- Marca la venta como `estado = anulada` y `activo = false`.
+- Devuelve el stock de productos vendidos.
+- Registra movimiento `producto_stock_movimiento` con tipo `reversion_venta`.
+- Evita revertir dos veces la misma venta si el usuario reintenta la anulación.
+
+## Observación de negocio
+
+No se cambió la lógica de stock porque el circuito actual es correcto para:
+
+- venta de producto,
+- venta de servicio,
+- descuento de stock,
+- anulación,
+- reposición de stock,
+- trazabilidad de movimientos.
+
+Sí queda recomendado para una feature futura crear un flujo formal de **devoluciones/cambios parciales**, porque editar ítems de una venta ya registrada no debe hacerse como una simple edición de detalle: debe generar movimientos de stock auditables.
+
+## Validación sugerida
+
+1. Entrar a `/dashboard/ventas`.
+2. Confirmar que el historial carga ventas existentes.
+3. Verificar métricas superiores:
+   - Ventas activas.
+   - Total vendido.
+   - Ítems vendidos.
+   - Anuladas.
+4. Abrir una venta con `Ver` y confirmar que muestra detalles.
+5. Registrar una nueva venta de producto y confirmar que descuenta stock.
+6. Anular una venta de producto y confirmar que devuelve stock.
+7. Validar exportación Excel.
+8. Ejecutar:
+
+```bash
+npm run build
+npm run test:e2e
+```
+
+## Base de datos
+
+No requiere migración nueva.

--- a/src/services/ventaService.ts
+++ b/src/services/ventaService.ts
@@ -75,6 +75,22 @@ const normalizeClienteTipo = (clienteTipo?: string | null): VentaClienteTipo => 
   return 'consumidor_final';
 };
 
+/**
+ * PostgREST construye los filtros `.in()` dentro de la URL.
+ * En historiales grandes de ventas, enviar cientos o miles de UUID en una
+ * sola consulta puede terminar en 400 Bad Request por URL demasiado larga.
+ * Por eso el detalle se recupera en tandas chicas y luego se agrupa en memoria.
+ */
+const VENTA_DETALLE_BATCH_SIZE = 80;
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
 const normalizeVentaPayload = (payload: CreateVentaConDetalleDto) => {
   const detalles = payload.detalles ?? (payload.venta_detalle ? [payload.venta_detalle] : []);
   const clienteTipo = normalizeClienteTipo(payload.venta.cliente_tipo);
@@ -181,21 +197,30 @@ async function getDetallesByVentaIds(ventaIds: string[]) {
   if (!ventaIds.length) return new Map<string, VentaDetalle[]>();
 
   const supabase = conexionBD();
-  const { data, error } = await supabase
-    .from('venta_detalle')
-    .select(
+  const uniqueVentaIds = Array.from(new Set(ventaIds.filter(Boolean)));
+  const detalles: VentaDetalle[] = [];
+
+  for (const ventaIdBatch of chunkArray(uniqueVentaIds, VENTA_DETALLE_BATCH_SIZE)) {
+    const { data, error } = await supabase
+      .from('venta_detalle')
+      .select(
+        `
+        *,
+        producto:producto_id(id, nombre),
+        servicio:servicio_id(id, nombre)
       `
-      *,
-      producto:producto_id(id, nombre),
-      servicio:servicio_id(id, nombre)
-    `
-    )
-    .in('venta_id', ventaIds)
-    .order('creado_en', { ascending: true });
+      )
+      .in('venta_id', ventaIdBatch)
+      .order('creado_en', { ascending: true });
 
-  if (error) throw new Error(error.message);
+    if (error) {
+      throw new Error(`No se pudo cargar el detalle del historial de ventas: ${error.message}`);
+    }
 
-  return (data as VentaDetalle[]).reduce((map, detalle) => {
+    detalles.push(...((data ?? []) as VentaDetalle[]));
+  }
+
+  return detalles.reduce((map, detalle) => {
     const current = map.get(detalle.venta_id) ?? [];
     current.push(detalle);
     map.set(detalle.venta_id, current);
@@ -250,6 +275,7 @@ export const createVenta = async (
       estado: 'pagada',
       activo: true,
       comprobante_codigo: comprobanteCodigo,
+      registrado_por: user?.id ?? null,
     })
     .select(
       `


### PR DESCRIPTION
# PR — Fix ventas: historial/listado y relación con stock

## Rama

`fix/ventas-historial-listado`

## Tipo de cambio

- [x] Fix funcional
- [x] Mejora de robustez backend/frontend
- [x] Documentación técnica
- [ ] Migración DB

## Contexto

Durante el recorrido de limpieza visual de producción se detectó que el módulo **Ventas** permitía registrar una venta, pero el historial/listado no cargaba correctamente. La pantalla mostraba métricas en cero y un aviso tipo `Bad Request`, aunque en base de datos existían ventas, detalles y movimientos de stock.

Se revisó el repositorio y el dump actual para verificar si el problema era un olvido puntual o si requería modificar la lógica de negocio de ventas/stock.

## Diagnóstico

El dump contiene un historial grande de ventas y detalles:

- Tabla `venta`: historial amplio de ventas registradas.
- Tabla `venta_detalle`: detalles asociados a productos y servicios.
- Tabla `producto_stock_movimiento`: movimientos de stock por ventas, ajustes y reversiones.

El problema principal estaba en la lectura del historial:

1. El servicio obtenía todas las ventas.
2. Luego intentaba obtener todos los detalles con una sola consulta `.in('venta_id', ventaIds)`.
3. Con un historial grande, esa lista de UUIDs genera una URL demasiado extensa para PostgREST/Supabase.
4. El resultado podía ser `400 Bad Request`, dejando la pantalla sin historial.

## Solución implementada

Se ajustó `src/services/ventaService.ts` para cargar los detalles de ventas en tandas.

Cambios principales:

- Se agregó `VENTA_DETALLE_BATCH_SIZE`.
- Se agregó helper `chunkArray`.
- `getDetallesByVentaIds` ahora divide los `venta_id` en lotes y agrupa los detalles en memoria por venta.
- Se mejoró el mensaje de error cuando falla la carga de detalles del historial.
- Al registrar una venta, se guarda `registrado_por` con el usuario autenticado cuando está disponible.
- Se agregó documentación técnica en `docs/comercial/fix-ventas-historial-listado.md`.

## Revisión de lógica venta/stock

La lógica de negocio existente se mantiene porque es correcta para esta etapa:

### Alta de venta

- Crea cabecera de venta.
- Crea detalle de productos/servicios.
- Si el ítem es producto, valida stock disponible.
- Descuenta stock.
- Registra movimiento `producto_stock_movimiento` con tipo `venta`.
- Actualiza el total de la venta.

### Error durante el alta

- Revierte stock afectado.
- Borra detalles creados.
- Borra cabecera de venta.

### Anulación

- No elimina físicamente la venta.
- Marca la venta como `estado = anulada` y `activo = false`.
- Devuelve stock de productos vendidos.
- Registra movimiento `producto_stock_movimiento` con tipo `reversion_venta`.
- Evita revertir stock dos veces ante reintentos.

## Observación para roadmap futuro

No se recomienda editar ítems de una venta registrada como una simple edición, porque podría romper trazabilidad de stock. Para eso debería existir una feature específica:

`feature/ventas-devoluciones-cambios-parciales`

Ese flujo debería registrar devoluciones, cambios parciales y ajustes con movimientos de stock auditables.

## Archivos modificados

- `src/services/ventaService.ts`
- `docs/comercial/fix-ventas-historial-listado.md`

## Validación realizada

Validación funcional reportada por Gustavo:

- El módulo Ventas volvió a cargar correctamente.
- El historial/listado se visualiza.
- Se preservó la lógica de venta relacionada con stock.

Validación sugerida adicional:

```bash
npm run build
npm run test:e2e
```

## Base de datos

No requiere migración nueva.

## Checklist

- [x] Historial de ventas corregido.
- [x] Lógica de stock revisada.
- [x] No se introdujo migración DB.
- [x] Documentación técnica agregada.
- [x] Se dejó recomendación para futuras devoluciones/cambios parciales.
