### PR TITLE
feat: refine commercial pdf reports

### DIFF
--- a/docs/comercial/reportes-comerciales-pdf-refinement.md
+++ b/docs/comercial/reportes-comerciales-pdf-refinement.md
@@ -1,0 +1,96 @@
+# Reportes comerciales PDF - refinamiento visual
+
+## Rama
+
+`feature/reportes-comerciales-pdf-refinement`
+
+## Objetivo
+
+Refinar la presentación de los reportes PDF comerciales y operativos de Gym Master para que tengan una salida más profesional, consistente y legible durante demos, auditorías internas y entrega al cliente.
+
+## Alcance
+
+La mejora se concentra en el generador compartido `src/utils/commercialReportPdf.ts`, utilizado por reportes de pagos, ventas, compras, productos/stock, socios, cuotas, finanzas, actividades, ranking/bonificación, empleados, proveedores, servicios y otros listados comerciales.
+
+También se ajusta el PDF específico de equipamiento/mantenimiento, que usa un render propio por su estructura ejecutiva con métricas, gráficos, historial y recomendaciones.
+
+## Cambios principales
+
+- Pie de página unificado con numeración real `Página X de Y`.
+- Línea separadora de pie para mejorar lectura y presentación.
+- Corrección de ejes de gráficos: los reportes no monetarios ya no muestran valores con `$`.
+- Etiquetas de gráficos compactadas para reducir solapamientos en reportes con muchos datos.
+- Filtros aplicados en PDF con ajuste de líneas para evitar desbordes laterales.
+- Gráficos impares o únicos usando ancho completo del reporte.
+- Tablas con encabezado oscuro y texto blanco para contraste profesional.
+- PDF de equipamiento con pie de página y numeración total de páginas.
+
+## Reportes impactados por el generador compartido
+
+- Pagos
+- Ventas
+- Compras
+- Productos / stock
+- Socios
+- Cuotas
+- Finanzas / BI
+- Actividades / turnos / cupos
+- Ranking / bonificación mensual
+- Asistencias
+- Empleados
+- Sueldos
+- Proveedores
+- Servicios
+- Notificaciones
+- Otros gastos
+
+## Recorrido manual sugerido
+
+1. `/dashboard/pagos` → Descargar PDF.
+2. `/dashboard/ventas` → Exportar PDF si hay historial cargado.
+3. `/dashboard/compras` → Descargar PDF.
+4. `/dashboard/productos` → Descargar PDF.
+5. `/dashboard/finanzas` → Descargar PDF/BI.
+6. `/dashboard/actividades` → Descargar PDF.
+7. `/dashboard/socios-ranking-bonificacion` → Descargar PDF.
+8. `/dashboard/bi/socios-demografia` → Descargar PDF.
+9. `/dashboard/equipamientos` → Descargar PDF.
+
+## Validaciones esperadas
+
+- El PDF abre correctamente.
+- El encabezado muestra marca/gimnasio y título del reporte.
+- Los filtros no se salen del margen.
+- Los KPIs se ven claros.
+- Los gráficos no superponen etiquetas de forma crítica.
+- Los ejes no monetarios no muestran símbolo `$`.
+- Las tablas tienen encabezados legibles.
+- La numeración muestra `Página X de Y`.
+- No aparecen textos técnicos ni QA.
+
+## Notas técnicas
+
+No requiere migración de base de datos. Es una mejora de presentación y estandarización de salida PDF.
+
+## Ajuste posterior de recorrido
+
+Durante el recorrido visual se detectó que:
+
+- Ventas tenía exportación Excel pero no descarga PDF.
+- Ventas necesitaba filtro por rango de fechas para consultar períodos como ventas del mes.
+- Compras tenía descarga PDF, pero no filtro por rango de fechas.
+
+Se agregó:
+
+- Botón PDF en `/dashboard/ventas` usando el generador comercial compartido.
+- Filtro `Desde / Hasta` en `/dashboard/ventas`.
+- Filtro `Desde / Hasta` en `/dashboard/compras`.
+- Métricas superiores recalculadas sobre el resultado filtrado por estado, búsqueda y rango de fechas.
+- Exportación PDF/Excel basada en el listado filtrado visible.
+
+## Recorrido adicional
+
+1. `/dashboard/ventas`: filtrar desde/hasta, validar tarjetas y descargar PDF.
+2. `/dashboard/ventas`: limpiar fechas y validar que vuelve el historial completo.
+3. `/dashboard/compras`: filtrar desde/hasta, validar tarjetas y descargar PDF.
+4. `/dashboard/compras`: limpiar fechas y validar que vuelve el historial completo.

