### PR TITLE
feat: connect rag coach with routine assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ RAG_MATCH_THRESHOLD=0.72
 RAG_MATCH_COUNT=8
 RAG_CONTEXT_MAX_CHARS=12000
 RAG_DEBUG=false
+# Ajustes específicos del asistente de rutinas con RAG interno.
+# Para pruebas con corpus chico usar threshold bajo, por ejemplo 0.0 a 0.3.
+RAG_ROUTINE_MATCH_THRESHOLD=0.3
+RAG_ROUTINE_MATCH_COUNT=8
 
 EMBEDDING_PROVIDER=github
 GITHUB_TOKEN=

--- a/docs/rag/rag-coach-chat-rutinas-v1.md
+++ b/docs/rag/rag-coach-chat-rutinas-v1.md
@@ -1,0 +1,105 @@
+# Gym Master — RAG Coach Chat Rutinas v1
+
+## Objetivo
+
+Conectar el RAG Coach ya validado desde Swagger/Admin con el asistente real de generación de rutinas de Gym Master.
+
+Esta versión no reemplaza el generador formal existente. Lo complementa con recuperación semántica de ejercicios reales indexados en `rag_document` y `rag_document_chunk`, manteniendo fallback seguro si el RAG no está configurado, no devuelve resultados o falla el proveedor de embeddings.
+
+## Alcance funcional
+
+- El endpoint `POST /api/rutinas/rag-assistant/generar` consulta el RAG interno antes de generar la rutina.
+- La consulta semántica usa el objetivo, nivel, días disponibles, mensaje del socio y restricciones.
+- La recuperación se limita al dominio `exercise` y tabla fuente `ejercicio`.
+- La rutina final se sigue creando con el generador formal de Gym Master (`dataGeneracionRutina`).
+- La respuesta indica si se usó RAG interno, puente externo o fallback local.
+- El frontend muestra referencias RAG aplicadas, títulos de ejercicios reales y score de similitud.
+- Se mantienen advertencias técnicas visibles si el RAG está desactivado, incompleto o falla.
+
+## Endpoints impactados
+
+### `POST /api/rutinas/rag-assistant/generar`
+
+Payload recomendado:
+
+```json
+{
+  "objetivo": 1,
+  "nivel": 1,
+  "dias": 3,
+  "idioma": "es",
+  "mensajeSocio": "Quiero ganar masa muscular, entrenar 3 días por semana y priorizar piernas. Soy principiante.",
+  "restricciones": "Cuidar rodilla derecha, evitar impacto alto."
+}
+```
+
+Para prueba técnica con rol admin puede indicarse `id_socio`:
+
+```json
+{
+  "objetivo": 1,
+  "nivel": 1,
+  "dias": 3,
+  "idioma": "es",
+  "mensajeSocio": "Rutina de fuerza inicial de 3 días con ejercicios seguros.",
+  "restricciones": "Sin saltos ni impacto alto.",
+  "id_socio": "2d2a45df-0fd5-4f4e-9c01-5de07dca1111"
+}
+```
+
+## Modos de respuesta
+
+| Modo | Significado |
+| --- | --- |
+| `internal_rag` | Se recuperaron referencias reales desde el RAG interno. |
+| `external_rag_bridge` | Existe microservicio externo configurado y respondió. |
+| `local_fallback` | No hubo RAG usable y se usó el generador formal seguro. |
+
+## Variables de entorno
+
+Variables base ya existentes:
+
+```env
+RAG_ENABLED=true
+EMBEDDING_PROVIDER=github
+GITHUB_TOKEN=token_real_solo_local_o_vercel
+GITHUB_EMBEDDING_MODEL=text-embedding-3-small
+GITHUB_EMBEDDING_MODEL_ID=openai/text-embedding-3-small
+RAG_VECTOR_RPC=match_rag_chunks
+```
+
+Variables específicas para rutinas:
+
+```env
+RAG_ROUTINE_MATCH_THRESHOLD=0.3
+RAG_ROUTINE_MATCH_COUNT=8
+```
+
+Para corpus chico de QA puede usarse temporalmente:
+
+```env
+RAG_ROUTINE_MATCH_THRESHOLD=0.0
+```
+
+## Validación recomendada
+
+1. Confirmar que existen documentos/chunks RAG vectorizados:
+   - `GET /api/rag/coach/status`
+2. Generar rutina desde Swagger o frontend:
+   - `POST /api/rutinas/rag-assistant/generar`
+3. Verificar que la respuesta incluya:
+   - `data.modo = "internal_rag"` cuando haya resultados.
+   - `data.ragContext.used = true`.
+   - `data.ragContext.results.length > 0`.
+   - títulos de ejercicios reales.
+   - `similarity` numérico.
+4. Verificar que la rutina quede creada y visible en `/dashboard/rutinas`.
+5. Validar que si el RAG no responde, la generación no se rompe y usa `local_fallback`.
+
+## Consideraciones
+
+- Esta feature no carga todo el corpus de ejercicios.
+- La carga completa debe manejarse en tandas chicas por límite 429 de GitHub Models.
+- Esta feature no implementa dietas ni evolución física.
+- Esta feature no genera PDFs.
+- El resultado final sigue pasando por el generador formal de Gym Master para no romper el modelo actual de rutinas.

