### PR TITLE
feat: connect rag coach with diet assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ RAG_DEBUG=false
 # Para pruebas con corpus chico usar threshold bajo, por ejemplo 0.0 a 0.3.
 RAG_ROUTINE_MATCH_THRESHOLD=0.3
 RAG_ROUTINE_MATCH_COUNT=8
+# Ajustes específicos del asistente de dietas con RAG interno.
+# Para pruebas con corpus chico usar threshold bajo, por ejemplo 0.0 a 0.3.
+RAG_DIET_MATCH_THRESHOLD=0.3
+RAG_DIET_MATCH_COUNT=8
 
 EMBEDDING_PROVIDER=github
 GITHUB_TOKEN=

--- a/docs/rag/rag-coach-dietas-v1.md
+++ b/docs/rag/rag-coach-dietas-v1.md
@@ -1,0 +1,103 @@
+# Gym Master — RAG Coach Dietas v1
+
+## Objetivo
+
+Conectar el RAG Coach con el flujo real de generación de dietas de Gym Master, usando reglas nutricionales reales del sistema y manteniendo un enfoque orientativo, seguro y no médico.
+
+Esta versión no reemplaza a un nutricionista. El sistema genera dietas orientativas con el generador formal existente y usa RAG para aportar contexto, trazabilidad y advertencias.
+
+## Alcance
+
+- Nuevo endpoint `POST /api/dieta/rag-assistant/generar`.
+- Nueva ingesta administrativa `POST /api/rag/coach/ingest/dietas` desde `comida_base`.
+- Nuevo servicio `ragDietasCoachService` para recuperar reglas `diet_rule` y `safety`.
+- Actualización del formulario de dietas para enviar pedido, restricciones y preferencias.
+- Visualización de referencias RAG, scores, disclaimers y advertencias.
+- Swagger actualizado.
+
+## Flujo operativo
+
+1. El admin o socio completa objetivo, fechas, pedido, restricciones y preferencias.
+2. El backend consulta el RAG interno con esos datos.
+3. El RAG recupera reglas nutricionales reales previamente indexadas desde `comida_base`.
+4. El generador formal de Gym Master crea la dieta mediante `genera_dieta_socio`.
+5. La respuesta incluye modo, resumen, referencias RAG, disclaimers y advertencias.
+6. Si el RAG no está disponible, la dieta se genera igual con fallback seguro.
+
+## Endpoints
+
+### Ingesta RAG de reglas nutricionales
+
+`POST /api/rag/coach/ingest/dietas`
+
+Payload sugerido:
+
+```json
+{
+  "limit": 10,
+  "force": false,
+  "onlyMissing": true,
+  "delayMs": 750
+}
+```
+
+### Generación de dieta con asistente RAG
+
+`POST /api/dieta/rag-assistant/generar`
+
+Payload sugerido:
+
+```json
+{
+  "socio_id": "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
+  "objetivo": 1,
+  "fecha_inicio": "2026-06-15",
+  "fecha_fin": "2026-07-15",
+  "idioma": "es",
+  "mensajeSocio": "Quiero bajar grasa sin perder músculo y necesito comidas simples.",
+  "restricciones": "Evitar exceso de sodio. No tengo alergias conocidas.",
+  "preferencias": "Prefiero pollo, arroz, verduras y comidas económicas."
+}
+```
+
+## Variables de entorno
+
+```env
+RAG_DIET_MATCH_THRESHOLD=0.3
+RAG_DIET_MATCH_COUNT=8
+```
+
+Para QA con corpus chico puede usarse temporalmente:
+
+```env
+RAG_DIET_MATCH_THRESHOLD=0.0
+```
+
+## Seguridad nutricional
+
+La respuesta incluye disclaimers fijos:
+
+- La dieta es orientativa.
+- No reemplaza nutricionista.
+- Ante enfermedades, embarazo, medicación, diabetes, hipertensión, trastornos alimentarios o condiciones clínicas, consultar con profesional.
+- No prometer resultados físicos o médicos garantizados.
+
+También detecta términos de riesgo como diabetes, hipertensión, embarazo, condiciones renales/hepáticas y TCA para agregar advertencias.
+
+## Validación recomendada
+
+1. Login admin desde Swagger.
+2. Autorizar con Bearer token.
+3. Ejecutar `POST /api/rag/coach/ingest/dietas` con límite chico.
+4. Revisar `GET /api/rag/coach/status`.
+5. Ejecutar `POST /api/dieta/rag-assistant/generar`.
+6. Validar que la dieta se cree en `dieta`.
+7. Validar que la respuesta incluya `ragContext`, disclaimers y advertencias.
+8. Probar desde `/dashboard/dietas`.
+
+## Consideraciones
+
+- Esta feature no modifica la estructura de base de datos.
+- Esta feature no genera PDF nuevo.
+- Esta feature no reemplaza la lógica formal de `genera_dieta_socio`.
+- La ingesta completa de reglas debe ejecutarse en tandas para evitar 429 del proveedor de embeddings.

