### PR TITLE
feat: complete rag coach corpus ingestion

### DIFF
--- a/docs/rag/rag-coach-corpus-ingestion-final.md
+++ b/docs/rag/rag-coach-corpus-ingestion-final.md
@@ -1,0 +1,70 @@
+# Gym Master - RAG Coach Corpus Ingestion Final
+
+## Rama
+
+`feature/rag-coach-corpus-ingestion-final`
+
+## Objetivo
+
+Completar la operación de ingesta real y controlada del corpus RAG de Gym Master, con estado administrativo, tandas pequeñas, delay configurable y continuidad segura ante límites 429 del proveedor de embeddings.
+
+## Alcance
+
+- Estado detallado del corpus RAG.
+- Contadores por dominio.
+- Cobertura de ejercicios activos vs ejercicios indexados.
+- Cobertura de reglas nutricionales vs reglas indexadas.
+- Chunks activos, vectorizados y pendientes.
+- Ejecución de tandas de ingesta y vectorización desde API y panel admin.
+- Reintentos suaves ante fallos temporales del proveedor de embeddings.
+- Recomendaciones operativas para continuar la carga.
+
+## Endpoints nuevos
+
+- `GET /api/rag/coach/corpus/status`
+- `POST /api/rag/coach/corpus/run`
+
+## Pantalla nueva
+
+- `/dashboard/rag-corpus`
+
+## Acciones soportadas
+
+- `ingest_exercises`: ingesta ejercicios activos.
+- `ingest_diet_rules`: ingesta reglas nutricionales desde `comida_base`.
+- `vectorize_pending`: vectoriza chunks activos pendientes.
+- `all`: ejecuta tanda completa chica.
+
+## Recomendación de uso
+
+Para GitHub Models se recomienda:
+
+```json
+{
+  "action": "vectorize_pending",
+  "limit": 10,
+  "delayMs": 1000,
+  "force": false,
+  "maxRetries": 1,
+  "retryDelayMs": 1500
+}
+```
+
+Si aparece rate limit 429, no se debe forzar carga masiva. Se espera y luego se continúa con `vectorize_pending`.
+
+## Seguridad
+
+- Solo admin puede administrar el corpus.
+- No se agregan migraciones SQL.
+- No se exponen tokens ni secretos.
+- No se indexan datos privados del socio.
+
+## Validación esperada
+
+1. Entrar como admin.
+2. Ir a `/dashboard/rag-corpus`.
+3. Consultar estado actual del corpus.
+4. Ejecutar una tanda chica de vectorización pendiente.
+5. Ejecutar una tanda chica de ingesta de ejercicios o dietas.
+6. Verificar actualización de contadores.
+7. Validar desde Swagger los endpoints nuevos.

--- a/src/app/api/rag/coach/corpus/run/route.ts
+++ b/src/app/api/rag/coach/corpus/run/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { runRagCorpusBatch } from '@/services/server/ragCorpusAdminService';
+
+export const dynamic = 'force-dynamic';
+
+function getAuthStatus(error: any) {
+  const message = error?.message ?? '';
+  if (message.includes('Token no proporcionado') || message.includes('Token inválido')) return 401;
+  if (message.includes('No autorizado')) return 403;
+  return 500;
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await authMiddleware(request);
+    const payload = await request.json().catch(() => ({}));
+    const result = await runRagCorpusBatch(user, payload);
+    return NextResponse.json(result, { status: result.ok ? 200 : 207 });
+  } catch (error: any) {
+    const status = getAuthStatus(error);
+    if (status === 500) console.error('Error al ejecutar tanda de corpus RAG:', error);
+    return NextResponse.json(
+      { ok: false, error: error?.message ?? 'Error al ejecutar tanda de corpus RAG.' },
+      { status },
+    );
+  }
+}

--- a/src/app/api/rag/coach/corpus/status/route.ts
+++ b/src/app/api/rag/coach/corpus/status/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getRagCorpusStatus } from '@/services/server/ragCorpusAdminService';
+
+export const dynamic = 'force-dynamic';
+
+function getAuthStatus(error: any) {
+  const message = error?.message ?? '';
+  if (message.includes('Token no proporcionado') || message.includes('Token inválido')) return 401;
+  if (message.includes('No autorizado')) return 403;
+  return 500;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { user } = await authMiddleware(request);
+    const status = await getRagCorpusStatus(user);
+    return NextResponse.json(status, { status: 200 });
+  } catch (error: any) {
+    const status = getAuthStatus(error);
+    if (status === 500) console.error('Error al consultar estado del corpus RAG:', error);
+    return NextResponse.json(
+      { ok: false, error: error?.message ?? 'Error al consultar estado del corpus RAG.' },
+      { status },
+    );
+  }
+}