--- a/src/app/api/rutinas/rag-assistant/generar/route.ts
+++ b/src/app/api/rutinas/rag-assistant/generar/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { authMiddleware } from '@/middlewares/auth.middleware';
 import { dataGeneracionRutina } from '@/services/rutinaService';
-import {
+import { buildRutinasRagContext } from '@/services/server/ragRutinasCoachService';
+import type {
   RagRutinasAssistantRequest,
+  RagRutinasContextSummary,
   RagRutinasIdioma,
 } from '@/interfaces/ragRutinasAssistant.interface';
 
@@ -158,6 +160,24 @@ export async function POST(req: Request) {
       },
     };
 
+    let internalRagContext: RagRutinasContextSummary | undefined;
+    let internalRagError: string | undefined;
+
+    try {
+      internalRagContext = await buildRutinasRagContext(user, {
+        objetivo: baseObjetivo,
+        nivel: baseNivel,
+        dias: baseDias,
+        idioma,
+        mensajeSocio,
+        restricciones,
+        id_socio: body.id_socio,
+      });
+    } catch (error) {
+      internalRagError = error instanceof Error ? error.message : 'Error desconocido al consultar RAG interno';
+      console.warn('RAG interno de rutinas no disponible. Se usa fallback local:', internalRagError);
+    }
+
     let ragRespuesta: RagCoachResponse | undefined;
     let ragError: string | undefined;
     const ragConfigurado = Boolean(getRagCoachEndpoint());
@@ -183,17 +203,32 @@ export async function POST(req: Request) {
       id_socio: body.id_socio,
     });
 
+    const ragContextUsed = Boolean(internalRagContext?.used);
+    const modo: 'external_rag_bridge' | 'internal_rag' | 'local_fallback' = ragRespuesta ? 'external_rag_bridge' : ragContextUsed ? 'internal_rag' : 'local_fallback';
+    const warnings = [
+      ...(Array.isArray(ragRespuesta?.advertencias) ? ragRespuesta.advertencias : []),
+      ...(internalRagContext?.warnings ?? []),
+      ...(internalRagError ? [internalRagError] : []),
+    ];
+
     const mensajeFinal =
       ragRespuesta?.mensajeFinal ||