--- a/src/app/dashboard/compras/page.tsx
+++ b/src/app/dashboard/compras/page.tsx
@@ -38,6 +38,28 @@ function getItemsLabel(compra: Compra) {
   return detalles.map((detalle) => `${detalle.cantidad} x ${detalle.producto?.nombre ?? 'Producto'}`).join(' | ');
 }
 
+function isDateWithinRange(value: string | null | undefined, from: string, to: string) {
+  const normalized = String(value ?? '').slice(0, 10);
+  if (!normalized) return false;
+  if (from && normalized < from) return false;
+  if (to && normalized > to) return false;
+  return true;
+}
+
+function getDateRangeLabel(from: string, to: string) {
+  if (from && to) return `Período: ${formatFrontendDate(from)} a ${formatFrontendDate(to)}`;
+  if (from) return `Desde: ${formatFrontendDate(from)}`;
+  if (to) return `Hasta: ${formatFrontendDate(to)}`;
+  return 'Período: todos';
+}
+
+const COMPRA_FILTER_LABELS: Record<CompraFilter, string> = {
+  todas: 'Todas',
+  pendiente: 'Pendientes',
+  pagada: 'Pagadas',
+  anulada: 'Anuladas',
+};
+
 export default function ComprasPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
@@ -46,6 +68,8 @@ export default function ComprasPage() {
   const [proveedores, setProveedores] = useState<Proveedor[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [filter, setFilter] = useState<CompraFilter>('todas');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [openModal, setOpenModal] = useState(false);
@@ -87,6 +111,7 @@ export default function ComprasPage() {
     const search = searchTerm.toLowerCase().trim();
     return compras.filter((compra) => {
       if (filter !== 'todas' && compra.estado !== filter) return false;
+      if (!isDateWithinRange(compra.fecha, dateFrom, dateTo)) return false;
       if (!search) return true;
       return (
         (compra.proveedor?.nombre ?? '').toLowerCase().includes(search) ||
@@ -97,20 +122,20 @@ export default function ComprasPage() {
         getItemsLabel(compra).toLowerCase().includes(search)
       );
     });
-  }, [compras, filter, searchTerm]);
+  }, [compras, filter, dateFrom, dateTo, searchTerm]);
 
-  useEffect(() => setCurrentPage(1), [searchTerm, filter]);
+  useEffect(() => setCurrentPage(1), [searchTerm, filter, dateFrom, dateTo]);
 
   const metrics = useMemo(() => {
-    const activas = compras.filter((compra) => compra.estado !== 'anulada' && compra.activo !== false);
-    const anuladas = compras.filter((compra) => compra.estado === 'anulada' || compra.activo === false);
+    const activas = filteredCompras.filter((compra) => compra.estado !== 'anulada' && compra.activo !== false);
+    const anuladas = filteredCompras.filter((compra) => compra.estado === 'anulada' || compra.activo === false);
     return {
       activas: activas.length,
-      pendientes: compras.filter((compra) => compra.estado === 'pendiente').length,
+      pendientes: filteredCompras.filter((compra) => compra.estado === 'pendiente').length,
       anuladas: anuladas.length,
       totalComprado: activas.reduce((acc, compra) => acc + Number(compra.total ?? 0), 0),
     };
-  }, [compras]);
+  }, [filteredCompras]);
 
   const totalPages = Math.max(1, Math.ceil(filteredCompras.length / COMPRAS_PAGE_SIZE));
   const safeCurrentPage = Math.min(currentPage, totalPages);
