### PR TITLE
feat: add rag coach swagger admin testing

### DIFF
--- a/docs/rag/rag-coach-swagger-admin-testing.md
+++ b/docs/rag/rag-coach-swagger-admin-testing.md
@@ -1,0 +1,151 @@
+# Gym Master RAG Coach - Swagger/Admin Testing
+
+## Objetivo
+
+Esta feature deja el RAG Coach listo para ser probado de forma controlada desde Swagger/API administrativa antes de conectarlo al chat final de rutinas y dietas.
+
+## Estado detectado en el ZIP + dump 2026-06-14
+
+- La migración `202606141621_rag_coach_architecture_foundation` ya está aplicada en remoto.
+- Existen las tablas `rag_document` y `rag_document_chunk`.
+- Existe la RPC `match_rag_chunks`.
+- En el dump recibido, las tablas RAG están creadas pero todavía no tienen documentos/chunks cargados.
+- El catálogo base de ejercicios existe y debe ser la fuente real de ingesta inicial.
+- No se agregan migraciones nuevas en esta feature.
+
+## Endpoints documentados en Swagger
+
+### `GET /api/rag/coach/status`
+
+Devuelve estado no sensible del RAG:
+
+- provider configurado;
+- si RAG está activo;
+- modelo de embeddings;
+- conteos de documentos/chunks;
+- chunks activos;
+- chunks con embedding;
+- chunks pendientes de embedding;
+- advertencias operativas.
+
+### `POST /api/rag/coach/ingest/ejercicios`
+
+Ingesta ejercicios activos reales de Gym Master como documentos/chunks RAG.
+
+Body sugerido:
+
+```json
+{
+  "limit": 25,
+  "force": false,
+  "onlyMissing": true
+}
+```
+
+### `POST /api/rag/coach/vectorize/pending`
+
+Vectoriza chunks activos que todavía no tienen embedding, usando el provider configurado en backend.
+
+Body sugerido:
+
+```json
+{
+  "limit": 25,
+  "force": false
+}
+```
+
+Cuando `force=true`, vuelve a generar embeddings para chunks activos aunque ya tengan vector.
+
+### `POST /api/rag/coach/search`
+
+Busca conocimiento RAG usando `match_rag_chunks`.
+
+Body sugerido:
+
+```json
+{
+  "query": "rutina de piernas para socio principiante",
+  "domains": ["exercise"],
+  "sourceTables": ["ejercicio"],
+  "matchCount": 8,
+  "matchThreshold": 0.72
+}
+```
+
+## Flujo de prueba recomendado
+
+1. Configurar variables server-side en `.env.local` o Vercel:
+
+```env
+RAG_ENABLED=true
+EMBEDDING_PROVIDER=github
+GITHUB_TOKEN=...
+GITHUB_MODELS_BASE_URL=https://models.github.ai/inference
+GITHUB_MODELS_API_VERSION=2026-03-10
+GITHUB_EMBEDDING_MODEL=text-embedding-3-small
+GITHUB_EMBEDDING_MODEL_ID=openai/text-embedding-3-small
+RAG_VECTOR_DIMENSIONS=1536
+```
+
+2. Reiniciar `npm run dev`.
+3. Entrar a Swagger con usuario administrador.
+4. Ejecutar `GET /api/rag/coach/status`.
+5. Ejecutar `POST /api/rag/coach/ingest/ejercicios` con un límite chico, por ejemplo 5 o 10.
+6. Si quedan chunks pendientes, ejecutar `POST /api/rag/coach/vectorize/pending`.
+7. Ejecutar `POST /api/rag/coach/search` con consultas reales.
+8. Verificar que los resultados devuelvan ejercicios reales, scores y metadata útil.
+
+## Criterios de seguridad
+
+- No exponer `GITHUB_TOKEN`, `OPENAI_API_KEY` ni service role en frontend, Swagger examples o docs versionadas.
+- No ejecutar embeddings desde SQL Studio pegando tokens.
+- Usar siempre endpoints backend autenticados.
+- La ficha médica, evolución física personal e historial sensible del socio no se indexan como conocimiento global.
+
+## Validación esperada
+
+- `npm run build` pasa.
+- Swagger muestra los endpoints RAG.
+- El status RAG devuelve conteos y warnings claros.
+- La ingesta usa ejercicios reales.
+- La vectorización genera embeddings sin exponer tokens.
+- La búsqueda devuelve resultados desde `match_rag_chunks`.
+
+## Nota operativa por rate limit 429
+
+Durante pruebas con GitHub Models puede aparecer:
+
+```txt
+GitHub Models embeddings falló (429): Too many requests
+```
+
+No indica error del catálogo ni de la migración. Es límite de velocidad del proveedor.
+
+Recomendaciones:
+
+- No iniciar con `limit: 100` sin pausa.
+- Probar primero con `limit: 5` o `limit: 10`.
+- Usar `delayMs: 750` o `delayMs: 1000` entre embeddings.
+- Si una ingesta falla por 429, los documentos/chunks quedan preparados con `embedding=null` y pueden retomarse luego desde `POST /api/rag/coach/vectorize/pending`.
+
+Payload recomendado para ingesta gradual:
+
+```json
+{
+  "limit": 10,
+  "force": false,
+  "onlyMissing": true,
+  "delayMs": 1000
+}
+```
+
+Payload recomendado para vectorizar pendientes:
+
+```json
+{
+  "limit": 10,
+  "force": false,
+  "delayMs": 1000
+}
+```