-      'Tu rutina se generó en base a los datos indicados. Dirigite al menú Rutinas y allí la encontrarás.';
+      (ragContextUsed
+        ? 'Tu rutina se generó usando el generador formal de Gym Master y referencias reales recuperadas por el RAG Coach.'
+        : 'Tu rutina se generó en base a los datos indicados. Dirigite al menú Rutinas y allí la encontrarás.');
+
+    const resumen =
+      ragRespuesta?.resumen ||
+      internalRagContext?.summary ||
+      'Se utilizó el generador formal de Gym Master con los parámetros seleccionados por el socio.';
 
     return NextResponse.json(
       {
         ok: true,
         message: 'Rutina generada correctamente desde el asistente.',
         data: {
-          modo: ragRespuesta ? 'rag_bridge' : 'local_fallback',
-          ragConfigurado,
+          modo,
+          ragConfigurado: ragConfigurado || Boolean(internalRagContext?.enabled),
           rutinaGenerada,
           parametros: {
             objetivo: objetivoFinal,
@@ -202,12 +237,9 @@ export async function POST(req: Request) {
             idioma: idiomaFinal,
           },
           mensajeFinal,
-          resumen:
-            ragRespuesta?.resumen ||
-            'Se utilizó el generador formal de Gym Master con los parámetros seleccionados por el socio.',
-          advertencias: Array.isArray(ragRespuesta?.advertencias)
-            ? ragRespuesta.advertencias
-            : [],
+          resumen,
+          advertencias: warnings,
+          ragContext: internalRagContext,
           ragRespuesta,
           ragError,
         },

--- a/src/app/dashboard/rutinas/asistente/page.tsx
+++ b/src/app/dashboard/rutinas/asistente/page.tsx
@@ -32,9 +32,9 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
-import { Nivel } from '@/interfaces/niveles.interface';
-import { Objetivo } from '@/interfaces/objetivo.interface';
-import { RagRutinasAssistantResponseData } from '@/interfaces/ragRutinasAssistant.interface';
+import type { Nivel } from '@/interfaces/niveles.interface';
+import type { Objetivo } from '@/interfaces/objetivo.interface';
+import type { RagRutinasAssistantResponseData } from '@/interfaces/ragRutinasAssistant.interface';
 import { getNiveles, getObjetivos } from '@/services/apiClient';
 import { generarRutinaConAsistente } from '@/services/ragRutinasAssistantService';
 import { useAuthStore } from '@/stores/authStore';
@@ -820,6 +820,35 @@ export default function RutinasAssistantPage() {
                         <div className='rounded-xl bg-background/80 p-3 text-muted-foreground'>
                           <p>{result.resumen}</p>
                         </div>
+
+                        {result.ragContext?.used && result.ragContext.results.length > 0 && (
+                          <div className='rounded-xl bg-background/80 p-3 text-muted-foreground'>
+                            <p className='font-semibold text-foreground'>Conocimiento RAG aplicado</p>
+                            <p className='mt-1'>
+                              Se recuperaron {result.ragContext.results.length} referencias de ejercicios reales para orientar la rutina.
+                            </p>
+                            <ul className='mt-2 list-disc space-y-1 pl-5'>
+                              {result.ragContext.results.slice(0, 5).map((source) => (
+                                <li key={source.chunkId}>
+                                  <span className='font-medium text-foreground'>{source.title}</span>
+                                  <span> · score {source.similarity.toFixed(2)}</span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {result.advertencias.length > 0 && (
+                          <div className='rounded-xl border border-amber-200 bg-amber-50 p-3 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100'>
+                            <p className='font-semibold'>Advertencias técnicas</p>
+                            <ul className='mt-2 list-disc space-y-1 pl-5'>
+                              {result.advertencias.map((warning) => (
+                                <li key={warning}>{warning}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
                         <Button asChild>
                           <Link href='/dashboard/rutinas'>Ir al menú Rutinas</Link>
                         </Button>

--- a/src/interfaces/ragRutinasAssistant.interface.ts
+++ b/src/interfaces/ragRutinasAssistant.interface.ts
@@ -17,14 +17,41 @@ export interface RagRutinasParametrosFinales {
   idioma: RagRutinasIdioma;
 }
 
+export interface RagRutinasContextResult {
+  chunkId: string;
+  documentId: string;
+  title: string;
+  sourceId: string;
+  sourceTable: string;
+  domain: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  documentMetadata: Record<string, unknown>;
+  similarity: number;
+}
+
+export interface RagRutinasContextSummary {
+  enabled: boolean;
+  used: boolean;
+  query: string;
+  provider?: string;
+  model?: string;
+  matchThreshold?: number;
+  matchCount?: number;
+  results: RagRutinasContextResult[];
+  summary: string;
+  warnings: string[];
+}
+
 export interface RagRutinasAssistantResponseData {
-  modo: 'rag_bridge' | 'local_fallback';
+  modo: 'external_rag_bridge' | 'internal_rag' | 'local_fallback';
   ragConfigurado: boolean;
   rutinaGenerada: unknown;
   parametros: RagRutinasParametrosFinales;
   mensajeFinal: string;
   resumen: string;
   advertencias: string[];
+  ragContext?: RagRutinasContextSummary;
   ragRespuesta?: unknown;
   ragError?: string;
 }

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1828,7 +1828,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     tag: "Rutinas",
     summary: "Generar rutina desde asistente RAG",
     description:
-      "Endpoint puente para el futuro gym-master-rag-coach. Si el microservicio RAG está configurado, consulta el servicio externo para sugerir parámetros; si no, usa fallback local con el generador formal de Gym Master. No expone claves en frontend.",
+      "Genera una rutina desde el asistente conversacional. Primero consulta el RAG interno de Gym Master para recuperar ejercicios reales indexados; si existe microservicio externo configurado, lo usa como puente; si no hay resultados RAG, mantiene fallback seguro con el generador formal. No expone claves en frontend.",
     auth: true,
     admin: false,
     notImplemented: false,
@@ -2187,7 +2187,7 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
               value: {
                 email: "admin@gymmaster.local",
                 password: "********",
-                userType: "admin",
+                rol: "admin",
               },
             },
           },
@@ -2317,6 +2317,42 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
                 sourceTables: ["ejercicio"],
                 matchCount: 8,
                 matchThreshold: 0.72,
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  if (endpoint.path === "/api/rutinas/rag-assistant/generar") {
+    return {
+      required: true,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagRutinasAssistantRequest" },
+          examples: {
+            socioRutina: {
+              summary: "Generar rutina con RAG interno",
+              value: {
+                objetivo: 1,
+                nivel: 1,
+                dias: 3,
+                idioma: "es",
+                mensajeSocio: "Quiero ganar masa muscular, entrenar 3 días por semana y priorizar piernas. Soy principiante.",
+                restricciones: "Cuidar rodilla derecha, evitar impacto alto.",
+              },
+            },
+            adminConSocio: {
+              summary: "Prueba técnica admin indicando socio",
+              value: {
+                objetivo: 1,
+                nivel: 1,
+                dias: 3,
+                idioma: "es",
+                mensajeSocio: "Rutina de fuerza inicial de 3 días con ejercicios seguros.",
+                restricciones: "Sin saltos ni impacto alto.",
+                id_socio: "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
               },
             },
           },
@@ -2781,10 +2817,11 @@ export const openApiSpec = {
             format: "password",
             example: "********",
           },
-          userType: {
+          rol: {
             type: "string",
             enum: ["admin", "usuario", "socio"],
             example: "admin",
+            description: "Rol esperado por /api/custom-login. No usar userType.",
           },
         },
       },
@@ -2920,6 +2957,52 @@ export const openApiSpec = {
             minimum: 1,
             maximum: 30,
             example: 8,
+          },
+        },
+      },
+      RagRutinasAssistantRequest: {
+        type: "object",
+        required: ["objetivo", "nivel", "dias"],
+        properties: {
+          objetivo: {
+            type: "integer",
+            minimum: 1,
+            example: 1,
+            description: "ID del objetivo de entrenamiento seleccionado.",
+          },
+          nivel: {
+            type: "integer",
+            minimum: 1,
+            example: 1,
+            description: "ID del nivel del socio.",
+          },
+          dias: {
+            type: "integer",
+            minimum: 1,
+            maximum: 6,
+            example: 3,
+            description: "Cantidad de días por semana disponibles para entrenar.",
+          },
+          idioma: {
+            type: "string",
+            enum: ["es", "en"],
+            example: "es",
+          },
+          mensajeSocio: {
+            type: "string",
+            maxLength: 1200,
+            example: "Quiero ganar masa muscular, entrenar 3 días por semana y priorizar piernas. Soy principiante.",
+          },
+          restricciones: {
+            type: "string",
+            maxLength: 1200,
+            example: "Cuidar rodilla derecha, evitar impacto alto.",
+          },
+          id_socio: {
+            type: "string",
+            format: "uuid",
+            nullable: true,
+            description: "Solo para pruebas/admin. El socio logueado se resuelve automáticamente.",
           },
         },
       },

--- a/src/services/server/ragRutinasCoachService.ts
+++ b/src/services/server/ragRutinasCoachService.ts
@@ -1,0 +1,208 @@
+import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import type {
+  RagRutinasAssistantRequest,
+  RagRutinasContextResult,
+  RagRutinasContextSummary,
+} from '@/interfaces/ragRutinasAssistant.interface';
+import { getRagConfig } from '@/lib/rag/ragConfig';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+import { createSingleRagEmbedding } from './ragEmbeddingProviderService';
+
+const DEFAULT_ROUTINE_MATCH_THRESHOLD = 0.3;
+const DEFAULT_ROUTINE_MATCH_COUNT = 8;
+const MAX_QUERY_LENGTH = 1600;
+
+function cleanText(value: unknown, maxLength = MAX_QUERY_LENGTH) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function readNumber(name: string, fallback: number, min: number, max: number) {
+  const value = Number(process.env[name]);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(value, min), max);
+}
+
+function toPositiveInteger(value: unknown) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeMetadata(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function mapRpcResult(row: Record<string, unknown>): RagRutinasContextResult {
+  return {
+    chunkId: String(row.chunk_id),
+    documentId: String(row.document_id),
+    title: String(row.title ?? 'Ejercicio RAG'),
+    sourceId: String(row.source_id ?? ''),
+    sourceTable: String(row.source_table ?? ''),
+    domain: String(row.domain ?? ''),
+    content: cleanText(row.content, 700),
+    metadata: normalizeMetadata(row.metadata),
+    documentMetadata: normalizeMetadata(row.document_metadata),
+    similarity: Number(row.similarity ?? 0),
+  };
+}
+
+async function getCatalogLabel(table: 'objetivo' | 'nivel', id: number | null) {
+  if (!id) return null;
+
+  const supabase = getSupabaseServerClient();
+
+  if (table === 'objetivo') {
+    const { data, error } = await supabase
+      .from('objetivo')
+      .select('nombre_objetivo')
+      .eq('id_objetivo', id)
+      .maybeSingle();
+
+    if (error) {
+      console.warn('No se pudo resolver etiqueta objetivo para RAG rutinas:', error.message);
+      return null;
+    }
+
+    return typeof data?.nombre_objetivo === 'string' ? data.nombre_objetivo : null;
+  }
+
+  const { data, error } = await supabase
+    .from('nivel')
+    .select('nombre_nivel')
+    .eq('id_nivel', id)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('No se pudo resolver etiqueta nivel para RAG rutinas:', error.message);
+    return null;
+  }
+
+  return typeof data?.nombre_nivel === 'string' ? data.nombre_nivel : null;
+}
+
+function buildQuery(params: {
+  payload: RagRutinasAssistantRequest;
+  objetivoNombre?: string | null;
+  nivelNombre?: string | null;
+}) {
+  const objetivo = params.objetivoNombre ? `Objetivo: ${params.objetivoNombre}.` : '';
+  const nivel = params.nivelNombre ? `Nivel: ${params.nivelNombre}.` : '';
+  const dias = params.payload.dias ? `Disponibilidad: ${params.payload.dias} días por semana.` : '';
+  const mensaje = cleanText(params.payload.mensajeSocio);
+  const restricciones = cleanText(params.payload.restricciones);
+
+  return [
+    'Armar rutina de gimnasio usando ejercicios reales del catálogo Gym Master.',
+    objetivo,
+    nivel,
+    dias,
+    mensaje ? `Pedido del socio: ${mensaje}.` : '',
+    restricciones ? `Restricciones o cuidados: ${restricciones}.` : '',
+    'Priorizar ejercicios compatibles con el objetivo, nivel y restricciones indicadas.',
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .slice(0, MAX_QUERY_LENGTH);
+}
+
+function buildSummary(results: RagRutinasContextResult[]) {
+  if (results.length === 0) {
+    return 'No se recuperaron ejercicios desde el RAG. Se usó el generador formal de Gym Master con fallback seguro.';
+  }
+
+  const titles = results
+    .slice(0, 5)
+    .map((result) => result.title)
+    .filter(Boolean)
+    .join(', ');
+
+  return `El RAG Coach recuperó ${results.length} referencias de ejercicios reales para orientar la rutina. Principales coincidencias: ${titles}.`;
+}
+
+export async function buildRutinasRagContext(
+  _user: JwtUser,
+  payload: RagRutinasAssistantRequest,
+): Promise<RagRutinasContextSummary> {
+  const warnings: string[] = [];
+  const config = getRagConfig();
+
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      used: false,
+      query: '',
+      results: [],
+      summary: 'RAG desactivado. Se usa generación local segura.',
+      warnings: ['RAG_ENABLED=false.'],
+    };
+  }
+
+  if (config.provider === 'github' && !config.githubToken) warnings.push('Falta GITHUB_TOKEN.');
+  if (config.provider === 'openai' && !config.openaiApiKey) warnings.push('Falta OPENAI_API_KEY.');
+
+  if (warnings.length > 0) {
+    return {
+      enabled: true,
+      used: false,
+      query: '',
+      results: [],
+      summary: 'RAG configurado parcialmente. Se usa generación local segura.',
+      warnings,
+    };
+  }
+
+  const objetivoId = toPositiveInteger(payload.objetivo);
+  const nivelId = toPositiveInteger(payload.nivel);
+  const [objetivoNombre, nivelNombre] = await Promise.all([
+    getCatalogLabel('objetivo', objetivoId),
+    getCatalogLabel('nivel', nivelId),
+  ]);
+
+  const query = buildQuery({ payload, objetivoNombre, nivelNombre });
+  const embedding = await createSingleRagEmbedding(query);
+  const supabase = getSupabaseServerClient();
+  const matchThreshold = readNumber(
+    'RAG_ROUTINE_MATCH_THRESHOLD',
+    Math.min(config.matchThreshold, DEFAULT_ROUTINE_MATCH_THRESHOLD),
+    0,
+    1,
+  );
+  const matchCount = readNumber('RAG_ROUTINE_MATCH_COUNT', DEFAULT_ROUTINE_MATCH_COUNT, 1, 20);
+
+  const { data, error } = await supabase.rpc(config.vectorRpc, {
+    query_embedding: embedding.embedding,
+    match_threshold: matchThreshold,
+    match_count: matchCount,
+    filter_domain: ['exercise'],
+    filter_source_table: ['ejercicio'],
+    filter_metadata: {},
+  });
+
+  if (error) {
+    return {
+      enabled: true,
+      used: false,
+      query,
+      results: [],
+      summary: 'No se pudo consultar el RAG. Se usa generación local segura.',
+      warnings: [`match_rag_chunks falló: ${error.message}`],
+    };
+  }
+
+  const results = (data ?? []).map(mapRpcResult);
+
+  return {
+    enabled: true,
+    used: results.length > 0,
+    query,
+    provider: embedding.provider,
+    model: embedding.model,
+    matchThreshold,
+    matchCount,
+    results,
+    summary: buildSummary(results),
+    warnings,
+  };
+}


### PR DESCRIPTION
# PR — Gym Master — RAG Coach Chat Rutinas v1

## Rama

`feature/rag-coach-chat-rutinas-v1`

## Título sugerido

Conectar RAG Coach interno con el asistente real de rutinas

## Resumen

Esta feature conecta el RAG Coach ya validado desde Swagger/Admin con el flujo real de generación de rutinas de Gym Master.

El endpoint `POST /api/rutinas/rag-assistant/generar` ahora consulta el RAG interno para recuperar ejercicios reales indexados antes de invocar el generador formal de rutinas. La generación final continúa usando el flujo actual de Gym Master para mantener estabilidad, pero la respuesta incluye contexto RAG, fuentes recuperadas, modo utilizado y advertencias técnicas.

La pantalla `/dashboard/rutinas/asistente` también muestra, cuando corresponde, las referencias de ejercicios reales utilizadas por el RAG y sus scores de similitud.

## Objetivo funcional

- Usar el RAG Coach interno como capa de contexto para el asistente de rutinas.
- Recuperar ejercicios reales desde `rag_document` / `rag_document_chunk`.
- Considerar objetivo, nivel, días disponibles, mensaje del socio y restricciones.
- Mantener fallback seguro si el RAG está apagado, sin token, sin resultados o con error.
- Preparar la base para una futura generación más inteligente de rutinas con IA.

## Cambios principales

### Backend

- Se agregó `src/services/server/ragRutinasCoachService.ts`.
- Se integró recuperación semántica en `src/app/api/rutinas/rag-assistant/generar/route.ts`.
- Se agregaron tipos de contexto RAG en `src/interfaces/ragRutinasAssistant.interface.ts`.
- Se mantuvo compatibilidad con el futuro puente externo `GYM_MASTER_RAG_COACH_URL`.
- Se agregó modo de respuesta:
  - `internal_rag`
  - `external_rag_bridge`
  - `local_fallback`

### Frontend

- Se actualizó `/dashboard/rutinas/asistente` para mostrar:
  - mensaje final,
  - resumen,
  - conocimiento RAG aplicado,
  - ejercicios recuperados,
  - score de similitud,
  - advertencias técnicas si existieran.

### Swagger / OpenAPI

- Se actualizó `src/lib/swagger/openApiSpec.ts`.
- Se documentó el payload específico de `POST /api/rutinas/rag-assistant/generar`.
- Se corrigió el ejemplo de login para usar `rol` en lugar de `userType`.

### Configuración

- Se agregaron variables documentadas en `.env.example`:

```env
RAG_ROUTINE_MATCH_THRESHOLD=0.3
RAG_ROUTINE_MATCH_COUNT=8
```

Para QA local con corpus chico se validó correctamente usando en `.env.local`:

```env
RAG_ROUTINE_MATCH_THRESHOLD=0.0
```

Ese valor queda recomendado solo para pruebas locales con pocos chunks vectorizados.

## Archivos modificados

```txt
.env.example
docs/rag/rag-coach-chat-rutinas-v1.md
src/app/api/rutinas/rag-assistant/generar/route.ts
src/app/dashboard/rutinas/asistente/page.tsx
src/interfaces/ragRutinasAssistant.interface.ts
src/lib/swagger/openApiSpec.ts
src/services/server/ragRutinasCoachService.ts
```

## Base de datos

No se agregaron migraciones nuevas.

La feature usa las tablas ya creadas por `feature/rag-coach-architecture-foundation`:

```txt
rag_document
rag_document_chunk
match_rag_chunks
```

Estado usado para validación:

```txt
rag_document: 100
rag_document_chunk: 35
chunks con embedding: 35
chunks pendientes: 0
ejercicio: 979
ejercicio_media: 1127
rutina: 371
socio: 144
usuario: 151
```

## Validaciones realizadas

- Build productivo con `npm run build`.
- Corrección de TypeScript en `ragRutinasCoachService.ts`.
- Pruebas funcionales exitosas del asistente de rutinas.
- Validación de recuperación RAG con corpus real.
- Validación de modo `internal_rag`.
- Validación de fallback seguro.
- Validación de UI mostrando referencias RAG.
- Validación de Swagger actualizado.
- Confirmación de que no se agregaron SQL/migraciones al repo público.

## Consideraciones técnicas

- `RAG_ROUTINE_MATCH_THRESHOLD=0.0` se usó para QA local porque el corpus vectorizado aún es pequeño.
- Para `.env.example` y demo inicial se recomienda mantener `RAG_ROUTINE_MATCH_THRESHOLD=0.3`.
- La generación formal de rutinas sigue siendo responsabilidad de `dataGeneracionRutina`.
- El RAG en esta versión aporta contexto y explicabilidad, sin reemplazar aún el algoritmo formal.

## Riesgos / mitigaciones

| Riesgo | Mitigación |
| --- | --- |
| RAG sin resultados por corpus chico | Threshold configurable y fallback local seguro. |
| Provider de embeddings sin token | La respuesta incluye advertencias y no rompe generación. |
| Resultados poco precisos con threshold bajo | Mantener `0.0` solo en QA local; subir a `0.3` en demo. |
| Microservicio externo no configurado | Se usa RAG interno o fallback local. |

## Checklist

- [x] Rama creada desde `main` actualizado.
- [x] Patch aplicado en `feature/rag-coach-chat-rutinas-v1`.
- [x] Build validado.
- [x] Pruebas funcionales exitosas.
- [x] Swagger actualizado.
- [x] Documentación técnica agregada.
- [x] Sin migración DB nueva.
- [x] Sin SQL privado commiteado.
- [x] Push realizado.

## Commit sugerido

```bash
git commit -m "feat: connect rag coach with routine assistant"
```

## Próximo paso sugerido

Después del merge, la siguiente evolución natural es avanzar con:

```txt
feature/rag-coach-dietas-v1
```

o, si se prefiere completar más el módulo de rutinas antes de dietas:

```txt
task/rag-coach-ejercicios-corpus-incremental
```

para cargar y vectorizar más ejercicios reales en tandas controladas.