@@ -169,7 +194,7 @@ export default function ComprasPage() {
           { label: 'Anuladas', value: metrics.anuladas },
           { label: 'Total comprado', value: formatCurrencyARS(metrics.totalComprado) },
         ],
-        filtersLabel: `Filtro: ${filter}${searchTerm.trim() ? ` · Búsqueda: ${searchTerm.trim()}` : ''}`,
+        filtersLabel: `Filtro: ${COMPRA_FILTER_LABELS[filter]} · ${getDateRangeLabel(dateFrom, dateTo)}${searchTerm.trim() ? ` · Búsqueda: ${searchTerm.trim()}` : ''}`,
         columns: [
           { header: 'Proveedor', width: 34, getValue: (compra) => compra.proveedor?.nombre ?? '-' },
           { header: 'Fecha', width: 18, getValue: (compra) => formatFrontendDate(compra.fecha) },
@@ -236,6 +261,27 @@ export default function ComprasPage() {
                   ].map(([value, label]) => (
                     <Button key={value} type="button" size="sm" variant={filter === value ? 'default' : 'outline'} onClick={() => setFilter(value as CompraFilter)}>{label}</Button>
                   ))}
+                </div>
+                <div className="grid gap-3 rounded-xl border bg-slate-50/60 p-3 md:grid-cols-[1fr_1fr_auto] md:items-end">
+                  <label className="space-y-1 text-sm font-medium">
+                    <span>Desde</span>
+                    <Input type="date" value={dateFrom} onChange={(event) => setDateFrom(event.target.value)} />
+                  </label>
+                  <label className="space-y-1 text-sm font-medium">
+                    <span>Hasta</span>
+                    <Input type="date" value={dateTo} onChange={(event) => setDateTo(event.target.value)} />
+                  </label>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setDateFrom('');
+                      setDateTo('');
+                    }}
+                    disabled={!dateFrom && !dateTo}
+                  >
+                    Limpiar fechas
+                  </Button>
                 </div>
                 <div className="overflow-x-auto">
                   <CompraTable