--- a/src/app/api/rag/coach/vectorize/pending/route.ts
+++ b/src/app/api/rag/coach/vectorize/pending/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { vectorizePendingRagChunks } from '@/services/server/ragCoachIngestionService';
+
+export const dynamic = 'force-dynamic';
+
+function getAuthStatus(error: any) {
+  const message = error?.message ?? '';
+  if (message.includes('Token no proporcionado') || message.includes('Token inválido')) return 401;
+  if (message.includes('No autorizado')) return 403;
+  return 500;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authMiddleware(request);
+    const payload = await request.json().catch(() => ({}));
+    const result = await vectorizePendingRagChunks(user, payload);
+    return NextResponse.json(result, { status: result.ok ? 200 : 207 });
+  } catch (error: any) {
+    const status = getAuthStatus(error);
+    if (status === 500) console.error('Error al vectorizar chunks RAG pendientes:', error);
+    return NextResponse.json(
+      { ok: false, error: error?.message ?? 'Error al vectorizar chunks RAG pendientes.' },
+      { status },
+    );
+  }
+}

--- a/src/interfaces/ragCoach.interface.ts
+++ b/src/interfaces/ragCoach.interface.ts
@@ -39,6 +39,8 @@ export interface RagHealthResponse {
     chunks: number;
     exerciseDocuments: number;
     activeChunks: number;
+    embeddedChunks?: number;
+    pendingEmbeddingChunks?: number;
   };
   warnings: string[];
 }