--- a/src/app/api/dieta/rag-assistant/generar/route.ts
+++ b/src/app/api/dieta/rag-assistant/generar/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { createDietaSocio } from '@/services/dietaService';
+import { buildDietasRagContext } from '@/services/server/ragDietasCoachService';
+import type {
+  RagDietasAssistantRequest,
+  RagDietasContextSummary,
+  RagDietasIdioma,
+} from '@/interfaces/ragDietasAssistant.interface';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_TEXT_LENGTH = 1200;
+
+function cleanText(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value.trim().slice(0, MAX_TEXT_LENGTH);
+}
+
+function normalizeIdioma(value: unknown): RagDietasIdioma {
+  return value === 'en' ? 'en' : 'es';
+}
+
+function validateDate(value: unknown) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  return value;
+}
+
+function validatePayload(body: Partial<RagDietasAssistantRequest>, fallbackSocioId?: string | null) {
+  const socioId = cleanText(body.socio_id) || cleanText(fallbackSocioId);
+  const objetivo = body.objetivo;
+  const fechaInicio = validateDate(body.fecha_inicio);
+  const fechaFin = validateDate(body.fecha_fin);
+
+  if (!socioId || !objetivo || !fechaInicio || !fechaFin) {
+    throw new Error('Debe enviar socio_id, objetivo, fecha_inicio y fecha_fin.');
+  }
+
+  return {
+    socio_id: socioId,
+    objetivo,
+    fecha_inicio: fechaInicio,
+    fecha_fin: fechaFin,
+    idioma: normalizeIdioma(body.idioma),
+    mensajeSocio: cleanText(body.mensajeSocio),
+    restricciones: cleanText(body.restricciones),
+    preferencias: cleanText(body.preferencias),
+  } satisfies RagDietasAssistantRequest;
+}
+
+export async function POST(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => ({}))) as Partial<RagDietasAssistantRequest>;
+    const payload = validatePayload(body, user.id_socio);
+
+    let ragContext: RagDietasContextSummary | undefined;
+    let ragError: string | undefined;
+
+    try {
+      ragContext = await buildDietasRagContext(user, payload);
+    } catch (error) {
+      ragError = error instanceof Error ? error.message : 'Error desconocido al consultar RAG de dietas';
+      console.warn('RAG interno de dietas no disponible. Se usa fallback local:', ragError);
+    }
+
+    const dietaGenerada = await createDietaSocio(
+      {
+        socio_id: payload.socio_id,
+        objetivo: String(payload.objetivo),
+        fecha_inicio: payload.fecha_inicio,
+        fecha_fin: payload.fecha_fin,
+      },
+      user,
+    );
+
+    const ragContextUsed = Boolean(ragContext?.used);
+    const warnings = [
+      ...(ragContext?.warnings ?? []),
+      ...(ragError ? [ragError] : []),
+    ];
+    const disclaimers = ragContext?.disclaimers ?? [
+      'La dieta generada es orientativa y no reemplaza la evaluación de un nutricionista matriculado.',
+    ];
+
+    return NextResponse.json(
+      {
+        ok: true,
+        message: 'Dieta generada correctamente desde el asistente RAG.',
+        data: {
+          modo: ragContextUsed ? 'internal_rag' : 'local_fallback',
+          ragConfigurado: Boolean(ragContext?.enabled),
+          dietaGenerada,
+          parametros: {
+            socio_id: payload.socio_id,
+            objetivo: payload.objetivo,
+            fecha_inicio: payload.fecha_inicio,
+            fecha_fin: payload.fecha_fin,
+            idioma: payload.idioma,
+          },
+          mensajeFinal: ragContextUsed
+            ? 'La dieta se generó con el generador formal de Gym Master y referencias nutricionales recuperadas por el RAG Coach.'
+            : 'La dieta se generó con el generador formal de Gym Master y fallback seguro.',
+          resumen: ragContext?.summary ?? 'Se utilizó el generador formal de Gym Master con los parámetros indicados.',
+          advertencias: warnings,
+          disclaimers,
+          ragContext,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error inesperado';
+    const status = message.toLowerCase().includes('token') ? 401 : message.includes('Debe enviar') ? 400 : 500;
+
+    console.error('Error en asistente RAG de dietas:', error);
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: message,
+      },
+      { status },
+    );
+  }
+}

--- a/src/app/api/rag/coach/ingest/dietas/route.ts
+++ b/src/app/api/rag/coach/ingest/dietas/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { ingestDietRulesForRag } from '@/services/server/ragCoachIngestionService';
+
+export const dynamic = 'force-dynamic';
+
+function getAuthStatus(error: any) {
+  const message = error?.message ?? '';
+  if (message.includes('Token no proporcionado') || message.includes('Token inválido')) return 401;
+  if (message.includes('No autorizado')) return 403;
+  return 500;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authMiddleware(request);
+    const payload = await request.json().catch(() => ({}));
+    const result = await ingestDietRulesForRag(user, payload);
+    return NextResponse.json(result, { status: result.ok ? 200 : 207 });
+  } catch (error: any) {
+    const status = getAuthStatus(error);
+    if (status === 500) console.error('Error en ingesta RAG de dietas:', error);
+    return NextResponse.json(
+      { ok: false, error: error?.message ?? 'Error en ingesta RAG de dietas.' },
+      { status },
+    );
+  }
+}