--- a/src/app/dashboard/equipamientos/page.tsx
+++ b/src/app/dashboard/equipamientos/page.tsx
@@ -320,9 +320,25 @@ export default function EquipamientosPage() {
     let y = margin;
 
     const addPageIfNeeded = (needed = 14) => {
-      if (y + needed > pageHeight - margin) {
+      if (y + needed > pageHeight - margin - 10) {
         doc.addPage();
         y = margin;
+      }
+    };
+
+    const addReportFooters = () => {
+      const totalPages = doc.getNumberOfPages();
+
+      for (let page = 1; page <= totalPages; page += 1) {
+        doc.setPage(page);
+        doc.setDrawColor(226, 232, 240);
+        doc.setLineWidth(0.2);
+        doc.line(margin, pageHeight - 10, pageWidth - margin, pageHeight - 10);
+        doc.setFont("helvetica", "normal");
+        doc.setFontSize(8);
+        doc.setTextColor(100, 116, 139);
+        doc.text("Gym Master · Equipamiento y mantenimiento", margin, pageHeight - 5);
+        doc.text(`Página ${page} de ${totalPages}`, pageWidth - margin, pageHeight - 5, { align: "right" });
       }
     };
 
@@ -432,14 +448,14 @@ export default function EquipamientosPage() {
 
         doc.setFont("helvetica", "bold");
         doc.setFontSize(8);
-        doc.setFillColor(226, 232, 240);
-        doc.setDrawColor(148, 163, 184);
-        doc.setTextColor(15, 23, 42);
+        doc.setFillColor(15, 23, 42);
+        doc.setDrawColor(30, 41, 59);
+        doc.setTextColor(255, 255, 255);
 
         headers.forEach((header, index) => {
-          doc.setFillColor(226, 232, 240);
-          doc.setDrawColor(148, 163, 184);
-          doc.setTextColor(15, 23, 42);
+          doc.setFillColor(15, 23, 42);
+          doc.setDrawColor(30, 41, 59);
+          doc.setTextColor(255, 255, 255);
           doc.rect(x, y, widths[index], rowHeight, "FD");
           doc.text(sanitizePdfText(header), x + 2, y + 4.8);
           x += widths[index];
@@ -558,6 +574,7 @@ export default function EquipamientosPage() {
       [48, 35, 20, 30, 103],
     );
 
+    addReportFooters();
     doc.save(buildTimestampedDownloadFileName("reporte-equipamiento-mantenimiento", "pdf"));
   };
 

--- a/src/app/dashboard/ventas/page.tsx
+++ b/src/app/dashboard/ventas/page.tsx
@@ -9,7 +9,7 @@ import { AppFooter } from '@/components/footer/AppFooter';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { FileSpreadsheet, Plus, Search, Store } from 'lucide-react';
+import { FileSpreadsheet, FileText, Plus, Search, Store } from 'lucide-react';
 import { deleteVenta, getAllVentas } from '@/services/ventaService';
 import VentaModal from '@/components/modal/VentaModal';
 import VentaViewModal from '@/components/modal/VentaViewModal';
@@ -22,6 +22,8 @@ import ExcelJS from 'exceljs';
 import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { formatCurrencyARS } from '@/lib/comercial/productos';
 import { PaginationControls } from '@/components/ui/PaginationControls';
+import { downloadCommercialReportPdf } from '@/utils/commercialReportPdf';
+import { formatFrontendDate } from '@/utils/dateFormat';
 
 const VENTAS_PAGE_SIZE = 10;
 
@@ -49,6 +51,29 @@ function getVentaItemsLabel(venta: Venta) {
     .join(' | ');
 }
 
+function isDateWithinRange(value: string | null | undefined, from: string, to: string) {
+  const normalized = String(value ?? '').slice(0, 10);
+  if (!normalized) return false;
+  if (from && normalized < from) return false;
+  if (to && normalized > to) return false;
+  return true;
+}
+
+function getDateRangeLabel(from: string, to: string) {
+  if (from && to) return `Período: ${formatFrontendDate(from)} a ${formatFrontendDate(to)}`;
+  if (from) return `Desde: ${formatFrontendDate(from)}`;
+  if (to) return `Hasta: ${formatFrontendDate(to)}`;
+  return 'Período: todos';
+}
+
+const VENTA_FILTER_LABELS: Record<VentaFilter, string> = {
+  todas: 'Todas',
+  socio: 'Socios',
+  consumidor_final: 'Consumidor final',
+  visitante: 'Visitantes',
+  anuladas: 'Anuladas',
+};
+
 export default function VentasPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
@@ -56,6 +81,8 @@ export default function VentasPage() {
   const [filteredVentas, setFilteredVentas] = useState<ResponseVenta[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [ventaFilter, setVentaFilter] = useState<VentaFilter>('todas');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [openModal, setOpenModal] = useState(false);
@@ -95,8 +122,8 @@ export default function VentasPage() {
   };
 
   const metrics = useMemo(() => {
-    const activas = ventas.filter((venta) => venta.activo !== false && venta.estado !== 'anulada');
-    const anuladas = ventas.filter((venta) => venta.activo === false || venta.estado === 'anulada');
+    const activas = filteredVentas.filter((venta) => venta.activo !== false && venta.estado !== 'anulada');
+    const anuladas = filteredVentas.filter((venta) => venta.activo === false || venta.estado === 'anulada');
     const totalVendido = activas.reduce((acc, venta) => acc + Number(venta.total ?? 0), 0);
     const itemsVendidos = activas.reduce(
       (acc, venta) =>
@@ -114,7 +141,7 @@ export default function VentasPage() {
       totalVendido,
       itemsVendidos,
     };
-  }, [ventas]);
+  }, [filteredVentas]);
 
   const handleExportExcel = async () => {
     const workbook = new ExcelJS.Workbook();
@@ -158,6 +185,36 @@ export default function VentasPage() {
     window.URL.revokeObjectURL(url);
   };
 
+
+  const handleDownloadPdf = async () => {
+    try {
+      await downloadCommercialReportPdf({
+        title: 'Listado de Ventas',
+        subtitle: 'Ventas de kiosco a socios, visitantes y consumidores finales.',
+        fileName: 'listado-ventas-kiosco',
+        rows: filteredVentas,
+        metrics: [
+          { label: 'Ventas activas', value: metrics.activas },
+          { label: 'Total vendido', value: formatCurrencyARS(metrics.totalVendido) },
+          { label: 'Ítems vendidos', value: metrics.itemsVendidos },
+          { label: 'Anuladas', value: metrics.anuladas },
+        ],
+        filtersLabel: `Filtro: ${VENTA_FILTER_LABELS[ventaFilter]} · ${getDateRangeLabel(dateFrom, dateTo)}${searchTerm.trim() ? ` · Búsqueda: ${searchTerm.trim()}` : ''}`,
+        columns: [
+          { header: 'Cliente', width: 34, getValue: (venta) => getVentaClienteLabel(venta) },
+          { header: 'Tipo', width: 20, getValue: (venta) => venta.cliente_tipo ?? 'consumidor_final' },
+          { header: 'Detalle', width: 72, getValue: (venta) => getVentaItemsLabel(venta) },
+          { header: 'Método', width: 20, getValue: (venta) => venta.metodo_pago ?? 'efectivo' },
+          { header: 'Total', width: 22, getValue: (venta) => formatCurrencyARS(venta.total), align: 'right' },
+          { header: 'Fecha', width: 18, getValue: (venta) => formatFrontendDate(venta.fecha) },
+          { header: 'Estado', width: 18, getValue: (venta) => venta.estado ?? (venta.activo === false ? 'anulada' : 'pagada') },
+        ],
+      });
+    } catch {
+      toast.error('No se pudo generar el PDF de ventas');
+    }
+  };
+
   useEffect(() => {
     if (isInitialized && isAuthenticated) {
       loadVentas();
@@ -176,6 +233,7 @@ export default function VentasPage() {
         if (estado === 'anulada') return false;
       }
       if (ventaFilter === 'todas' && estado === 'anulada') return false;
+      if (!isDateWithinRange(venta.fecha, dateFrom, dateTo)) return false;
 
       if (!lowercaseSearch) return true;
 
@@ -189,11 +247,11 @@ export default function VentasPage() {
     });
 
     setFilteredVentas(filtered);
-  }, [searchTerm, ventaFilter, ventas]);
+  }, [searchTerm, ventaFilter, dateFrom, dateTo, ventas]);
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [searchTerm, ventaFilter]);
+  }, [searchTerm, ventaFilter, dateFrom, dateTo]);
 
   const totalVentas = filteredVentas.length;
   const totalPages = Math.max(1, Math.ceil(totalVentas / VENTAS_PAGE_SIZE));
@@ -278,6 +336,14 @@ export default function VentasPage() {
                   </div>
                   <Button
                     variant='outline'
+                    onClick={handleDownloadPdf}
+                    className='flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd]'
+                  >
+                    <FileText className='h-4 w-4' />
+                    <span className='hidden sm:inline'>PDF</span>
+                  </Button>
+                  <Button
+                    variant='outline'
                     onClick={handleExportExcel}
                     className='flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd]'
                   >
@@ -313,6 +379,27 @@ export default function VentasPage() {
                       {label}
                     </Button>
                   ))}