@@ -61,6 +63,7 @@ export interface RagIngestExercisesRequest {
   limit?: number;
   force?: boolean;
   onlyMissing?: boolean;
+  delayMs?: number;
 }
 
 export interface RagIngestExercisesResponse {
@@ -69,6 +72,23 @@ export interface RagIngestExercisesResponse {
   indexed: number;
   skipped: number;
   failed: number;
+  errors: string[];
+}
+
+export interface RagVectorizePendingRequest {
+  limit?: number;
+  force?: boolean;
+  delayMs?: number;
+}
+
+export interface RagVectorizePendingResponse {
+  ok: boolean;
+  processed: number;
+  vectorized: number;
+  skipped: number;
+  failed: number;
+  provider?: RagEmbeddingProvider;
+  model?: string;
   errors: string[];
 }
 

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1767,6 +1767,62 @@ const endpointDefinitions: EndpointDefinition[] = [
     source: "src/app/api/swagger-json/route.ts",
   },
   {
+    path: "/api/rag/coach/status",
+    methods: ["GET"],
+    tag: "RAG Coach",
+    summary: "Estado técnico del RAG Coach",
+    description:
+      "Devuelve configuración no sensible, advertencias operativas y conteos de documentos/chunks para validar la base RAG desde Swagger o herramientas administrativas.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/status/route.ts",
+  },
+  {
+    path: "/api/rag/coach/ingest/ejercicios",
+    methods: ["POST"],
+    tag: "RAG Coach",
+    summary: "Ingestar ejercicios reales al RAG",
+    description:
+      "Indexa ejercicios activos de Gym Master como documentos/chunks RAG usando datos reales del catálogo. Requiere rol administrador y proveedor de embeddings configurado cuando genera vectores.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 207, 400, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/ingest/ejercicios/route.ts",
+  },
+  {
+    path: "/api/rag/coach/vectorize/pending",
+    methods: ["POST"],
+    tag: "RAG Coach",
+    summary: "Vectorizar chunks RAG pendientes",
+    description:
+      "Genera embeddings para chunks RAG activos que todavía no tienen vector, usando el provider configurado en backend. Permite validar la vectorización sin exponer tokens en SQL Studio ni frontend.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 207, 400, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/vectorize/pending/route.ts",
+  },
+  {
+    path: "/api/rag/coach/search",
+    methods: ["POST"],
+    tag: "RAG Coach",
+    summary: "Buscar conocimiento RAG",
+    description:
+      "Ejecuta una búsqueda semántica contra rag_document_chunk mediante match_rag_chunks. Sirve para validar recuperación RAG desde Swagger antes de conectar el chat final de rutinas/dietas.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 400, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/search/route.ts",
+  },
+  {
     path: "/api/rutinas/rag-assistant/generar",
     methods: ["POST"],
     tag: "Rutinas",
@@ -1905,6 +1961,12 @@ const tags = [
     name: "Rutinas",
     description: "Generación, historial y eliminación de rutinas.",
   },
+  {
+    name: "RAG Coach",
+    description:
+      "Herramientas administrativas para validar ingesta, vectorización y búsqueda semántica del Gym Master RAG Coach.",
+  },
+
   {
     name: "Dietas",
     description: "Generación y consulta de dietas.",
@@ -2190,6 +2252,71 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
                 type: "string",
                 description: "Token QR recibido desde el lector o cámara.",
                 example: "qr_2026_05_23_abcd",
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  if (endpoint.path === "/api/rag/coach/ingest/ejercicios") {
+    return {
+      required: false,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagIngestExercisesRequest" },
+          examples: {
+            previewLimitado: {
+              summary: "Ingesta limitada de ejercicios",
+              value: { limit: 10, force: false, onlyMissing: true, delayMs: 750 },
+            },
+            reindexar: {
+              summary: "Reindexar ejercicios aunque ya existan",
+              value: { limit: 25, force: true, delayMs: 1000 },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  if (endpoint.path === "/api/rag/coach/vectorize/pending") {
+    return {
+      required: false,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagVectorizePendingRequest" },
+          examples: {
+            pendientes: {
+              summary: "Vectorizar chunks pendientes",
+              value: { limit: 25, force: false, delayMs: 750 },
+            },
+            revectorizar: {
+              summary: "Forzar vectorización de chunks activos",
+              value: { limit: 10, force: true, delayMs: 1000 },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  if (endpoint.path === "/api/rag/coach/search") {
+    return {
+      required: true,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagSearchRequest" },
+          examples: {
+            piernasPrincipiante: {
+              summary: "Buscar ejercicios para piernas principiante",
+              value: {
+                query: "rutina de piernas para socio principiante",
+                domains: ["exercise"],
+                sourceTables: ["ejercicio"],
+                matchCount: 8,
+                matchThreshold: 0.72,
               },
             },
           },
@@ -2690,6 +2817,109 @@ export const openApiSpec = {
             type: "string",
             format: "password",
             example: "NuevaClave2026!",
+          },
+        },
+      },
+      RagIngestExercisesRequest: {
+        type: "object",
+        properties: {
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            example: 25,
+            description: "Cantidad máxima de ejercicios a procesar en la corrida.",
+          },
+          force: {
+            type: "boolean",
+            example: false,
+            description: "Cuando vale true, reindexa aunque el hash del contenido no haya cambiado.",
+          },
+          onlyMissing: {
+            type: "boolean",
+            example: true,
+            description: "Reservado para flujos de ingesta incremental.",
+          },
+          delayMs: {
+            type: "integer",
+            minimum: 0,
+            maximum: 5000,
+            example: 750,
+            description: "Pausa en milisegundos entre embeddings para reducir errores 429 del proveedor.",
+          },
+        },
+      },
+      RagVectorizePendingRequest: {
+        type: "object",
+        properties: {
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            example: 25,
+            description: "Cantidad máxima de chunks a vectorizar.",
+          },
+          force: {
+            type: "boolean",
+            example: false,
+            description:
+              "Cuando vale true, vuelve a generar embeddings para chunks activos aunque ya tengan vector.",
+          },
+          delayMs: {
+            type: "integer",
+            minimum: 0,
+            maximum: 5000,
+            example: 750,
+            description: "Pausa en milisegundos entre embeddings para reducir errores 429 del proveedor.",
+          },
+        },
+      },
+      RagSearchRequest: {
+        type: "object",
+        required: ["query"],
+        properties: {
+          query: {
+            type: "string",
+            minLength: 3,
+            example: "rutina para piernas nivel principiante",
+          },
+          domains: {
+            type: "array",
+            items: {
+              type: "string",
+              enum: [
+                "exercise",
+                "routine_rule",
+                "diet_rule",
+                "safety",
+                "evolution",
+                "business",
+                "general",
+              ],
+            },
+            example: ["exercise"],
+          },
+          sourceTables: {
+            type: "array",
+            items: { type: "string" },
+            example: ["ejercicio"],
+          },
+          metadata: {
+            type: "object",
+            additionalProperties: true,
+            example: { media_quality: "completo" },
+          },
+          matchThreshold: {
+            type: "number",
+            minimum: 0,
+            maximum: 1,
+            example: 0.72,
+          },
+          matchCount: {
+            type: "integer",
+            minimum: 1,
+            maximum: 30,
+            example: 8,
           },
         },
       },

--- a/src/services/server/ragCoachIngestionService.ts
+++ b/src/services/server/ragCoachIngestionService.ts
@@ -1,11 +1,17 @@
 import { createHash } from 'node:crypto';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
-import { RagIngestExercisesRequest, RagIngestExercisesResponse } from '@/interfaces/ragCoach.interface';
+import {
+  RagIngestExercisesRequest,
+  RagIngestExercisesResponse,
+  RagVectorizePendingRequest,
+  RagVectorizePendingResponse,
+} from '@/interfaces/ragCoach.interface';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 import { createSingleRagEmbedding } from './ragEmbeddingProviderService';
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
+const MAX_DELAY_MS = 5000;
 
 type ExerciseRow = Record<string, any>;
 
@@ -33,6 +39,15 @@ function hashContent(content: string) {
 function safeLimit(value?: number) {
   if (!Number.isInteger(value) || !value || value <= 0) return DEFAULT_LIMIT;
   return Math.min(value, MAX_LIMIT);
+}
+
+function safeDelayMs(value?: number) {
+  if (!Number.isInteger(value) || !value || value <= 0) return 0;
+  return Math.min(value, MAX_DELAY_MS);
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function hasCloudinary(row: ExerciseRow) {
@@ -176,6 +191,7 @@ async function upsertExerciseDocument(row: ExerciseRow, force: boolean) {
   const { content, metadata } = buildExerciseContent(row);
   const contentHash = hashContent(content);
   const sourceId = String(row.id_ejercicio);
+  const tokenCount = Math.ceil(content.length / 4);
 
   const { data: existing, error: existingError } = await supabase
     .from('rag_document')
@@ -217,25 +233,41 @@ async function upsertExerciseDocument(row: ExerciseRow, force: boolean) {
     throw new Error(documentError.message);
   }
 
+  const { data: chunk, error: chunkUpsertError } = await supabase
+    .from('rag_document_chunk')
+    .upsert(
+      {
+        document_id: document.id,
+        chunk_index: 0,
+        content,
+        token_count: tokenCount,
+        embedding: null,
+        metadata,
+        active: true,
+        actualizado_en: new Date().toISOString(),
+      },
+      { onConflict: 'document_id,chunk_index' },
+    )
+    .select('id')
+    .single();
+
+  if (chunkUpsertError) {
+    throw new Error(chunkUpsertError.message);
+  }
+
   const embedding = await createSingleRagEmbedding(content);
-  const tokenCount = Math.ceil(content.length / 4);
 
-  const { error: chunkError } = await supabase.from('rag_document_chunk').upsert(
-    {
-      document_id: document.id,
-      chunk_index: 0,
-      content,
-      token_count: tokenCount,
+  const { error: chunkVectorError } = await supabase
+    .from('rag_document_chunk')
+    .update({
       embedding: embedding.embedding,
-      metadata,
-      active: true,
+      token_count: tokenCount,
       actualizado_en: new Date().toISOString(),
-    },
-    { onConflict: 'document_id,chunk_index' },
-  );
+    })
+    .eq('id', chunk.id);
 
-  if (chunkError) {
-    throw new Error(chunkError.message);
+  if (chunkVectorError) {
+    throw new Error(chunkVectorError.message);
   }
 
   return { indexed: true, skipped: false };
@@ -248,6 +280,7 @@ export async function ingestExercisesForRag(
   assertAdmin(user);
 
   const limit = safeLimit(payload.limit);
+  const delayMs = safeDelayMs(payload.delayMs);
   const exercises = await fetchExercises(limit);
   const response: RagIngestExercisesResponse = {
     ok: true,
@@ -258,7 +291,8 @@ export async function ingestExercisesForRag(
     errors: [],
   };
 
-  for (const exercise of exercises) {
+  for (let index = 0; index < exercises.length; index += 1) {
+    const exercise = exercises[index];
     try {
       const result = await upsertExerciseDocument(exercise, Boolean(payload.force));
       if (result.indexed) response.indexed += 1;
@@ -266,6 +300,87 @@ export async function ingestExercisesForRag(
     } catch (error: any) {
       response.failed += 1;
       response.errors.push(`${exercise.nombre_ejercicio}: ${error?.message ?? 'error desconocido'}`);
+    }
+
+    if (delayMs > 0 && index < exercises.length - 1) {
+      await sleep(delayMs);
+    }
+  }
+
+  response.ok = response.failed === 0;
+  return response;
+}
+
+export async function vectorizePendingRagChunks(
+  user: JwtUser,
+  payload: RagVectorizePendingRequest = {},
+): Promise<RagVectorizePendingResponse> {
+  assertAdmin(user);
+
+  const limit = safeLimit(payload.limit);
+  const delayMs = safeDelayMs(payload.delayMs);
+  const supabase = getSupabaseServerClient();
+
+  let query = supabase
+    .from('rag_document_chunk')
+    .select('id, content, token_count, active, document_id')
+    .eq('active', true)
+    .order('creado_en', { ascending: true })
+    .limit(limit);
+
+  if (!payload.force) {
+    query = query.is('embedding', null);
+  }
+
+  const { data: chunks, error } = await query;
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const response: RagVectorizePendingResponse = {
+    ok: true,
+    processed: chunks?.length ?? 0,
+    vectorized: 0,
+    skipped: 0,
+    failed: 0,
+    errors: [],
+  };
+
+  const chunksToVectorize = chunks ?? [];
+  for (let index = 0; index < chunksToVectorize.length; index += 1) {
+    const chunk = chunksToVectorize[index];
+    try {
+      const content = String(chunk.content ?? '').replace(/\s+/g, ' ').trim();
+      if (content.length < 3) {
+        response.skipped += 1;
+        continue;
+      }
+
+      const embedding = await createSingleRagEmbedding(content);
+      response.provider = embedding.provider;
+      response.model = embedding.model;
+
+      const { error: updateError } = await supabase
+        .from('rag_document_chunk')
+        .update({
+          embedding: embedding.embedding,
+          token_count: chunk.token_count ?? Math.ceil(content.length / 4),
+          actualizado_en: new Date().toISOString(),
+        })
+        .eq('id', chunk.id);
+
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+
+      response.vectorized += 1;
+    } catch (error: any) {
+      response.failed += 1;
+      response.errors.push(`${chunk.id}: ${error?.message ?? 'error desconocido'}`);
+    }
+
+    if (delayMs > 0 && index < chunksToVectorize.length - 1) {
+      await sleep(delayMs);
     }
   }
 

--- a/src/services/server/ragCoachSearchService.ts
+++ b/src/services/server/ragCoachSearchService.ts
@@ -105,12 +105,19 @@ export async function getRagHealth(user: JwtUser): Promise<RagHealthResponse> {
   if (status.provider === 'openai' && !status.openaiConfigured) warnings.push('Falta OPENAI_API_KEY.');
 
   try {
-    const [documents, chunks, exerciseDocuments, activeChunks] = await Promise.all([
-      safeCount('rag_document'),
-      safeCount('rag_document_chunk'),
-      safeCount('rag_document', (query) => query.eq('domain', 'exercise')),
-      safeCount('rag_document_chunk', (query) => query.eq('active', true)),
-    ]);
+    const [documents, chunks, exerciseDocuments, activeChunks, embeddedChunks, pendingEmbeddingChunks] =
+      await Promise.all([
+        safeCount('rag_document'),
+        safeCount('rag_document_chunk'),
+        safeCount('rag_document', (query) => query.eq('domain', 'exercise')),
+        safeCount('rag_document_chunk', (query) => query.eq('active', true)),
+        safeCount('rag_document_chunk', (query) => query.eq('active', true).not('embedding', 'is', null)),
+        safeCount('rag_document_chunk', (query) => query.eq('active', true).is('embedding', null)),
+      ]);
+
+    if (pendingEmbeddingChunks > 0) {
+      warnings.push(`Hay ${pendingEmbeddingChunks} chunks RAG activos sin embedding.`);
+    }
 
     return {
       ok: true,
@@ -120,6 +127,8 @@ export async function getRagHealth(user: JwtUser): Promise<RagHealthResponse> {
         chunks,
         exerciseDocuments,
         activeChunks,
+        embeddedChunks,
+        pendingEmbeddingChunks,
       },
       warnings,
     };


### PR DESCRIPTION
# PR - Gym Master - RAG Coach Swagger/Admin Testing

## Rama

`feature/rag-coach-swagger-admin-testing`

## Resumen

Esta feature deja el **Gym Master RAG Coach** probado y documentado desde Swagger/Admin antes de avanzar al chat funcional de rutinas. El objetivo fue validar la base técnica creada en `feature/rag-coach-architecture-foundation`: estado del RAG, ingesta de ejercicios reales, vectorización, búsqueda semántica y manejo operativo de límites del proveedor de embeddings.

## Contexto

La migración previa `202606141621_rag_coach_architecture_foundation` ya se encontraba aplicada correctamente en local/remoto. El dump actualizado confirmó la existencia de:

- `public.rag_document`
- `public.rag_document_chunk`
- RPC `public.match_rag_chunks`
- extensión `pgvector`
- políticas RLS y grants básicos para consulta autenticada

El dump también mostró que las tablas RAG estaban creadas, pero inicialmente sin documentos/chunks cargados.

## Alcance incluido

### 1. Swagger RAG Coach

Se documentaron formalmente los endpoints administrativos RAG:

- `GET /api/rag/coach/status`
- `POST /api/rag/coach/ingest/ejercicios`
- `POST /api/rag/coach/vectorize/pending`
- `POST /api/rag/coach/search`

Se agregó el tag `RAG Coach` dentro de Swagger/OpenAPI y ejemplos de payload para pruebas controladas.

### 2. Estado RAG mejorado

El endpoint de estado ahora informa conteos más útiles para QA:

- documentos totales
- chunks totales
- documentos de ejercicios
- chunks activos
- chunks con embedding
- chunks pendientes de embedding
- warnings operativos

### 3. Vectorización pendiente

Se agregó el endpoint:

`POST /api/rag/coach/vectorize/pending`

Este endpoint permite retomar chunks activos con `embedding=null`, evitando exponer tokens en SQL Studio o frontend.

### 4. Resiliencia ante rate limit 429

Durante las pruebas se detectó límite de GitHub Models:

`GitHub Models embeddings falló (429): Too many requests`

Se ajustó el flujo para:

- crear primero `rag_document`;
- crear/actualizar `rag_document_chunk` con `embedding=null`;
- intentar luego generar el embedding;
- si GitHub responde 429, dejar el chunk pendiente;
- retomar luego desde `/api/rag/coach/vectorize/pending`.

También se agregó `delayMs` para espaciar requests de embeddings en ingesta y vectorización.

### 5. Documentación técnica

Se agregó:

`docs/rag/rag-coach-swagger-admin-testing.md`

Incluye recorrido completo de prueba, variables necesarias, advertencias de seguridad y recomendaciones ante rate limit 429.

## Archivos modificados/agregados

- `src/interfaces/ragCoach.interface.ts`
- `src/services/server/ragCoachIngestionService.ts`
- `src/services/server/ragCoachSearchService.ts`
- `src/app/api/rag/coach/vectorize/pending/route.ts`
- `src/lib/swagger/openApiSpec.ts`
- `docs/rag/rag-coach-swagger-admin-testing.md`

## Base de datos

No se agregan migraciones nuevas en esta feature.

Se usa la base ya creada por:

`202606141621_rag_coach_architecture_foundation`

## Seguridad

- No se agregan secretos al repositorio.
- `GITHUB_TOKEN` y `OPENAI_API_KEY` siguen siendo variables server-side.
- `.env.example` mantiene placeholders sin tokens reales.
- La generación de embeddings se realiza desde backend autenticado.
- No se indexan datos privados sensibles del socio como ficha médica, evolución personal o historial clínico dentro del conocimiento global.

## Validaciones realizadas

### Build

- `npm run build` validado por Gustavo.

### Swagger/Admin

Recorrido probado correctamente:

1. `POST /api/custom-login` usando `rol: "admin"`.
2. Autorización Swagger mediante Bearer token.
3. `GET /api/rag/coach/status`.
4. `POST /api/rag/coach/ingest/ejercicios`.
5. Detección de rate limit 429 de GitHub Models.
6. Aplicación de resiliencia con chunks pendientes y `delayMs`.
7. `POST /api/rag/coach/vectorize/pending`.
8. `POST /api/rag/coach/search`.
9. Validación de funcionamiento general del flujo RAG.

## Resultado

La feature cumple su objetivo: el RAG Coach queda probado desde Swagger/Admin, con endpoints documentados, control de estado, ingesta real, vectorización pendiente y manejo operativo del rate limit 429.

## Próxima feature recomendada

`feature/rag-coach-chat-rutinas-v1`

Objetivo: conectar el RAG ya probado con el flujo real de generación de rutinas para que use ejercicios reales, objetivo, nivel, días disponibles, restricciones e historial del socio.

## Checklist

- [x] Endpoints RAG documentados en Swagger.
- [x] Estado RAG mejorado.
- [x] Endpoint de vectorización pendiente agregado.
- [x] Manejo de rate limit 429 incorporado.
- [x] Documentación técnica agregada.
- [x] Sin migraciones nuevas.
- [x] Sin secretos versionados.
- [x] Build validado.
- [x] Pruebas Swagger/Admin validadas.