--- a/src/app/dashboard/rag-corpus/page.tsx
+++ b/src/app/dashboard/rag-corpus/page.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Activity, Database, Loader2, Play, RefreshCw, ShieldAlert } from 'lucide-react';
+
+import { AppFooter } from '@/components/footer/AppFooter';
+import { AppHeader } from '@/components/header/AppHeader';
+import { AppSidebar } from '@/components/sidebar/AppSidebar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import type { RagCorpusBatchAction, RagCorpusBatchResponse, RagCorpusStatusResponse } from '@/interfaces/ragCorpus.interface';
+import { getRagCorpusStatusClient, runRagCorpusBatchClient } from '@/services/ragCorpusAdminClient';
+
+const actionLabels: Record<RagCorpusBatchAction, string> = {
+  ingest_exercises: 'Ingestar ejercicios',
+  ingest_diet_rules: 'Ingestar dietas',
+  vectorize_pending: 'Vectorizar pendientes',
+  all: 'Tanda completa',
+};
+
+function progressPercent(indexed: number, total: number) {
+  if (!total) return 0;
+  return Math.round((indexed / total) * 100);
+}
+
+function StatusCard({ title, value, hint }: { title: string; value: number | string; hint?: string }) {
+  return (
+    <Card className="p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{title}</p>
+      <p className="mt-2 text-3xl font-bold text-slate-950">{value}</p>
+      {hint ? <p className="mt-1 text-xs text-muted-foreground">{hint}</p> : null}
+    </Card>
+  );
+}
+
+export default function RagCorpusPage() {
+  const [status, setStatus] = useState<RagCorpusStatusResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [runningAction, setRunningAction] = useState<RagCorpusBatchAction | null>(null);
+  const [lastRun, setLastRun] = useState<RagCorpusBatchResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [limit, setLimit] = useState(10);
+  const [delayMs, setDelayMs] = useState(1000);
+
+  const exercisesPercent = useMemo(
+    () => progressPercent(status?.sources.indexedExercises ?? 0, status?.sources.activeExercises ?? 0),
+    [status],
+  );
+
+  const dietPercent = useMemo(
+    () => progressPercent(status?.sources.indexedDietRules ?? 0, status?.sources.dietRules ?? 0),
+    [status],
+  );
+
+  const loadStatus = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getRagCorpusStatusClient();
+      setStatus(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo consultar estado del corpus.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadStatus();
+  }, []);
+
+  const runAction = async (action: RagCorpusBatchAction) => {
+    setRunningAction(action);
+    setError(null);
+    try {
+      const result = await runRagCorpusBatchClient({
+        action,
+        limit,
+        delayMs,
+        force: false,
+        onlyMissing: true,
+      });
+      setLastRun(result);
+      if (result.status) setStatus(result.status);
+      else await loadStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo ejecutar la tanda RAG.');
+    } finally {
+      setRunningAction(null);
+    }
+  };
+
+  return (
+    <SidebarProvider>
+      <div className="flex min-h-screen w-full">
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader title="RAG Corpus" />
+          <main className="flex-1 space-y-6 p-6">
+            <Card className="border-cyan-100 bg-white p-6 shadow-sm">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <Database className="h-6 w-6 text-cyan-600" />
+                    <h1 className="text-2xl font-bold text-slate-950">Estado del corpus RAG</h1>
+                  </div>
+                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                    Panel administrativo para continuar la ingesta real del corpus del Coach IA por tandas controladas, con delay, pendientes y manejo seguro de límites 429.
+                  </p>
+                </div>
+
+                <Button type="button" variant="outline" onClick={loadStatus} disabled={loading || Boolean(runningAction)}>
+                  {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+                  Actualizar
+                </Button>
+              </div>
+            </Card>
+
+            {error ? (
+              <Card className="border-red-200 bg-red-50 p-4 text-sm text-red-800">
+                <div className="flex items-center gap-2 font-semibold">
+                  <ShieldAlert className="h-4 w-4" />
+                  {error}
+                </div>
+              </Card>
+            ) : null}
+
+            {status ? (
+              <>
+                <div className="grid gap-4 md:grid-cols-5">
+                  <StatusCard title="Documentos" value={status.totals.documents} />
+                  <StatusCard title="Chunks" value={status.totals.chunks} />
+                  <StatusCard title="Vectorizados" value={status.totals.embeddedChunks} />
+                  <StatusCard title="Pendientes" value={status.totals.pendingChunks} />
+                  <StatusCard title="Dominios" value={status.domains.filter((domain) => domain.documents > 0).length} />
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <Card className="p-5">
+                    <h2 className="font-semibold text-slate-950">Cobertura ejercicios</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {status.sources.indexedExercises} de {status.sources.activeExercises} ejercicios activos indexados.
+                    </p>
+                    <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-100">
+                      <div className="h-full bg-cyan-600" style={{ width: `${exercisesPercent}%` }} />
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{exercisesPercent}%</p>
+                  </Card>
+
+                  <Card className="p-5">
+                    <h2 className="font-semibold text-slate-950">Cobertura dietas</h2>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      {status.sources.indexedDietRules} de {status.sources.dietRules} reglas nutricionales indexadas.
+                    </p>
+                    <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-100">
+                      <div className="h-full bg-lime-600" style={{ width: `${dietPercent}%` }} />
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{dietPercent}%</p>
+                  </Card>
+                </div>
+
+                <Card className="p-5">
+                  <h2 className="mb-3 flex items-center gap-2 font-semibold text-slate-950">
+                    <Activity className="h-5 w-5 text-cyan-600" />
+                    Ejecutar tandas controladas
+                  </h2>
+
+                  <div className="grid gap-3 md:grid-cols-4">
+                    <label className="text-sm">
+                      <span className="mb-1 block font-medium">Límite</span>
+                      <input
+                        type="number"
+                        min={1}
+                        max={100}
+                        value={limit}
+                        onChange={(event) => setLimit(Number(event.target.value))}
+                        className="w-full rounded-md border px-3 py-2"
+                      />
+                    </label>
+                    <label className="text-sm">
+                      <span className="mb-1 block font-medium">Delay ms</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={5000}
+                        step={250}
+                        value={delayMs}
+                        onChange={(event) => setDelayMs(Number(event.target.value))}
+                        className="w-full rounded-md border px-3 py-2"
+                      />
+                    </label>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {(Object.keys(actionLabels) as RagCorpusBatchAction[]).map((action) => (
+                      <Button key={action} type="button" onClick={() => runAction(action)} disabled={Boolean(runningAction)}>
+                        {runningAction === action ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Play className="mr-2 h-4 w-4" />}
+                        {actionLabels[action]}
+                      </Button>
+                    ))}
+                  </div>
+
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    Recomendado para GitHub Models: tandas chicas, por ejemplo límite 10 y delay 1000 ms. Si aparece 429, continuar luego con “Vectorizar pendientes”.
+                  </p>
+                </Card>
+
+                <Card className="p-5">
+                  <h2 className="mb-3 font-semibold text-slate-950">Dominios del corpus</h2>
+                  <div className="overflow-x-auto">
+                    <table className="w-full min-w-[720px] text-left text-sm">
+                      <thead className="bg-slate-50 text-xs uppercase text-muted-foreground">
+                        <tr>
+                          <th className="px-3 py-2">Dominio</th>
+                          <th className="px-3 py-2">Documentos</th>
+                          <th className="px-3 py-2">Chunks</th>
+                          <th className="px-3 py-2">Vectorizados</th>
+                          <th className="px-3 py-2">Pendientes</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {status.domains.map((domain) => (
+                          <tr key={domain.domain} className="border-b">
+                            <td className="px-3 py-2 font-medium">{domain.domain}</td>
+                            <td className="px-3 py-2">{domain.documents}</td>
+                            <td className="px-3 py-2">{domain.chunks}</td>
+                            <td className="px-3 py-2">{domain.embeddedChunks}</td>
+                            <td className="px-3 py-2">{domain.pendingChunks}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </Card>
+
+                {status.recommendations.length > 0 ? (
+                  <Card className="p-5">
+                    <h2 className="mb-2 font-semibold text-slate-950">Recomendaciones</h2>
+                    <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                      {status.recommendations.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </Card>
+                ) : null}
+              </>
+            ) : loading ? (
+              <Card className="p-6 text-sm text-muted-foreground">Cargando estado del corpus...</Card>
+            ) : null}
+
+            {lastRun ? (
+              <Card className="p-5">
+                <h2 className="mb-2 font-semibold text-slate-950">Última ejecución</h2>
+                <pre className="max-h-80 overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-50">
+                  {JSON.stringify(lastRun, null, 2)}
+                </pre>
+              </Card>
+            ) : null}
+          </main>
+          <AppFooter />
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -119,6 +119,11 @@ export const sections: SidebarSectionType[] = [
         link: "/dashboard/rutinas/media",
         level: 2,
       },
+      {
+        title: "RAG Corpus",
+        link: "/dashboard/rag-corpus",
+        level: 2,
+      },
       { title: "Pagos", link: "/dashboard/pagos", level: 2 },
       { title: "Comercial / Kiosco", link: "/dashboard/comercial", level: 2 },
       { title: "Ventas", link: "/dashboard/ventas", level: 2 },

--- a/src/interfaces/ragCoach.interface.ts
+++ b/src/interfaces/ragCoach.interface.ts
@@ -65,6 +65,8 @@ export interface RagIngestExercisesRequest {
   force?: boolean;
   onlyMissing?: boolean;
   delayMs?: number;
+  maxRetries?: number;
+  retryDelayMs?: number;
 }
 
 export interface RagIngestExercisesResponse {
@@ -81,6 +83,8 @@ export interface RagIngestDietRulesRequest {
   force?: boolean;
   onlyMissing?: boolean;
   delayMs?: number;
+  maxRetries?: number;
+  retryDelayMs?: number;
 }
 
 export interface RagIngestDietRulesResponse {
@@ -96,6 +100,8 @@ export interface RagVectorizePendingRequest {
   limit?: number;
   force?: boolean;
   delayMs?: number;
+  maxRetries?: number;
+  retryDelayMs?: number;
 }
 
 export interface RagVectorizePendingResponse {

--- a/src/interfaces/ragCorpus.interface.ts
+++ b/src/interfaces/ragCorpus.interface.ts
@@ -1,0 +1,58 @@
+export type RagCorpusBatchAction =
+  | 'ingest_exercises'
+  | 'ingest_diet_rules'
+  | 'vectorize_pending'
+  | 'all';
+
+export type RagCorpusDomainStatus = {
+  domain: string;
+  documents: number;
+  chunks: number;
+  embeddedChunks: number;
+  pendingChunks: number;
+};
+
+export type RagCorpusStatusResponse = {
+  ok: boolean;
+  generatedAt: string;
+  totals: {
+    documents: number;
+    chunks: number;
+    activeChunks: number;
+    embeddedChunks: number;
+    pendingChunks: number;
+  };
+  sources: {
+    activeExercises: number;
+    indexedExercises: number;
+    dietRules: number;
+    indexedDietRules: number;
+  };
+  domains: RagCorpusDomainStatus[];
+  recommendations: string[];
+  warnings: string[];
+};
+
+export type RagCorpusBatchRequest = {
+  action: RagCorpusBatchAction;
+  limit?: number;
+  force?: boolean;
+  onlyMissing?: boolean;
+  delayMs?: number;
+  maxRetries?: number;
+  retryDelayMs?: number;
+};
+
+export type RagCorpusBatchStep = {
+  action: Exclude<RagCorpusBatchAction, 'all'>;
+  ok: boolean;
+  result: unknown;
+};
+
+export type RagCorpusBatchResponse = {
+  ok: boolean;
+  action: RagCorpusBatchAction;
+  steps: RagCorpusBatchStep[];
+  status?: RagCorpusStatusResponse;
+  warnings: string[];
+};

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -166,6 +166,13 @@ export const MENU_PERMISSION_GROUPS: Array<{
         roles: ["admin", "usuario"],
       },
       {
+        key: "RAG Corpus",
+        label: "RAG Corpus",
+        path: "/dashboard/rag-corpus",
+        group: "Administración",
+        roles: ["admin"],
+      },
+      {
         key: "Pagos",
         label: "Pagos",
         path: "/dashboard/pagos",

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1795,6 +1795,34 @@ const endpointDefinitions: EndpointDefinition[] = [
     source: "src/app/api/swagger-json/route.ts",
   },
   {
+    path: "/api/rag/coach/corpus/status",
+    methods: ["GET"],
+    tag: "RAG Coach",
+    summary: "Estado detallado del corpus RAG",
+    description:
+      "Devuelve contadores detallados del corpus RAG por dominio, chunks pendientes, cobertura de ejercicios y reglas nutricionales.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/corpus/status/route.ts",
+  },
+  {
+    path: "/api/rag/coach/corpus/run",
+    methods: ["POST"],
+    tag: "RAG Coach",
+    summary: "Ejecutar tanda controlada del corpus RAG",
+    description:
+      "Ejecuta una tanda de ingesta o vectorización del corpus RAG con límite y delay configurables para tolerar rate limits 429.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 207, 400, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/rag/coach/corpus/run/route.ts",
+  },
+  {
     path: "/api/rag/coach/status",
     methods: ["GET"],
     tag: "RAG Coach",
@@ -2309,6 +2337,27 @@ function getRequestBody(endpoint: EndpointDefinition, method: string) {
                 description: "Token QR recibido desde el lector o cámara.",
                 example: "qr_2026_05_23_abcd",
               },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  if (endpoint.path === "/api/rag/coach/corpus/run") {
+    return {
+      required: true,
+      content: {
+        "application/json": {
+          schema: { $ref: "#/components/schemas/RagCorpusBatchRequest" },
+          examples: {
+            vectorizar: {
+              summary: "Vectorizar pendientes",
+              value: { action: "vectorize_pending", limit: 10, delayMs: 1000, force: false },
+            },
+            completa: {
+              summary: "Tanda completa chica",
+              value: { action: "all", limit: 10, delayMs: 1000, force: false, onlyMissing: true },
             },
           },
         },
@@ -3263,6 +3312,23 @@ export const openApiSpec = {
             maxLength: 1200,
             example: "Prefiero pollo, arroz, verduras y comidas económicas.",
           },
+        },
+      },
+      RagCorpusBatchRequest: {
+        type: "object",
+        required: ["action"],
+        properties: {
+          action: {
+            type: "string",
+            enum: ["ingest_exercises", "ingest_diet_rules", "vectorize_pending", "all"],
+            example: "vectorize_pending",
+          },
+          limit: { type: "integer", minimum: 1, maximum: 100, example: 10 },
+          force: { type: "boolean", example: false },
+          onlyMissing: { type: "boolean", example: true },
+          delayMs: { type: "integer", minimum: 0, maximum: 5000, example: 1000 },
+          maxRetries: { type: "integer", minimum: 0, maximum: 3, example: 1 },
+          retryDelayMs: { type: "integer", minimum: 0, maximum: 5000, example: 1500 },
         },
       },
       RagCoachChatRequest: {

--- a/src/services/ragCorpusAdminClient.ts
+++ b/src/services/ragCorpusAdminClient.ts
@@ -1,0 +1,33 @@
+import type { RagCorpusBatchRequest, RagCorpusBatchResponse, RagCorpusStatusResponse } from '@/interfaces/ragCorpus.interface';
+import { getToken } from './storageService';
+
+function authHeaders() {
+  const token = getToken();
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function getRagCorpusStatusClient(): Promise<RagCorpusStatusResponse> {
+  const res = await fetch('/api/rag/coach/corpus/status', {
+    method: 'GET',
+    headers: authHeaders(),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || 'No se pudo consultar estado del corpus RAG.');
+  return data as RagCorpusStatusResponse;
+}
+
+export async function runRagCorpusBatchClient(payload: RagCorpusBatchRequest): Promise<RagCorpusBatchResponse> {
+  const res = await fetch('/api/rag/coach/corpus/run', {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok && res.status !== 207) throw new Error(data.error || 'No se pudo ejecutar tanda de corpus RAG.');
+  return data as RagCorpusBatchResponse;
+}

--- a/src/services/server/ragCoachIngestionService.ts
+++ b/src/services/server/ragCoachIngestionService.ts
@@ -14,6 +14,8 @@ import { createSingleRagEmbedding } from './ragEmbeddingProviderService';
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
 const MAX_DELAY_MS = 5000;
+const MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 1500;
 
 type ExerciseRow = Record<string, any>;
 type DietRuleRow = Record<string, any>;
@@ -51,6 +53,50 @@ function safeDelayMs(value?: number) {
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function safeRetries(value?: number) {
+  if (!Number.isInteger(value) || value === undefined || value < 0) return 1;
+  return Math.min(value, MAX_RETRIES);
+}
+
+function safeRetryDelayMs(value?: number) {
+  if (!Number.isInteger(value) || !value || value <= 0) return DEFAULT_RETRY_DELAY_MS;
+  return Math.min(value, MAX_DELAY_MS);
+}
+
+async function fetchIndexedSourceIds(domain: string, sourceTable: string) {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from('rag_document')
+    .select('source_id')
+    .eq('domain', domain)
+    .eq('source_table', sourceTable)
+    .eq('active', true);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? [])
+    .map((row) => String(row.source_id ?? '').trim())
+    .filter(Boolean);
+}
+
+async function runWithRetries<T>(fn: () => Promise<T>, retries: number, retryDelayMs: number): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= retries) break;
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Error desconocido al ejecutar reintento RAG.');
 }
 
 function hasCloudinary(row: ExerciseRow) {
@@ -140,9 +186,10 @@ function buildExerciseContent(row: ExerciseRow) {
   };
 }
 
-async function fetchExercises(limit: number) {
+async function fetchExercises(limit: number, onlyMissing: boolean) {
   const supabase = getSupabaseServerClient();
-  const { data, error } = await supabase
+  const indexedIds = onlyMissing ? await fetchIndexedSourceIds('exercise', 'ejercicio') : [];
+  let query = supabase
     .from('ejercicio')
     .select(
       `
@@ -178,7 +225,13 @@ async function fetchExercises(limit: number) {
       grupo_muscular:grupo_muscular!ejercicio_id_gm_fkey(nombre_gp)
     `,
     )
-    .eq('activo', true)
+    .eq('activo', true);
+
+  if (indexedIds.length > 0) {
+    query = query.not('id_ejercicio', 'in', `(${indexedIds.join(',')})`);
+  }
+
+  const { data, error } = await query
     .order('nombre_ejercicio', { ascending: true })
     .limit(limit);
 
@@ -225,9 +278,10 @@ function buildDietRuleContent(row: DietRuleRow) {
   };
 }
 
-async function fetchDietRules(limit: number) {
+async function fetchDietRules(limit: number, onlyMissing: boolean) {
   const supabase = getSupabaseServerClient();
-  const { data, error } = await supabase
+  const indexedIds = onlyMissing ? await fetchIndexedSourceIds('diet_rule', 'comida_base') : [];
+  let query = supabase
     .from('comida_base')
     .select(
       `
@@ -241,7 +295,13 @@ async function fetchDietRules(limit: number) {
       grasas_aprox,
       objetivo:objetivo!comida_base_objetivo_id_fkey(nombre_objetivo)
     `,
-    )
+    );
+
+  if (indexedIds.length > 0) {
+    query = query.not('id', 'in', `(${indexedIds.join(',')})`);
+  }
+
+  const { data, error } = await query
     .order('objetivo_id', { ascending: true })
     .order('tipo_comida', { ascending: true })
     .limit(limit);
@@ -253,7 +313,7 @@ async function fetchDietRules(limit: number) {
   return data ?? [];
 }
 
-async function upsertDietRuleDocument(row: DietRuleRow, force: boolean) {
+async function upsertDietRuleDocument(row: DietRuleRow, force: boolean, maxRetries: number, retryDelayMs: number) {
   const supabase = getSupabaseServerClient();
   const { content, metadata } = buildDietRuleContent(row);
   const contentHash = hashContent(content);
@@ -323,7 +383,7 @@ async function upsertDietRuleDocument(row: DietRuleRow, force: boolean) {
     throw new Error(chunkUpsertError.message);
   }
 
-  const embedding = await createSingleRagEmbedding(content);
+  const embedding = await runWithRetries(() => createSingleRagEmbedding(content), maxRetries, retryDelayMs);
 
   const { error: chunkVectorError } = await supabase
     .from('rag_document_chunk')
@@ -341,7 +401,7 @@ async function upsertDietRuleDocument(row: DietRuleRow, force: boolean) {
   return { indexed: true, skipped: false };
 }
 
-async function upsertExerciseDocument(row: ExerciseRow, force: boolean) {
+async function upsertExerciseDocument(row: ExerciseRow, force: boolean, maxRetries: number, retryDelayMs: number) {
   const supabase = getSupabaseServerClient();
   const { content, metadata } = buildExerciseContent(row);
   const contentHash = hashContent(content);
@@ -410,7 +470,7 @@ async function upsertExerciseDocument(row: ExerciseRow, force: boolean) {
     throw new Error(chunkUpsertError.message);
   }
 
-  const embedding = await createSingleRagEmbedding(content);
+  const embedding = await runWithRetries(() => createSingleRagEmbedding(content), maxRetries, retryDelayMs);
 
   const { error: chunkVectorError } = await supabase
     .from('rag_document_chunk')
@@ -436,7 +496,9 @@ export async function ingestExercisesForRag(
 
   const limit = safeLimit(payload.limit);
   const delayMs = safeDelayMs(payload.delayMs);
-  const exercises = await fetchExercises(limit);
+  const maxRetries = safeRetries(payload.maxRetries);
+  const retryDelayMs = safeRetryDelayMs(payload.retryDelayMs);
+  const exercises = await fetchExercises(limit, Boolean(payload.onlyMissing));
   const response: RagIngestExercisesResponse = {
     ok: true,
     processed: exercises.length,
@@ -449,7 +511,7 @@ export async function ingestExercisesForRag(
   for (let index = 0; index < exercises.length; index += 1) {
     const exercise = exercises[index];
     try {
-      const result = await upsertExerciseDocument(exercise, Boolean(payload.force));
+      const result = await upsertExerciseDocument(exercise, Boolean(payload.force), maxRetries, retryDelayMs);
       if (result.indexed) response.indexed += 1;
       if (result.skipped) response.skipped += 1;
     } catch (error: any) {
@@ -474,7 +536,9 @@ export async function ingestDietRulesForRag(
 
   const limit = safeLimit(payload.limit);
   const delayMs = safeDelayMs(payload.delayMs);
-  const dietRules = await fetchDietRules(limit);
+  const maxRetries = safeRetries(payload.maxRetries);
+  const retryDelayMs = safeRetryDelayMs(payload.retryDelayMs);
+  const dietRules = await fetchDietRules(limit, Boolean(payload.onlyMissing));
   const response: RagIngestDietRulesResponse = {
     ok: true,
     processed: dietRules.length,
@@ -487,7 +551,7 @@ export async function ingestDietRulesForRag(
   for (let index = 0; index < dietRules.length; index += 1) {
     const dietRule = dietRules[index];
     try {
-      const result = await upsertDietRuleDocument(dietRule, Boolean(payload.force));
+      const result = await upsertDietRuleDocument(dietRule, Boolean(payload.force), maxRetries, retryDelayMs);
       if (result.indexed) response.indexed += 1;
       if (result.skipped) response.skipped += 1;
     } catch (error: any) {
@@ -512,6 +576,8 @@ export async function vectorizePendingRagChunks(
 
   const limit = safeLimit(payload.limit);
   const delayMs = safeDelayMs(payload.delayMs);
+  const maxRetries = safeRetries(payload.maxRetries);
+  const retryDelayMs = safeRetryDelayMs(payload.retryDelayMs);
   const supabase = getSupabaseServerClient();
 
   let query = supabase
@@ -549,7 +615,7 @@ export async function vectorizePendingRagChunks(
         continue;
       }
 
-      const embedding = await createSingleRagEmbedding(content);
+      const embedding = await runWithRetries(() => createSingleRagEmbedding(content), maxRetries, retryDelayMs);
       response.provider = embedding.provider;
       response.model = embedding.model;
 

--- a/src/services/server/ragCorpusAdminService.ts
+++ b/src/services/server/ragCorpusAdminService.ts
@@ -1,0 +1,210 @@
+import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import type {
+  RagCorpusBatchAction,
+  RagCorpusBatchRequest,
+  RagCorpusBatchResponse,
+  RagCorpusBatchStep,
+  RagCorpusDomainStatus,
+  RagCorpusStatusResponse,
+} from '@/interfaces/ragCorpus.interface';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
+import {
+  ingestDietRulesForRag,
+  ingestExercisesForRag,
+  vectorizePendingRagChunks,
+} from './ragCoachIngestionService';
+
+const DOMAINS = ['exercise', 'diet_rule', 'routine_rule', 'safety', 'evolution', 'business', 'general'];
+
+function normalizeRole(role?: string | null) {
+  return role?.trim().toLowerCase() ?? '';
+}
+
+function assertAdmin(user: JwtUser) {
+  const role = normalizeRole(user.rol);
+  if (role !== 'admin' && role !== 'administrador') {
+    throw new Error('No autorizado para administrar el corpus RAG.');
+  }
+}
+
+async function safeCount(table: string, filters?: (query: any) => any) {
+  const supabase = getSupabaseServerClient();
+  let query = supabase.from(table).select('*', { count: 'exact', head: true });
+  if (filters) query = filters(query);
+  const { count, error } = await query;
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+async function countChunksForDomain(domain: string, embedded: 'all' | 'embedded' | 'pending') {
+  const supabase = getSupabaseServerClient();
+  let query = supabase
+    .from('rag_document_chunk')
+    .select('id, rag_document!inner(domain)', { count: 'exact', head: true })
+    .eq('active', true)
+    .eq('rag_document.domain', domain);
+
+  if (embedded === 'embedded') query = query.not('embedding', 'is', null);
+  if (embedded === 'pending') query = query.is('embedding', null);
+
+  const { count, error } = await query;
+  if (error) throw new Error(error.message);
+  return count ?? 0;
+}
+
+async function getDomainStatus(domain: string): Promise<RagCorpusDomainStatus> {
+  const [documents, chunks, embeddedChunks, pendingChunks] = await Promise.all([
+    safeCount('rag_document', (query) => query.eq('domain', domain).eq('active', true)),
+    countChunksForDomain(domain, 'all'),
+    countChunksForDomain(domain, 'embedded'),
+    countChunksForDomain(domain, 'pending'),
+  ]);
+
+  return {
+    domain,
+    documents,
+    chunks,
+    embeddedChunks,
+    pendingChunks,
+  };
+}
+
+function buildRecommendations(status: Omit<RagCorpusStatusResponse, 'recommendations' | 'warnings' | 'ok' | 'generatedAt'>) {
+  const recommendations: string[] = [];
+  const missingExercises = Math.max(status.sources.activeExercises - status.sources.indexedExercises, 0);
+  const missingDietRules = Math.max(status.sources.dietRules - status.sources.indexedDietRules, 0);
+
+  if (missingExercises > 0) {
+    recommendations.push(`Faltan indexar aproximadamente ${missingExercises} ejercicios activos.`);
+  }
+
+  if (missingDietRules > 0) {
+    recommendations.push(`Faltan indexar aproximadamente ${missingDietRules} reglas nutricionales.`);
+  }
+
+  if (status.totals.pendingChunks > 0) {
+    recommendations.push(`Hay ${status.totals.pendingChunks} chunks activos pendientes de vectorizar. Ejecutar vectorización por tandas.`);
+  }
+
+  if (recommendations.length === 0) {
+    recommendations.push('El corpus base de ejercicios y dietas no muestra pendientes principales. Mantener monitoreo por dominio.');
+  }
+
+  return recommendations;
+}
+
+export async function getRagCorpusStatus(user: JwtUser): Promise<RagCorpusStatusResponse> {
+  assertAdmin(user);
+
+  const [
+    documents,
+    chunks,
+    activeChunks,
+    embeddedChunks,
+    pendingChunks,
+    activeExercises,
+    indexedExercises,
+    dietRules,
+    indexedDietRules,
+    domains,
+  ] = await Promise.all([
+    safeCount('rag_document', (query) => query.eq('active', true)),
+    safeCount('rag_document_chunk'),
+    safeCount('rag_document_chunk', (query) => query.eq('active', true)),
+    safeCount('rag_document_chunk', (query) => query.eq('active', true).not('embedding', 'is', null)),
+    safeCount('rag_document_chunk', (query) => query.eq('active', true).is('embedding', null)),
+    safeCount('ejercicio', (query) => query.eq('activo', true)),
+    safeCount('rag_document', (query) => query.eq('domain', 'exercise').eq('source_table', 'ejercicio').eq('active', true)),
+    safeCount('comida_base'),
+    safeCount('rag_document', (query) => query.eq('domain', 'diet_rule').eq('source_table', 'comida_base').eq('active', true)),
+    Promise.all(DOMAINS.map(getDomainStatus)),
+  ]);
+
+  const base = {
+    totals: {
+      documents,
+      chunks,
+      activeChunks,
+      embeddedChunks,
+      pendingChunks,
+    },
+    sources: {
+      activeExercises,
+      indexedExercises,
+      dietRules,
+      indexedDietRules,
+    },
+    domains,
+  };
+
+  return {
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    ...base,
+    recommendations: buildRecommendations(base),
+    warnings: pendingChunks > 0 ? ['Existen chunks pendientes sin embedding.'] : [],
+  };
+}
+
+function normalizeAction(value?: string): RagCorpusBatchAction {
+  if (
+    value === 'ingest_exercises' ||
+    value === 'ingest_diet_rules' ||
+    value === 'vectorize_pending' ||
+    value === 'all'
+  ) {
+    return value;
+  }
+
+  return 'vectorize_pending';
+}
+
+async function runStep(
+  user: JwtUser,
+  action: Exclude<RagCorpusBatchAction, 'all'>,
+  payload: RagCorpusBatchRequest,
+): Promise<RagCorpusBatchStep> {
+  if (action === 'ingest_exercises') {
+    const result = await ingestExercisesForRag(user, payload);
+    return { action, ok: result.ok, result };
+  }
+
+  if (action === 'ingest_diet_rules') {
+    const result = await ingestDietRulesForRag(user, payload);
+    return { action, ok: result.ok, result };
+  }
+
+  const result = await vectorizePendingRagChunks(user, payload);
+  return { action: 'vectorize_pending', ok: result.ok, result };
+}
+
+export async function runRagCorpusBatch(
+  user: JwtUser,
+  payload: RagCorpusBatchRequest,
+): Promise<RagCorpusBatchResponse> {
+  assertAdmin(user);
+
+  const action = normalizeAction(payload.action);
+  const actions: Array<Exclude<RagCorpusBatchAction, 'all'>> = action === 'all'
+    ? ['ingest_exercises', 'ingest_diet_rules', 'vectorize_pending']
+    : [action];
+
+  const steps: RagCorpusBatchStep[] = [];
+  for (const stepAction of actions) {
+    steps.push(await runStep(user, stepAction, payload));
+  }
+
+  const status = await getRagCorpusStatus(user).catch(() => undefined);
+  const warnings: string[] = [];
+  if (steps.some((step) => !step.ok)) {
+    warnings.push('Una o más tandas finalizaron con errores parciales. Revisar detalle y continuar con vectorización pendiente.');
+  }
+
+  return {
+    ok: steps.every((step) => step.ok),
+    action,
+    steps,
+    status,
+    warnings,
+  };
+}


### PR DESCRIPTION
# PR - Gym Master - RAG Coach Corpus Ingestion Final

## Rama

`feature/rag-coach-corpus-ingestion-final`

## Resumen

Esta feature completa la administración operativa del corpus RAG de Gym Master, permitiendo controlar desde UI/Admin la ingesta real de ejercicios y reglas nutricionales, vectorizar chunks pendientes, consultar estado por dominio y continuar cargas por tandas sin duplicar documentos.

La rama deja el corpus base listo para demo y producción inicial usando OpenAI embeddings (`text-embedding-3-small`) sobre el carril vectorial de 1536 dimensiones.

## Objetivo funcional

- Administrar la carga del corpus RAG desde el panel interno.
- Evitar cargas manuales inseguras o dependientes de SQL.
- Permitir tandas controladas de ingesta y vectorización.
- Ver cobertura de ejercicios y dietas en tiempo real.
- Mantener trazabilidad de documentos, chunks, vectorizados y pendientes.
- Dejar el RAG listo para el Coach IA, rutinas, dietas y evolución física.

## Cambios principales

### UI Admin

- Se agrega pantalla administrativa:

`/dashboard/rag-corpus`

La pantalla permite:

- Consultar estado general del corpus.
- Ver documentos, chunks, vectorizados, pendientes y dominios.
- Ver cobertura de ejercicios activos y reglas nutricionales.
- Ejecutar tandas controladas de ingesta.
- Vectorizar pendientes.
- Ejecutar tanda completa.

### API

Se agregan endpoints:

- `GET /api/rag/coach/corpus/status`
- `POST /api/rag/coach/corpus/run`

Acciones soportadas:

- `ingest_exercises`
- `ingest_diet_rules`
- `vectorize_pending`
- `all`

### Servicios

Se incorpora lógica server-side para:

- Estado agregado del corpus.
- Métricas por dominio.
- Conteo de documentos/chunks/vectorizados/pendientes.
- Cobertura de ejercicios y dietas.
- Ejecución de tandas controladas.
- Continuidad de ingesta con `onlyMissing` sin repetir siempre los primeros registros.

### Swagger / OpenAPI

Se documentan los endpoints nuevos del corpus RAG para validación técnica.

### Documentación técnica

Se agrega documentación en:

`docs/rag/rag-coach-corpus-ingestion-final.md`

## Estado final validado

El corpus base fue completado exitosamente con OpenAI embeddings.

| Métrica | Resultado |
|---|---:|
| Documentos RAG | 1007 |
| Chunks RAG | 942 |
| Chunks vectorizados | 942 |
| Chunks pendientes | 0 |
| Ejercicios indexados | 979 / 979 |
| Reglas nutricionales indexadas | 28 / 28 |

### Dominios

| Dominio | Documentos | Chunks | Vectorizados | Pendientes |
|---|---:|---:|---:|---:|
| `exercise` | 979 | 914 | 914 | 0 |
| `diet_rule` | 28 | 28 | 28 | 0 |
| `routine_rule` | 0 | 0 | 0 | 0 |
| `safety` | 0 | 0 | 0 | 0 |
| `evolution` | 0 | 0 | 0 | 0 |
| `business` | 0 | 0 | 0 | 0 |
| `general` | 0 | 0 | 0 | 0 |

## Provider final utilizado

Se decidió usar OpenAI embeddings para demo y producción inicial.

Configuración objetivo:

```env
RAG_ENABLED=true
EMBEDDING_PROVIDER=openai
OPENAI_EMBEDDING_MODEL=text-embedding-3-small
RAG_VECTOR_DIMENSIONS=1536
RAG_VECTOR_TABLE=rag_document_chunk
RAG_VECTOR_RPC=match_rag_chunks
```

GitHub Models queda pausado por rate limit 429. Ollama queda como alternativa local/back-up, no como provider principal de demo o producción inicial.

## Fixes incluidos durante la rama

- Fix TypeScript por valores opcionales en pantalla `/dashboard/rag-corpus`.
- Limpieza de texto residual `TS` en `page.tsx`.
- Corrección de ingesta `onlyMissing` para que avance sobre registros faltantes y no repita siempre los primeros ejercicios.
- Ajuste pendiente/recomendado de texto UI para no hablar específicamente de GitHub Models cuando el provider activo es OpenAI.

## Seguridad

- No se agregan SQL ni migraciones públicas.
- No se versionan API keys ni tokens.
- `.env.local` mantiene secretos fuera del repositorio.
- El token de GitHub debe quedar revocado/reemplazado si fue expuesto durante pruebas.
- OpenAI API Key debe permanecer solo en `.env.local` y variables de entorno de Vercel.

## Validaciones realizadas

- Build Next.js validado con `npm run build` después de fixes.
- Pantalla `/dashboard/rag-corpus` operativa.
- Vectorización pendiente con OpenAI validada.
- Ingesta completa de ejercicios validada.
- Ingesta completa de reglas nutricionales validada.
- Estado final con `pendingChunks = 0`.
- Cobertura final: ejercicios 100% y dietas 100%.

## Checklist de cierre

- [x] UI admin de corpus RAG creada.
- [x] Endpoints de estado y ejecución creados.
- [x] Swagger actualizado.
- [x] Documentación técnica agregada.
- [x] Ingesta de ejercicios completada.
- [x] Ingesta de reglas nutricionales completada.
- [x] Vectorización completada con OpenAI.
- [x] Pendientes en cero.
- [x] Sin SQL ni secretos versionados.

## Próxima feature sugerida

`feature/admin-socio-menu-reorganization`

Objetivo: reorganizar el menú de administración y socio en submenús por áreas funcionales, sin perder ningún módulo ni funcionalidad existente.