+                </div>
+                <div className='grid gap-3 rounded-xl border bg-slate-50/60 p-3 md:grid-cols-[1fr_1fr_auto] md:items-end'>
+                  <label className='space-y-1 text-sm font-medium'>
+                    <span>Desde</span>
+                    <Input type='date' value={dateFrom} onChange={(event) => setDateFrom(event.target.value)} />
+                  </label>
+                  <label className='space-y-1 text-sm font-medium'>
+                    <span>Hasta</span>
+                    <Input type='date' value={dateTo} onChange={(event) => setDateTo(event.target.value)} />
+                  </label>
+                  <Button
+                    type='button'
+                    variant='outline'
+                    onClick={() => {
+                      setDateFrom('');
+                      setDateTo('');
+                    }}
+                    disabled={!dateFrom && !dateTo}
+                  >
+                    Limpiar fechas
+                  </Button>
                 </div>
                 <div className='overflow-x-auto'>
                   <VentaTable

--- a/src/utils/commercialReportPdf.ts
+++ b/src/utils/commercialReportPdf.ts
@@ -188,13 +188,23 @@ const addHeader = (
   doc.line(PAGE_MARGIN, HEADER_HEIGHT + 3, pageWidth - PAGE_MARGIN, HEADER_HEIGHT + 3);
 };
 