--- a/src/app/dashboard/dietas/page.tsx
+++ b/src/app/dashboard/dietas/page.tsx
@@ -21,6 +21,7 @@ export default function DietasPage() {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState("");
   const [openModal, setOpenModal] = useState(false);
+  const [dietasRefreshKey, setDietasRefreshKey] = useState(0);
 
   useEffect(() => {
     initializeAuth();
@@ -86,7 +87,9 @@ export default function DietasPage() {
                   </Button>
                 </CardHeader>
                 <CardContent className="p-4">
-                  <DietaForm />
+                  <DietaForm
+                    onSuccess={() => setDietasRefreshKey((current) => current + 1)}
+                  />
                 </CardContent>
               </Card>
             )}
@@ -131,7 +134,16 @@ export default function DietasPage() {
                 </div>
               </CardHeader>
               <CardContent className="p-4">
-                {user?.id && <DietaHistorial userId={user.id} />}
+                {user?.id_socio ? (
+                  <DietaHistorial
+                    socioId={user.id_socio}
+                    refreshKey={dietasRefreshKey}
+                  />
+                ) : (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                    No se pudo identificar el socio asociado a este usuario.
+                  </div>
+                )}
               </CardContent>
             </Card>
           </main>

--- a/src/components/forms/DietaForm.tsx
+++ b/src/components/forms/DietaForm.tsx
@@ -7,13 +7,13 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import type { CreateDietaDto, Dieta } from "@/interfaces/dieta.interface";
 import {
-  crearDieta,
+  generarDietaConAsistente,
   getObjetivos,
-  getSocioByUsuarioId,
 } from "@/services/apiClient";
 import { useAuthStore } from "@/stores/authStore";
 
 import type { Objetivo } from "@/interfaces/objetivo.interface";
+import type { RagDietasAssistantResponseData } from "@/interfaces/ragDietasAssistant.interface";
 
 interface DietaFormProps {
   initialSocioId?: string;
@@ -35,6 +35,10 @@ export default function DietaForm({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [fechaFin, setFechaFin] = useState<CreateDietaDto["fecha_fin"]>("");
+  const [mensajeSocio, setMensajeSocio] = useState("");
+  const [restricciones, setRestricciones] = useState("");
+  const [preferencias, setPreferencias] = useState("");
+  const [assistantResult, setAssistantResult] = useState<RagDietasAssistantResponseData | null>(null);
   const [objetivos, setObjetivos] = useState<Objetivo[]>([]);
   const { user } = useAuthStore();
 
@@ -46,11 +50,8 @@ export default function DietaForm({
 
   const resolveSocioId = async () => {
     if (initialSocioId) return initialSocioId;
-
-    if (!user?.id) return null;
-
-    const socio = await getSocioByUsuarioId(user.id.toString());
-    return socio?.id_socio?.toString() ?? null;
+    if (user?.id_socio) return user.id_socio.toString();
+    return null;
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -58,6 +59,7 @@ export default function DietaForm({
     setLoading(true);
     setMessage(null);
     setErrorMessage(null);
+    setAssistantResult(null);
 
     try {
       const socioId = await resolveSocioId();
@@ -71,9 +73,13 @@ export default function DietaForm({
         objetivo,
         fecha_inicio: fechaInicio,
         fecha_fin: fechaFin,
+        idioma: "es",
+        mensajeSocio,
+        restricciones,
+        preferencias,
       };
 
-      const res = await crearDieta(body);
+      const res = await generarDietaConAsistente(body);
       if (!res.ok) {
         setErrorMessage(
           res.data?.error || res.data?.message || "No se pudo generar la dieta."
@@ -81,9 +87,13 @@ export default function DietaForm({
         return;
       }
 
-      setMessage("Dieta generada correctamente.");
-      if (res.data && onSuccess) {
-        onSuccess(res.data as Dieta);
+      const result = res.data?.data as RagDietasAssistantResponseData | undefined;
+      const dietaGenerada = result?.dietaGenerada ?? res.data;
+
+      setAssistantResult(result ?? null);
+      setMessage(result?.mensajeFinal || "Dieta generada correctamente.");
+      if (dietaGenerada && onSuccess) {
+        onSuccess(dietaGenerada as Dieta);
       }
     } catch (error) {
       console.error("Error al generar dieta:", error);
@@ -146,6 +156,42 @@ export default function DietaForm({
           required
         />
       </div>
+
+      <div className="flex flex-col gap-1.5 col-span-full">
+        <Label htmlFor="mensajeSocio">Pedido u objetivo del socio</Label>
+        <textarea
+          id="mensajeSocio"
+          className="min-h-24 rounded-md border px-3 py-2 text-sm"
+          placeholder="Ejemplo: quiero bajar grasa sin perder músculo, entreno 3 días y necesito comidas simples."
+          value={mensajeSocio}
+          maxLength={1200}
+          onChange={(e) => setMensajeSocio(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5 col-span-full md:col-span-1">
+        <Label htmlFor="restricciones">Restricciones o cuidados</Label>
+        <textarea
+          id="restricciones"
+          className="min-h-24 rounded-md border px-3 py-2 text-sm"
+          placeholder="Ejemplo: hipertensión, diabetes, alergias, intolerancias, medicación, embarazo."
+          value={restricciones}
+          maxLength={1200}
+          onChange={(e) => setRestricciones(e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-1.5 col-span-full md:col-span-1">
+        <Label htmlFor="preferencias">Preferencias alimentarias</Label>
+        <textarea
+          id="preferencias"
+          className="min-h-24 rounded-md border px-3 py-2 text-sm"
+          placeholder="Ejemplo: prefiero pollo, arroz, verduras, sin lactosa, económico y fácil de preparar."
+          value={preferencias}
+          maxLength={1200}
+          onChange={(e) => setPreferencias(e.target.value)}
+        />
+      </div>
       <Button
         type="submit"
         className="col-span-full justify-self-end"
@@ -157,6 +203,51 @@ export default function DietaForm({
       {message && (
         <div className="p-3 text-sm text-green-700 border border-green-200 rounded-md col-span-full bg-green-50">
           {message}
+        </div>
+      )}
+
+      {assistantResult && (
+        <div className="space-y-3 rounded-md border bg-muted/40 p-4 text-sm col-span-full">
+          <div>
+            <p className="font-semibold">Resumen RAG Coach</p>
+            <p className="text-muted-foreground">{assistantResult.resumen}</p>
+          </div>
+
+          {assistantResult.ragContext?.used && assistantResult.ragContext.results.length > 0 && (
+            <div>
+              <p className="font-semibold">Referencias nutricionales aplicadas</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-muted-foreground">
+                {assistantResult.ragContext.results.slice(0, 5).map((source) => (
+                  <li key={source.chunkId}>
+                    <span className="font-medium text-foreground">{source.title}</span>
+                    <span> · score {source.similarity.toFixed(2)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {assistantResult.disclaimers.length > 0 && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-900">
+              <p className="font-semibold">Aviso nutricional</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                {assistantResult.disclaimers.map((disclaimer) => (
+                  <li key={disclaimer}>{disclaimer}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {assistantResult.advertencias.length > 0 && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-blue-900">
+              <p className="font-semibold">Advertencias técnicas / seguridad</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                {assistantResult.advertencias.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/tables/DietaHistorial.tsx
+++ b/src/components/tables/DietaHistorial.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
   TableCaption,
 } from "@/components/ui/table";
-import { getDietasPorSocio, getSocioByUsuarioId } from "@/services/apiClient";
+import { getDietasPorSocio } from "@/services/apiClient";
 import type { Dieta } from "@/interfaces/dieta.interface";
 import { formatFrontendDate } from "@/utils/dateFormat";
 import {
@@ -24,9 +24,11 @@ import {
 } from "@/components/ui/dialog";
 
 export default function DietaHistorial({
-  userId,
+  socioId,
+  refreshKey = 0,
 }: {
-  userId: number | string;
+  socioId: number | string;
+  refreshKey?: number;
 }) {
   const [dietas, setDietas] = useState<Dieta[]>([]);
   const [selected, setSelected] = useState<Dieta | null>(null);
@@ -67,16 +69,20 @@ export default function DietaHistorial({
 
   useEffect(() => {
     const fetchDietas = async () => {
-      const socio = await getSocioByUsuarioId(userId.toString());
-      if (socio) {
-        const res = await getDietasPorSocio(socio.id_socio);
-        if (res.ok && Array.isArray(res.data)) {
-          setDietas(res.data);
-        }
+      if (!socioId) {
+        setDietas([]);
+        return;
+      }
+
+      const res = await getDietasPorSocio(socioId.toString());
+      if (res.ok && Array.isArray(res.data)) {
+        setDietas(res.data);
+      } else {
+        setDietas([]);
       }
     };
     fetchDietas();
-  }, [userId]);
+  }, [socioId, refreshKey]);
   const dietasOrdenadas = [...dietas].sort((a, b) =>
     b.fecha_inicio.localeCompare(a.fecha_inicio)
   );

--- a/src/interfaces/ragCoach.interface.ts
+++ b/src/interfaces/ragCoach.interface.ts
@@ -38,6 +38,7 @@ export interface RagHealthResponse {
     documents: number;
     chunks: number;
     exerciseDocuments: number;
+    dietDocuments?: number;
     activeChunks: number;
     embeddedChunks?: number;
     pendingEmbeddingChunks?: number;
@@ -67,6 +68,22 @@ export interface RagIngestExercisesRequest {
 }
 
 export interface RagIngestExercisesResponse {
+  ok: boolean;
+  processed: number;
+  indexed: number;
+  skipped: number;
+  failed: number;
+  errors: string[];
+}
+
+export interface RagIngestDietRulesRequest {
+  limit?: number;
+  force?: boolean;
+  onlyMissing?: boolean;
+  delayMs?: number;
+}
+
+export interface RagIngestDietRulesResponse {
   ok: boolean;
   processed: number;
   indexed: number;

--- a/src/interfaces/ragDietasAssistant.interface.ts
+++ b/src/interfaces/ragDietasAssistant.interface.ts
@@ -1,0 +1,66 @@
+import type { Dieta } from './dieta.interface';
+
+export type RagDietasIdioma = 'es' | 'en';
+
+export interface RagDietasAssistantRequest {
+  socio_id: string;
+  objetivo: string | number;
+  fecha_inicio: string;
+  fecha_fin: string;
+  idioma?: RagDietasIdioma;
+  mensajeSocio?: string;
+  restricciones?: string;
+  preferencias?: string;
+}
+
+export interface RagDietasContextResult {
+  chunkId: string;
+  documentId: string;
+  title: string;
+  sourceId: string;
+  sourceTable: string;
+  domain: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  documentMetadata: Record<string, unknown>;
+  similarity: number;
+}
+
+export interface RagDietasContextSummary {
+  enabled: boolean;
+  used: boolean;
+  query: string;
+  provider?: string;
+  model?: string;
+  matchThreshold?: number;
+  matchCount?: number;
+  results: RagDietasContextResult[];
+  summary: string;
+  disclaimers: string[];
+  warnings: string[];
+}
+
+export interface RagDietasAssistantResponseData {
+  modo: 'internal_rag' | 'local_fallback';
+  ragConfigurado: boolean;
+  dietaGenerada: Dieta;
+  parametros: {
+    socio_id: string;
+    objetivo: string | number;
+    fecha_inicio: string;
+    fecha_fin: string;
+    idioma: RagDietasIdioma;
+  };
+  mensajeFinal: string;
+  resumen: string;
+  advertencias: string[];
+  disclaimers: string[];
+  ragContext?: RagDietasContextSummary;
+}
+
+export interface RagDietasAssistantApiResponse {
+  ok: boolean;
+  message?: string;
+  error?: string;
+  data?: RagDietasAssistantResponseData;
+}

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -972,6 +972,20 @@ const endpointDefinitions: EndpointDefinition[] = [
     source: "src/app/api/dieta/generar/route.ts",
   },
   {
+    path: "/api/dieta/rag-assistant/generar",
+    methods: ["POST"],
+    tag: "Dietas",
+    summary: "Generar dieta desde asistente RAG",
+    description:
+      "Genera una dieta con el generador formal de Gym Master y consulta el RAG interno para recuperar reglas nutricionales reales desde comida_base. Mantiene fallback seguro y disclaimers nutricionales.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [201, 400, 401, 500],
+    queryParams: [],
+    source: "src/app/api/dieta/rag-assistant/generar/route.ts",
+  },
+  {
     path: "/api/dieta/{id}",
     methods: ["GET"],
     tag: "Dietas",
@@ -1795,6 +1809,20 @@ const endpointDefinitions: EndpointDefinition[] = [
     source: "src/app/api/rag/coach/ingest/ejercicios/route.ts",
   },
   {
+    path: "/api/rag/coach/ingest/dietas",
+    methods: ["POST"],
+    tag: "RAG Coach",
+    summary: "Ingestar reglas nutricionales al RAG",
+    description:
+      "Indexa reglas nutricionales reales desde comida_base como documentos/chunks RAG del dominio diet_rule. Requiere rol administrador y proveedor de embeddings configurado.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 207, 400, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/ingest/dietas/route.ts",
+  },
+  {
     path: "/api/rag/coach/vectorize/pending",
     methods: ["POST"],
     tag: "RAG Coach",
@@ -2281,6 +2309,27 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
     };
   }
 
+  if (endpoint.path === "/api/rag/coach/ingest/dietas") {
+    return {
+      required: false,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagIngestDietRulesRequest" },
+          examples: {
+            reglasNutricionales: {
+              summary: "Ingesta limitada de reglas de comida_base",
+              value: { limit: 10, force: false, onlyMissing: true, delayMs: 750 },
+            },
+            reindexarReglas: {
+              summary: "Reindexar reglas nutricionales aunque ya existan",
+              value: { limit: 25, force: true, delayMs: 1000 },
+            },
+          },
+        },
+      },
+    };
+  }
+
   if (endpoint.path === "/api/rag/coach/vectorize/pending") {
     return {
       required: false,
@@ -2353,6 +2402,45 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
                 mensajeSocio: "Rutina de fuerza inicial de 3 días con ejercicios seguros.",
                 restricciones: "Sin saltos ni impacto alto.",
                 id_socio: "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  if (endpoint.path === "/api/dieta/rag-assistant/generar") {
+    return {
+      required: true,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagDietasAssistantRequest" },
+          examples: {
+            dietaRag: {
+              summary: "Generar dieta con RAG interno",
+              value: {
+                socio_id: "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
+                objetivo: 1,
+                fecha_inicio: "2026-06-15",
+                fecha_fin: "2026-07-15",
+                idioma: "es",
+                mensajeSocio: "Quiero bajar grasa sin perder músculo y necesito comidas simples.",
+                restricciones: "Evitar exceso de sodio. No tengo alergias conocidas.",
+                preferencias: "Prefiero pollo, arroz, verduras y comidas económicas.",
+              },
+            },
+            cuidadoNutricional: {
+              summary: "Caso con advertencia de seguridad",
+              value: {
+                socio_id: "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
+                objetivo: 2,
+                fecha_inicio: "2026-06-15",
+                fecha_fin: "2026-07-15",
+                idioma: "es",
+                mensajeSocio: "Quiero mejorar mi alimentación y entreno tres veces por semana.",
+                restricciones: "Tengo hipertensión.",
+                preferencias: "Comidas simples y sin frituras.",
               },
             },
           },
@@ -2886,6 +2974,35 @@ export const openApiSpec = {
           },
         },
       },
+      RagIngestDietRulesRequest: {
+        type: "object",
+        properties: {
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 100,
+            example: 25,
+            description: "Cantidad máxima de reglas nutricionales de comida_base a procesar.",
+          },
+          force: {
+            type: "boolean",
+            example: false,
+            description: "Cuando vale true, reindexa aunque el hash del contenido no haya cambiado.",
+          },
+          onlyMissing: {
+            type: "boolean",
+            example: true,
+            description: "Reservado para flujos de ingesta incremental.",
+          },
+          delayMs: {
+            type: "integer",
+            minimum: 0,
+            maximum: 5000,
+            example: 750,
+            description: "Pausa en milisegundos entre embeddings para reducir errores 429 del proveedor.",
+          },
+        },
+      },
       RagVectorizePendingRequest: {
         type: "object",
         properties: {
@@ -3003,6 +3120,53 @@ export const openApiSpec = {
             format: "uuid",
             nullable: true,
             description: "Solo para pruebas/admin. El socio logueado se resuelve automáticamente.",
+          },
+        },
+      },
+      RagDietasAssistantRequest: {
+        type: "object",
+        required: ["socio_id", "objetivo", "fecha_inicio", "fecha_fin"],
+        properties: {
+          socio_id: {
+            type: "string",
+            format: "uuid",
+            example: "2d2a45df-0fd5-4f4e-9c01-5de07dca1111",
+          },
+          objetivo: {
+            type: "integer",
+            minimum: 1,
+            example: 1,
+            description: "ID del objetivo nutricional/de entrenamiento.",
+          },
+          fecha_inicio: {
+            type: "string",
+            format: "date",
+            example: "2026-06-15",
+          },
+          fecha_fin: {
+            type: "string",
+            format: "date",
+            example: "2026-07-15",
+          },
+          idioma: {
+            type: "string",
+            enum: ["es", "en"],
+            example: "es",
+          },
+          mensajeSocio: {
+            type: "string",
+            maxLength: 1200,
+            example: "Quiero bajar grasa sin perder músculo y necesito comidas simples.",
+          },
+          restricciones: {
+            type: "string",
+            maxLength: 1200,
+            example: "Evitar exceso de sodio. No tengo alergias conocidas.",
+          },
+          preferencias: {
+            type: "string",
+            maxLength: 1200,
+            example: "Prefiero pollo, arroz, verduras y comidas económicas.",
           },
         },
       },

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -391,6 +391,20 @@ export async function crearDieta(body: any) {
   return { ok: res.ok, data };
 }
 
+export async function generarDietaConAsistente(body: any) {
+  const token = getToken();
+  const res = await fetch(`/api/dieta/rag-assistant/generar`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return { ok: res.ok, data };
+}
+
 export async function actualizarDieta(id: number | string, body: any) {
   const token = getToken();
   const res = await fetch(`/api/dieta/${id}`, {

--- a/src/services/server/ragCoachIngestionService.ts
+++ b/src/services/server/ragCoachIngestionService.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
 import {
+  RagIngestDietRulesRequest,
+  RagIngestDietRulesResponse,
   RagIngestExercisesRequest,
   RagIngestExercisesResponse,
   RagVectorizePendingRequest,
@@ -14,6 +16,7 @@ const MAX_LIMIT = 100;
 const MAX_DELAY_MS = 5000;
 
 type ExerciseRow = Record<string, any>;
+type DietRuleRow = Record<string, any>;
 
 function normalizeRole(role?: string | null) {
   return role?.trim().toLowerCase() ?? '';
@@ -186,6 +189,158 @@ async function fetchExercises(limit: number) {
   return data ?? [];
 }
 
+
+function buildDietRuleMetadata(row: DietRuleRow) {
+  const objetivo = getRelatedName(row.objetivo, 'nombre_objetivo');
+
+  return {
+    id: row.id,
+    tipo_comida: row.tipo_comida,
+    objetivo,
+    objetivo_id: row.objetivo_id,
+    calorias_aprox: row.calorias_aprox ?? null,
+    proteinas_aprox: row.proteinas_aprox ?? null,
+    carbohidratos_aprox: row.carbohidratos_aprox ?? null,
+    grasas_aprox: row.grasas_aprox ?? null,
+  };
+}
+
+function buildDietRuleContent(row: DietRuleRow) {
+  const metadata = buildDietRuleMetadata(row);
+  const lines = [
+    `Regla nutricional Gym Master: ${row.tipo_comida}`,
+    metadata.objetivo ? `Objetivo asociado: ${metadata.objetivo}` : null,
+    row.descripcion ? `Descripción alimentaria: ${row.descripcion}` : null,
+    row.calorias_aprox ? `Calorías aproximadas: ${row.calorias_aprox}` : null,
+    row.proteinas_aprox ? `Proteínas aproximadas: ${row.proteinas_aprox} g` : null,
+    row.carbohidratos_aprox ? `Carbohidratos aproximados: ${row.carbohidratos_aprox} g` : null,
+    row.grasas_aprox ? `Grasas aproximadas: ${row.grasas_aprox} g` : null,
+    'Uso recomendado: orientar una dieta de gimnasio de forma general, simple y segura.',
+    'Límite de seguridad: no reemplaza nutricionista ni indicación médica individual.',
+  ].filter(Boolean);
+
+  return {
+    content: lines.join('\n'),
+    metadata,
+  };
+}
+
+async function fetchDietRules(limit: number) {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('comida_base')
+    .select(
+      `
+      id,
+      tipo_comida,
+      objetivo_id,
+      descripcion,
+      calorias_aprox,
+      proteinas_aprox,
+      carbohidratos_aprox,
+      grasas_aprox,
+      objetivo:objetivo!comida_base_objetivo_id_fkey(nombre_objetivo)
+    `,
+    )
+    .order('objetivo_id', { ascending: true })
+    .order('tipo_comida', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}
+
+async function upsertDietRuleDocument(row: DietRuleRow, force: boolean) {
+  const supabase = getSupabaseServerClient();
+  const { content, metadata } = buildDietRuleContent(row);
+  const contentHash = hashContent(content);
+  const sourceId = String(row.id);
+  const title = `${metadata.objetivo ? `${metadata.objetivo} - ` : ''}${row.tipo_comida}`;
+  const tokenCount = Math.ceil(content.length / 4);
+
+  const { data: existing, error: existingError } = await supabase
+    .from('rag_document')
+    .select('id, content_hash')
+    .eq('domain', 'diet_rule')
+    .eq('source_table', 'comida_base')
+    .eq('source_id', sourceId)
+    .maybeSingle();
+
+  if (existingError) {
+    throw new Error(existingError.message);
+  }
+
+  if (existing?.id && existing.content_hash === contentHash && !force) {
+    return { indexed: false, skipped: true };
+  }
+
+  const { data: document, error: documentError } = await supabase
+    .from('rag_document')
+    .upsert(
+      {
+        id: existing?.id,
+        domain: 'diet_rule',
+        source_table: 'comida_base',
+        source_id: sourceId,
+        title,
+        language: 'es-AR',
+        metadata,
+        content_hash: contentHash,
+        active: true,
+        actualizado_en: new Date().toISOString(),
+      },
+      { onConflict: 'domain,source_table,source_id' },
+    )
+    .select('id')
+    .single();
+
+  if (documentError) {
+    throw new Error(documentError.message);
+  }
+
+  const { data: chunk, error: chunkUpsertError } = await supabase
+    .from('rag_document_chunk')
+    .upsert(
+      {
+        document_id: document.id,
+        chunk_index: 0,
+        content,
+        token_count: tokenCount,
+        embedding: null,
+        metadata,
+        active: true,
+        actualizado_en: new Date().toISOString(),
+      },
+      { onConflict: 'document_id,chunk_index' },
+    )
+    .select('id')
+    .single();
+
+  if (chunkUpsertError) {
+    throw new Error(chunkUpsertError.message);
+  }
+
+  const embedding = await createSingleRagEmbedding(content);
+
+  const { error: chunkVectorError } = await supabase
+    .from('rag_document_chunk')
+    .update({
+      embedding: embedding.embedding,
+      token_count: tokenCount,
+      actualizado_en: new Date().toISOString(),
+    })
+    .eq('id', chunk.id);
+
+  if (chunkVectorError) {
+    throw new Error(chunkVectorError.message);
+  }
+
+  return { indexed: true, skipped: false };
+}
+
 async function upsertExerciseDocument(row: ExerciseRow, force: boolean) {
   const supabase = getSupabaseServerClient();
   const { content, metadata } = buildExerciseContent(row);
@@ -303,6 +458,44 @@ export async function ingestExercisesForRag(
     }
 
     if (delayMs > 0 && index < exercises.length - 1) {
+      await sleep(delayMs);
+    }
+  }
+
+  response.ok = response.failed === 0;
+  return response;
+}
+
+export async function ingestDietRulesForRag(
+  user: JwtUser,
+  payload: RagIngestDietRulesRequest = {},
+): Promise<RagIngestDietRulesResponse> {
+  assertAdmin(user);
+
+  const limit = safeLimit(payload.limit);
+  const delayMs = safeDelayMs(payload.delayMs);
+  const dietRules = await fetchDietRules(limit);
+  const response: RagIngestDietRulesResponse = {
+    ok: true,
+    processed: dietRules.length,
+    indexed: 0,
+    skipped: 0,
+    failed: 0,
+    errors: [],
+  };
+
+  for (let index = 0; index < dietRules.length; index += 1) {
+    const dietRule = dietRules[index];
+    try {
+      const result = await upsertDietRuleDocument(dietRule, Boolean(payload.force));
+      if (result.indexed) response.indexed += 1;
+      if (result.skipped) response.skipped += 1;
+    } catch (error: any) {
+      response.failed += 1;
+      response.errors.push(`${dietRule.tipo_comida ?? dietRule.id}: ${error?.message ?? 'error desconocido'}`);
+    }
+
+    if (delayMs > 0 && index < dietRules.length - 1) {
       await sleep(delayMs);
     }
   }

--- a/src/services/server/ragCoachSearchService.ts
+++ b/src/services/server/ragCoachSearchService.ts
@@ -105,11 +105,12 @@ export async function getRagHealth(user: JwtUser): Promise<RagHealthResponse> {
   if (status.provider === 'openai' && !status.openaiConfigured) warnings.push('Falta OPENAI_API_KEY.');
 
   try {
-    const [documents, chunks, exerciseDocuments, activeChunks, embeddedChunks, pendingEmbeddingChunks] =
+    const [documents, chunks, exerciseDocuments, dietDocuments, activeChunks, embeddedChunks, pendingEmbeddingChunks] =
       await Promise.all([
         safeCount('rag_document'),
         safeCount('rag_document_chunk'),
         safeCount('rag_document', (query) => query.eq('domain', 'exercise')),
+        safeCount('rag_document', (query) => query.eq('domain', 'diet_rule')),
         safeCount('rag_document_chunk', (query) => query.eq('active', true)),
         safeCount('rag_document_chunk', (query) => query.eq('active', true).not('embedding', 'is', null)),
         safeCount('rag_document_chunk', (query) => query.eq('active', true).is('embedding', null)),
@@ -126,6 +127,7 @@ export async function getRagHealth(user: JwtUser): Promise<RagHealthResponse> {
         documents,
         chunks,
         exerciseDocuments,
+        dietDocuments,
         activeChunks,
         embeddedChunks,
         pendingEmbeddingChunks,

--- a/src/services/server/ragDietasCoachService.ts
+++ b/src/services/server/ragDietasCoachService.ts
@@ -1,0 +1,225 @@
+import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import type {
+  RagDietasAssistantRequest,
+  RagDietasContextResult,
+  RagDietasContextSummary,
+} from '@/interfaces/ragDietasAssistant.interface';
+import { getRagConfig } from '@/lib/rag/ragConfig';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+import { createSingleRagEmbedding } from './ragEmbeddingProviderService';
+
+const DEFAULT_DIET_MATCH_THRESHOLD = 0.3;
+const DEFAULT_DIET_MATCH_COUNT = 8;
+const MAX_QUERY_LENGTH = 1800;
+
+const BASE_DIET_DISCLAIMERS = [
+  'La dieta generada es orientativa y no reemplaza la evaluación de un nutricionista matriculado.',
+  'Ante enfermedades, embarazo, medicación, diabetes, hipertensión, trastornos alimentarios o condiciones clínicas, consultar con un profesional de salud antes de aplicar cambios alimentarios.',
+  'No se deben prometer resultados físicos o médicos garantizados desde el sistema.',
+];
+
+function cleanText(value: unknown, maxLength = MAX_QUERY_LENGTH) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function readNumber(name: string, fallback: number, min: number, max: number) {
+  const value = Number(process.env[name]);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(Math.max(value, min), max);
+}
+
+function toPositiveInteger(value: unknown) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeMetadata(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function mapRpcResult(row: Record<string, unknown>): RagDietasContextResult {
+  return {
+    chunkId: String(row.chunk_id),
+    documentId: String(row.document_id),
+    title: String(row.title ?? 'Regla nutricional RAG'),
+    sourceId: String(row.source_id ?? ''),
+    sourceTable: String(row.source_table ?? ''),
+    domain: String(row.domain ?? ''),
+    content: cleanText(row.content, 900),
+    metadata: normalizeMetadata(row.metadata),
+    documentMetadata: normalizeMetadata(row.document_metadata),
+    similarity: Number(row.similarity ?? 0),
+  };
+}
+
+async function getObjectiveLabel(id: number | null) {
+  if (!id) return null;
+
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('objetivo')
+    .select('nombre_objetivo')
+    .eq('id_objetivo', id)
+    .maybeSingle();
+
+  if (error) {
+    console.warn('No se pudo resolver objetivo para RAG dietas:', error.message);
+    return null;
+  }
+
+  return typeof data?.nombre_objetivo === 'string' ? data.nombre_objetivo : null;
+}
+
+function detectHighRiskWarnings(payload: RagDietasAssistantRequest) {
+  const text = cleanText(
+    `${payload.mensajeSocio ?? ''} ${payload.restricciones ?? ''} ${payload.preferencias ?? ''}`,
+    4000,
+  )
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+  const warnings: string[] = [];
+  const risks: Array<[RegExp, string]> = [
+    [/\b(diabetes|glucemia|insulina)\b/, 'Condición relacionada con diabetes/glucemia informada. Requiere revisión profesional.'],
+    [/\b(hipertension|presion alta|cardiopatia|corazon)\b/, 'Condición cardiovascular o presión alta informada. Requiere revisión profesional.'],
+    [/\b(embarazo|embarazada|lactancia)\b/, 'Embarazo o lactancia informado. Requiere indicación profesional específica.'],
+    [/\b(renal|rinon|riñon|hepatica|higado)\b/, 'Condición renal/hepática informada. Requiere revisión profesional.'],
+    [/\b(anorexia|bulimia|trastorno alimentario|tca)\b/, 'Posible trastorno de la conducta alimentaria informado. No generar indicaciones restrictivas sin profesional.'],
+  ];
+
+  for (const [pattern, warning] of risks) {
+    if (pattern.test(text)) warnings.push(warning);
+  }
+
+  return warnings;
+}
+
+function buildQuery(params: {
+  payload: RagDietasAssistantRequest;
+  objetivoNombre?: string | null;
+}) {
+  const objetivo = params.objetivoNombre ? `Objetivo nutricional/de entrenamiento: ${params.objetivoNombre}.` : '';
+  const fechas = params.payload.fecha_inicio && params.payload.fecha_fin
+    ? `Periodo del plan: desde ${params.payload.fecha_inicio} hasta ${params.payload.fecha_fin}.`
+    : '';
+  const mensaje = cleanText(params.payload.mensajeSocio);
+  const restricciones = cleanText(params.payload.restricciones);
+  const preferencias = cleanText(params.payload.preferencias);
+
+  return [
+    'Armar dieta orientativa para socio de gimnasio usando reglas nutricionales reales de Gym Master.',
+    objetivo,
+    fechas,
+    mensaje ? `Pedido del socio: ${mensaje}.` : '',
+    restricciones ? `Restricciones, salud o cuidados: ${restricciones}.` : '',
+    preferencias ? `Preferencias alimentarias: ${preferencias}.` : '',
+    'Priorizar seguridad, adherencia, comidas simples y advertencias claras cuando corresponda.',
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .slice(0, MAX_QUERY_LENGTH);
+}
+
+function buildSummary(results: RagDietasContextResult[]) {
+  if (results.length === 0) {
+    return 'No se recuperaron reglas nutricionales desde el RAG. Se usó el generador formal de Gym Master con fallback seguro.';
+  }
+
+  const titles = results
+    .slice(0, 5)
+    .map((result) => result.title)
+    .filter(Boolean)
+    .join(', ');
+
+  return `El RAG Coach recuperó ${results.length} referencias nutricionales reales para orientar la dieta. Principales coincidencias: ${titles}.`;
+}
+
+export async function buildDietasRagContext(
+  _user: JwtUser,
+  payload: RagDietasAssistantRequest,
+): Promise<RagDietasContextSummary> {
+  const warnings: string[] = [];
+  const config = getRagConfig();
+
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      used: false,
+      query: '',
+      results: [],
+      summary: 'RAG desactivado. Se usa generación local segura.',
+      disclaimers: BASE_DIET_DISCLAIMERS,
+      warnings: ['RAG_ENABLED=false.'],
+    };
+  }
+
+  if (config.provider === 'github' && !config.githubToken) warnings.push('Falta GITHUB_TOKEN.');
+  if (config.provider === 'openai' && !config.openaiApiKey) warnings.push('Falta OPENAI_API_KEY.');
+
+  if (warnings.length > 0) {
+    return {
+      enabled: true,
+      used: false,
+      query: '',
+      results: [],
+      summary: 'RAG configurado parcialmente. Se usa generación local segura.',
+      disclaimers: BASE_DIET_DISCLAIMERS,
+      warnings,
+    };
+  }
+
+  const objetivoId = toPositiveInteger(payload.objetivo);
+  const objetivoNombre = await getObjectiveLabel(objetivoId);
+  const query = buildQuery({ payload, objetivoNombre });
+  const embedding = await createSingleRagEmbedding(query);
+  const supabase = getSupabaseServerClient();
+  const matchThreshold = readNumber(
+    'RAG_DIET_MATCH_THRESHOLD',
+    Math.min(config.matchThreshold, DEFAULT_DIET_MATCH_THRESHOLD),
+    0,
+    1,
+  );
+  const matchCount = readNumber('RAG_DIET_MATCH_COUNT', DEFAULT_DIET_MATCH_COUNT, 1, 20);
+
+  const { data, error } = await supabase.rpc(config.vectorRpc, {
+    query_embedding: embedding.embedding,
+    match_threshold: matchThreshold,
+    match_count: matchCount,
+    filter_domain: ['diet_rule', 'safety'],
+    filter_source_table: null,
+    filter_metadata: {},
+  });
+
+  const highRiskWarnings = detectHighRiskWarnings(payload);
+
+  if (error) {
+    return {
+      enabled: true,
+      used: false,
+      query,
+      results: [],
+      summary: 'No se pudo consultar el RAG de dietas. Se usa generación local segura.',
+      disclaimers: BASE_DIET_DISCLAIMERS,
+      warnings: [`match_rag_chunks falló: ${error.message}`, ...highRiskWarnings],
+    };
+  }
+
+  const results = (data ?? []).map(mapRpcResult);
+
+  return {
+    enabled: true,
+    used: results.length > 0,
+    query,
+    provider: embedding.provider,
+    model: embedding.model,
+    matchThreshold,
+    matchCount,
+    results,
+    summary: buildSummary(results),
+    disclaimers: BASE_DIET_DISCLAIMERS,
+    warnings: [...warnings, ...highRiskWarnings],
+  };
+}


### PR DESCRIPTION
# PR — Gym Master — RAG Coach Dietas v1

## Rama

`feature/rag-coach-dietas-v1`

## Título sugerido

Conectar RAG Coach interno con el asistente real de dietas

## Resumen

Esta feature conecta el RAG Coach de Gym Master con el flujo real de generación de dietas, incorporando recuperación semántica sobre reglas nutricionales indexadas desde `comida_base`, generación asistida desde el formulario de dietas, disclaimers nutricionales obligatorios y visibilidad correcta para el socio.

El flujo permite generar dietas desde Swagger y desde `/dashboard/dietas`, usando objetivo nutricional, fechas, pedido del socio, restricciones/cuidados y preferencias alimentarias. La dieta final se guarda mediante el flujo existente de Gym Master, mientras que la respuesta expone el contexto RAG aplicado, referencias nutricionales, advertencias de seguridad y modo utilizado.

Durante la validación se corrigieron además dos puntos funcionales importantes: el socio ya no intenta consultar `/api/socios` para identificarse, y el historial de dietas se refresca automáticamente después de generar una nueva dieta.

## Objetivo funcional

- Conectar el RAG Coach con la generación real de dietas.
- Ingestar reglas nutricionales reales desde `comida_base` como dominio `diet_rule`.
- Usar objetivo, pedido del socio, restricciones y preferencias para recuperar contexto nutricional.
- Generar dietas orientativas sin reemplazar el criterio de un nutricionista.
- Mostrar referencias RAG, disclaimers y advertencias de seguridad.
- Permitir que el socio vea correctamente las dietas asociadas a su `id_socio`.
- Refrescar el historial sin salir y volver al menú.

## Cambios principales

### Backend

- Se agregó `src/services/server/ragDietasCoachService.ts`.
- Se agregó `POST /api/dieta/rag-assistant/generar`.
- Se agregó `POST /api/rag/coach/ingest/dietas`.
- Se extendió `ragCoachIngestionService` para ingerir `comida_base` como reglas nutricionales.
- Se extendió `ragCoachSearchService` para soportar dominio `diet_rule`.
- Se agregó fallback al `id_socio` autenticado cuando el payload no envía `socio_id`.
- Se mantuvo el generador formal de dietas como responsable de guardar la dieta final.

### Frontend

- Se actualizó `DietaForm` para enviar:
  - pedido u objetivo del socio,
  - restricciones o cuidados,
  - preferencias alimentarias.
- Se muestran resultados del RAG Coach:
  - resumen,
  - referencias nutricionales aplicadas,
  - scores de similitud,
  - disclaimers,
  - advertencias.
- Se corrigió la identificación del socio desde el menú personal usando `user.id_socio`.
- Se corrigió `DietaHistorial` para consultar dietas por `socio_id` y no por `usuario_id`.
- Se agregó refresco automático del historial después de crear una nueva dieta.

### Seguridad nutricional

- Se agregaron disclaimers obligatorios para aclarar que la dieta es orientativa.
- Se agregaron advertencias simples ante términos sensibles como:
  - diabetes,
  - hipertensión,
  - embarazo/lactancia,
  - enfermedad renal o hepática,
  - trastornos de la conducta alimentaria.
- El asistente evita formular promesas médicas o reemplazar atención profesional.

### Swagger / OpenAPI

- Se actualizó `src/lib/swagger/openApiSpec.ts`.
- Se documentó `POST /api/rag/coach/ingest/dietas`.
- Se documentó `POST /api/dieta/rag-assistant/generar`.
- Se incorporaron ejemplos de payload para pruebas desde Swagger.

### Configuración

Se agregaron variables documentadas en `.env.example`:

```env
RAG_DIET_MATCH_THRESHOLD=0.3
RAG_DIET_MATCH_COUNT=8
```

Para QA local con corpus chico se validó correctamente usando en `.env.local`:

```env
RAG_DIET_MATCH_THRESHOLD=0.0
```

Ese valor queda recomendado solo para pruebas locales con pocos chunks vectorizados.

## Archivos modificados

```txt
.env.example
docs/rag/rag-coach-dietas-v1.md
src/app/api/dieta/rag-assistant/generar/route.ts
src/app/api/rag/coach/ingest/dietas/route.ts
src/app/dashboard/dietas/page.tsx
src/components/forms/DietaForm.tsx
src/components/tables/DietaHistorial.tsx
src/interfaces/ragCoach.interface.ts
src/interfaces/ragDietasAssistant.interface.ts
src/lib/swagger/openApiSpec.ts
src/services/apiClient.ts
src/services/server/ragCoachIngestionService.ts
src/services/server/ragCoachSearchService.ts
src/services/server/ragDietasCoachService.ts
```

## Base de datos

No se agregaron migraciones nuevas.

La feature usa las tablas ya creadas por `feature/rag-coach-architecture-foundation`:

```txt
rag_document
rag_document_chunk
match_rag_chunks
```

Además utiliza datos reales ya existentes:

```txt
comida_base
dieta
objetivo
socio
usuario
```

Estado usado como referencia para validación:

```txt
rag_document: 100
rag_document_chunk: 35
dietas: 125
comida_base: 28
objetivo: 10
socio: 144
usuario: 151
```

## Validaciones realizadas

- Build productivo con `npm run build`.
- Validación de ingesta de reglas nutricionales desde Swagger.
- Validación de generación de dieta desde Swagger.
- Validación de generación de dieta desde `/dashboard/dietas`.
- Validación de RAG con referencias nutricionales aplicadas.
- Validación de disclaimers y advertencias de seguridad.
- Validación de dieta creada por administrador para un socio.
- Validación de visibilidad posterior desde login del socio.
- Corrección de error 403 por consulta indebida a `/api/socios` desde usuario socio.
- Corrección de historial usando `socio_id`.
- Validación de refresco automático del historial sin salir del menú.
- Validación de que no se agregaron migraciones SQL ni archivos privados.

## Pruebas sugeridas post-merge

1. Login como admin.
2. Ejecutar `POST /api/rag/coach/ingest/dietas` con límite bajo.
3. Generar dieta desde `POST /api/dieta/rag-assistant/generar` para un socio real.
4. Generar dieta desde `/dashboard/dietas`.
5. Verificar que el historial se actualiza automáticamente.
6. Login como socio y verificar que ve sus dietas.
7. Validar que no aparece `GET /api/socios 403` en consola.
8. Revisar que el botón `Ver` muestra el plan alimentario.

## Resultado

La feature queda lista para merge. Gym Master ahora cuenta con una primera versión funcional del RAG Coach aplicado a dietas, con integración real al módulo existente, seguridad nutricional básica, visibilidad correcta por socio y experiencia de usuario mejorada.

## Próximo paso recomendado

Luego de esta feature, el roadmap RAG puede continuar con:

```txt
feature/rag-coach-evolucion-fisica-v1
```

Ese paso completaría el tercer pilar del RAG Coach: rutinas, dietas y evolución física.