-const addFooter = (doc: jsPDF, pageWidth: number, pageHeight: number, footerText: string) => {
-  const pageNumber = doc.getNumberOfPages();
+const addFooter = (
+  doc: jsPDF,
+  pageWidth: number,
+  pageHeight: number,
+  footerText: string,
+  currentPage: number,
+  totalPages: number
+) => {
+  doc.setDrawColor(...BORDER);
+  doc.setLineWidth(0.2);
+  doc.line(PAGE_MARGIN, pageHeight - 10, pageWidth - PAGE_MARGIN, pageHeight - 10);
+
   doc.setFont("helvetica", "normal");
   doc.setFontSize(8);
   doc.setTextColor(...MUTED);
   doc.text(footerText, PAGE_MARGIN, pageHeight - 5);
-  doc.text(`Página ${pageNumber}`, pageWidth - PAGE_MARGIN, pageHeight - 5, {
+  doc.text(`Página ${currentPage} de ${totalPages}`, pageWidth - PAGE_MARGIN, pageHeight - 5, {
     align: "right",
   });
 };
@@ -251,6 +261,34 @@ const formatCompactMoney = (value: number): string => {
   return `$${Math.round(value)}`;
 };
 
+const formatCompactNumber = (value: number): string => {
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${Math.round(value / 1_000)}k`;
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+};
+
+const chartLooksMonetary = (chart: CommercialReportChart): boolean => {
+  const haystack = [
+    chart.title,
+    ...chart.series.flatMap((serie) => [serie.key, serie.label]),
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return /monto|costo|coste|total vendido|vendido|venta|ventas|recaud|ingreso|egreso|saldo|pago|importe|precio|ars|\$/.test(haystack);
+};
+
+const formatChartAxisValue = (chart: CommercialReportChart, value: number): string => {
+  return chartLooksMonetary(chart) ? formatCompactMoney(value) : formatCompactNumber(value);
+};
+
+const compactLabel = (value: unknown, maxChars: number): string => {
+  const text = normalizeText(value, "").trim();
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(1, maxChars - 1))}…`;
+};
+
 const setPdfColor = (doc: jsPDF, color: [number, number, number], mode: "draw" | "fill" | "text") => {
   if (mode === "draw") doc.setDrawColor(color[0], color[1], color[2]);
   if (mode === "fill") doc.setFillColor(color[0], color[1], color[2]);
@@ -298,7 +336,7 @@ const drawChartCard = (
     const gridY = plotY + (plotHeight / 3) * i;
     const gridValue = max - (adjustedRange / 3) * i;
     doc.line(plotX, gridY, plotX + plotWidth, gridY);
-    doc.text(formatCompactMoney(gridValue), x + 2, gridY + 1.5);
+    doc.text(formatChartAxisValue(chart, gridValue), x + 2, gridY + 1.5);
   }
 
   doc.setDrawColor(148, 163, 184);
@@ -334,9 +372,10 @@ const drawChartCard = (
         doc.rect(barX, barY, barWidth, barHeight, "F");
       });
 
+      const maxLabelChars = Math.max(4, Math.floor(groupWidth * 0.72));
       doc.setFontSize(6.2);
       doc.setTextColor(...MUTED);
-      doc.text(normalizeText(item[chart.labelKey], ""), plotX + itemIndex * groupWidth + groupWidth / 2, bottomY + 4, { align: "center" });
+      doc.text(compactLabel(item[chart.labelKey], maxLabelChars), plotX + itemIndex * groupWidth + groupWidth / 2, bottomY + 4, { align: "center" });
     });
   } else {
     chart.series.forEach((serie) => {
@@ -355,9 +394,10 @@ const drawChartCard = (
     });
 
     data.forEach((item, index) => {
+      const maxLabelChars = Math.max(4, Math.floor(plotWidth / Math.max(data.length, 1) * 0.72));
       doc.setFontSize(6.2);
       doc.setTextColor(...MUTED);
-      doc.text(normalizeText(item[chart.labelKey], ""), xForIndex(index), bottomY + 4, { align: "center" });
+      doc.text(compactLabel(item[chart.labelKey], maxLabelChars), xForIndex(index), bottomY + 4, { align: "center" });
     });
   }
 
@@ -492,12 +532,12 @@ export async function downloadCommercialReportPdf<T>({
     doc.setFont("helvetica", "normal");
     doc.setFontSize(8.5);
     doc.setTextColor(...MUTED);
-    doc.text(filtersLabel, PAGE_MARGIN, y);
-    y += 6;
+    const filterLines = doc.splitTextToSize(filtersLabel, pageWidth - PAGE_MARGIN * 2).slice(0, 3);
+    doc.text(filterLines, PAGE_MARGIN, y);
+    y += filterLines.length * 4 + 3;
   }
 
   y = drawCharts(doc, charts, pageWidth, pageHeight, y, () => {
-    addFooter(doc, pageWidth, pageHeight, resolvedFooterText);
     doc.addPage();
     addHeader(doc, pageWidth, logoDataUrl, title, subtitle, resolvedBrandName, resolvedBrandSubtitle);
     return HEADER_HEIGHT + 10;
@@ -531,7 +571,6 @@ export async function downloadCommercialReportPdf<T>({
     );
 
     if (y + rowHeight > pageHeight - FOOTER_HEIGHT - 6) {
-      addFooter(doc, pageWidth, pageHeight, resolvedFooterText);
       doc.addPage();
       addHeader(doc, pageWidth, logoDataUrl, title, subtitle, resolvedBrandName, resolvedBrandSubtitle);
       y = HEADER_HEIGHT + 10;
@@ -569,7 +608,7 @@ export async function downloadCommercialReportPdf<T>({
   const pages = doc.getNumberOfPages();
   for (let page = 1; page <= pages; page += 1) {
     doc.setPage(page);
-    addFooter(doc, pageWidth, pageHeight, resolvedFooterText);
+    addFooter(doc, pageWidth, pageHeight, resolvedFooterText, page, pages);
   }
 
   doc.save(fileName.toLowerCase().endsWith(".pdf") ? fileName : buildTimestampedDownloadFileName(fileName, "pdf"));


### PR DESCRIPTION
# PR: feature/reportes-comerciales-pdf-refinement

## Resumen

Esta PR refina la salida PDF comercial y operativa de Gym Master para mejorar la calidad visual de los reportes utilizados en demo, gestión interna y entrega al cliente.

La mejora se concentra en el generador compartido de reportes PDF y en ajustes específicos detectados durante el recorrido funcional: ventas no tenía descarga PDF y ventas/compras necesitaban filtro por rango de fechas para consultar períodos comerciales como ventas o compras del mes.

## Objetivos

- Estandarizar la presentación de reportes PDF comerciales.
- Mejorar la legibilidad de encabezados, tablas, filtros, gráficos y pies de página.
- Corregir la numeración de páginas para mostrar `Página X de Y`.
- Evitar ejes monetarios incorrectos en gráficos no monetarios.
- Agregar exportación PDF a Ventas.
- Agregar filtros `Desde / Hasta` en Ventas y Compras.
- Asegurar que PDF y Excel exporten el listado filtrado visible.

## Cambios principales

### Generador compartido de PDFs comerciales

Archivo: `src/utils/commercialReportPdf.ts`

- Pie de página unificado con línea separadora.
- Numeración real `Página X de Y`.
- Filtros con ajuste de línea para evitar desbordes.
- Gráficos únicos o impares usando ancho completo.
- Etiquetas compactas en gráficos para reducir solapamientos.
- Ejes no monetarios sin símbolo `$`.
- Encabezados de tabla oscuros con texto blanco para mejor contraste.

### Ventas

Archivo: `src/app/dashboard/ventas/page.tsx`

- Se agrega botón PDF.
- Se agrega filtro por rango de fechas `Desde / Hasta`.
- Se agrega acción `Limpiar fechas`.
- Las métricas superiores se recalculan sobre el resultado filtrado.
- PDF y Excel se generan usando el listado filtrado.

### Compras

Archivo: `src/app/dashboard/compras/page.tsx`

- Se agrega filtro por rango de fechas `Desde / Hasta`.
- Se agrega acción `Limpiar fechas`.
- Las métricas superiores se recalculan sobre el resultado filtrado.
- PDF y Excel se generan usando el listado filtrado.

### Equipamiento / mantenimiento

Archivo: `src/app/dashboard/equipamientos/page.tsx`

- Se agrega pie de página y numeración total al PDF específico de equipamiento/mantenimiento.
- Se refuerza contraste de encabezados de tabla.

### Documentación

Archivo: `docs/comercial/reportes-comerciales-pdf-refinement.md`

- Se documenta el alcance del refinamiento.
- Se agrega recorrido manual sugerido.
- Se documenta el ajuste posterior detectado en ventas/compras.

## Reportes impactados

El generador compartido impacta en reportes de:

- Pagos
- Ventas
- Compras
- Productos / stock
- Socios
- Cuotas
- Finanzas / BI
- Actividades / turnos / cupos
- Ranking / bonificación mensual
- Asistencias
- Empleados
- Sueldos
- Proveedores
- Servicios
- Notificaciones
- Otros gastos

## Validación funcional

Validación manual reportada como correcta por Gustavo:

- Ventas muestra historial y permite filtrar por rango de fechas.
- Ventas permite descargar PDF y Excel con el listado filtrado.
- Compras permite filtrar por rango de fechas.
- Compras permite descargar PDF y Excel con el listado filtrado.
- El resto del recorrido de reportes se visualizó correctamente.

## Base de datos

No requiere migración de base de datos.

No se incorporan archivos SQL, dumps, scripts privados ni cambios de configuración Supabase.

## Checklist

- [x] Generador PDF comercial refinado.
- [x] PDF de ventas agregado.
- [x] Filtro por fechas en ventas.
- [x] Filtro por fechas en compras.
- [x] Métricas recalculadas sobre filtros.
- [x] PDF/Excel basados en listado filtrado.
- [x] PDF de equipamiento con pie y numeración.
- [x] Documentación actualizada.
- [x] Sin migración DB.
