### PR TITLE
feat: add equipment preventive plans and technical orders

### DIFF
--- a/docs/infraestructura/equipamientos-preventivos-ordenes-tecnicas-v1.md
+++ b/docs/infraestructura/equipamientos-preventivos-ordenes-tecnicas-v1.md
@@ -1,0 +1,31 @@
+# Gym Master - Infraestructura / Equipamientos Preventivos + Órdenes Técnicas v1
+
+## Rama
+
+`feature/infraestructura-equipamientos-preventivos-ordenes-tecnicas`
+
+## Objetivo
+
+Madurar el módulo de Equipamientos dentro de Infraestructura incorporando planes preventivos, tareas técnicas, órdenes técnicas, historial y métricas operativas.
+
+## Alcance
+
+- Nueva pantalla `/dashboard/infraestructura/equipamientos/preventivos`.
+- Nuevo ítem de menú `Infraestructura > Preventivos Equipos`.
+- Dashboard con métricas de planes, órdenes abiertas, vencidas, equipos fuera de servicio, equipos en mantenimiento, costo mensual y downtime abierto.
+- CRUD rápido de planes preventivos.
+- Tareas técnicas por plan.
+- Creación de órdenes técnicas asociadas a equipamientos.
+- Cierre de órdenes técnicas.
+- Actualización del estado del equipamiento al crear/cerrar órdenes.
+- Historial técnico del equipamiento.
+- Swagger actualizado.
+
+## Sin alcance en esta fase
+
+- Repuestos y stock técnico.
+- QR específico de equipamientos.
+- BI profundo de fallas/downtime.
+- Predicción avanzada de fallas.
+
+Estos puntos quedan preparados para futuras fases.

--- a/src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts
+++ b/src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { updateEquipamientoOrdenTecnica } from '@/services/server/equipamientoPreventivoService';
+
+export const dynamic = 'force-dynamic';
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const orden = await updateEquipamientoOrdenTecnica(id, body);
+    return NextResponse.json({ message: 'Orden técnica actualizada con éxito', data: orden }, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error?.message || 'Error al actualizar orden técnica.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/equipamientos/preventivos/ordenes/route.ts
+++ b/src/app/api/equipamientos/preventivos/ordenes/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { createEquipamientoOrdenTecnica } from '@/services/server/equipamientoPreventivoService';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const orden = await createEquipamientoOrdenTecnica(body);
+    return NextResponse.json({ message: 'Orden técnica creada con éxito', data: orden }, { status: 201 });
+  } catch (error: any) {
+    const message = error?.message || 'Error al crear orden técnica.';
+    const status = message.includes('obligatorio') || message.includes('Seleccioná') ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/api/equipamientos/preventivos/planes/route.ts
+++ b/src/app/api/equipamientos/preventivos/planes/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { createEquipamientoPlanPreventivo } from '@/services/server/equipamientoPreventivoService';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const plan = await createEquipamientoPlanPreventivo(body);
+    return NextResponse.json({ message: 'Plan preventivo creado con éxito', data: plan }, { status: 201 });
+  } catch (error: any) {
+    const message = error?.message || 'Error al crear plan preventivo.';
+    return NextResponse.json({ error: message }, { status: message.includes('obligatorio') ? 400 : 500 });
+  }
+}

--- a/src/app/api/equipamientos/preventivos/route.ts
+++ b/src/app/api/equipamientos/preventivos/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { getEquipamientosPreventivosDashboard } from '@/services/server/equipamientoPreventivoService';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const dashboard = await getEquipamientosPreventivosDashboard();
+    return NextResponse.json(dashboard, { status: 200 });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error?.message || 'Error al consultar preventivos de equipamientos.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/dashboard/infraestructura/equipamientos/preventivos/page.tsx
+++ b/src/app/dashboard/infraestructura/equipamientos/preventivos/page.tsx
@@ -1,0 +1,490 @@
+'use client';
+
+import type { FormEvent, ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CalendarClock,
+  CheckCircle2,
+  ClipboardCheck,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Wrench,
+} from 'lucide-react';
+
+import { AppFooter } from '@/components/footer/AppFooter';
+import { AppHeader } from '@/components/header/AppHeader';
+import { AppSidebar } from '@/components/sidebar/AppSidebar';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import type {
+  CreateEquipamientoOrdenTecnicaDTO,
+  CreateEquipamientoPlanPreventivoDTO,
+  EquipamientoOrdenTecnica,
+  EquipamientoPreventivosDashboard,
+} from '@/interfaces/equipamientoPreventivo.interface';
+import {
+  createEquipamientoOrdenTecnicaClient,
+  createEquipamientoPlanPreventivoClient,
+  getEquipamientosPreventivosDashboardClient,
+  updateEquipamientoOrdenTecnicaClient,
+} from '@/services/equipamientoPreventivoClient';
+
+const currencyFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+  maximumFractionDigits: 0,
+});
+
+function formatCurrency(value?: number | null) {
+  return currencyFormatter.format(Number(value ?? 0));
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value).slice(0, 10);
+  return date.toLocaleDateString('es-AR');
+}
+
+function labelFromValue(value?: string | null) {
+  if (!value) return '-';
+  return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function MetricCard({
+  title,
+  value,
+  helper,
+  tone = 'slate',
+}: {
+  title: string;
+  value: string | number;
+  helper?: string;
+  tone?: 'red' | 'amber' | 'blue' | 'emerald' | 'slate' | 'violet';
+}) {
+  const tones = {
+    red: 'border-red-100 bg-red-50 text-red-900',
+    amber: 'border-amber-100 bg-amber-50 text-amber-900',
+    blue: 'border-blue-100 bg-blue-50 text-blue-900',
+    emerald: 'border-emerald-100 bg-emerald-50 text-emerald-900',
+    slate: 'border-slate-100 bg-white text-slate-950',
+    violet: 'border-violet-100 bg-violet-50 text-violet-900',
+  };
+
+  return (
+    <Card className={`p-4 shadow-sm ${tones[tone]}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] opacity-70">{title}</p>
+      <p className="mt-2 text-3xl font-bold">{value}</p>
+      {helper ? <p className="mt-1 text-xs opacity-75">{helper}</p> : null}
+    </Card>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="space-y-1 text-sm font-medium text-slate-700">
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function SelectField({
+  value,
+  onChange,
+  children,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  children: ReactNode;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+    >
+      {children}
+    </select>
+  );
+}
+
+export default function EquipamientosPreventivosPage() {
+  const [dashboard, setDashboard] = useState<EquipamientoPreventivosDashboard | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const [planForm, setPlanForm] = useState<CreateEquipamientoPlanPreventivoDTO>({
+    nombre: '',
+    tipo_equipamiento: '',
+    frecuencia_dias: 90,
+    criticidad: 'media',
+    descripcion: '',
+    tareas: [''],
+  });
+
+  const [ordenForm, setOrdenForm] = useState<CreateEquipamientoOrdenTecnicaDTO>({
+    id_equipamiento: '',
+    plan_id: '',
+    tipo_orden: 'preventivo',
+    prioridad: 'media',
+    titulo: '',
+    fecha_programada: '',
+    fecha_vencimiento: '',
+    tecnico_responsable: '',
+    costo_estimado: null,
+    descripcion: '',
+  });
+
+  const loadDashboard = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getEquipamientosPreventivosDashboardClient();
+      setDashboard(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo cargar preventivos de equipamientos.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDashboard();
+  }, []);
+
+  const activeOrders = useMemo(
+    () => (dashboard?.ordenes ?? []).filter((orden) => orden.activo !== false && !['completada', 'cancelada'].includes(String(orden.estado))),
+    [dashboard],
+  );
+
+  const registerSuccess = async (message: string) => {
+    setSuccess(message);
+    await loadDashboard();
+    setTimeout(() => setSuccess(null), 3500);
+  };
+
+  const handleCreatePlan = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaving('plan');
+    setError(null);
+    try {
+      await createEquipamientoPlanPreventivoClient({
+        ...planForm,
+        tareas: (planForm.tareas ?? []).map((tarea) => String(tarea).trim()).filter(Boolean),
+      });
+      setPlanForm({ nombre: '', tipo_equipamiento: '', frecuencia_dias: 90, criticidad: 'media', descripcion: '', tareas: [''] });
+      await registerSuccess('Plan preventivo creado correctamente.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo crear el plan preventivo.');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleCreateOrden = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaving('orden');
+    setError(null);
+    try {
+      await createEquipamientoOrdenTecnicaClient({
+        ...ordenForm,
+        plan_id: ordenForm.plan_id || null,
+        fecha_programada: ordenForm.fecha_programada || null,
+        fecha_vencimiento: ordenForm.fecha_vencimiento || null,
+        costo_estimado: ordenForm.costo_estimado ? Number(ordenForm.costo_estimado) : null,
+      });
+      setOrdenForm({ id_equipamiento: '', plan_id: '', tipo_orden: 'preventivo', prioridad: 'media', titulo: '', fecha_programada: '', fecha_vencimiento: '', tecnico_responsable: '', costo_estimado: null, descripcion: '' });
+      await registerSuccess('Orden técnica creada correctamente.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo crear la orden técnica.');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const completeOrder = async (orden: EquipamientoOrdenTecnica) => {
+    setSaving(orden.id);
+    setError(null);
+    try {
+      await updateEquipamientoOrdenTecnicaClient(orden.id, {
+        estado: 'completada',
+        resultado: 'Orden técnica completada desde panel de preventivos.',
+        costo_real: orden.costo_estimado ?? null,
+        downtime_fin: orden.downtime_inicio ? new Date().toISOString() : null,
+      });
+      await registerSuccess('Orden técnica completada y equipamiento actualizado.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo completar la orden técnica.');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const updatePlanTask = (index: number, value: string) => {
+    setPlanForm((prev) => ({
+      ...prev,
+      tareas: (prev.tareas ?? ['']).map((tarea, idx) => (idx === index ? value : tarea)),
+    }));
+  };
+
+  return (
+    <SidebarProvider>
+      <div className="flex min-h-screen w-full">
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader title="Preventivos de Equipamientos" />
+          <main className="flex-1 space-y-6 p-6">
+            <Card className="border-sky-100 bg-white p-6 shadow-sm">
+              <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <Wrench className="h-6 w-6 text-sky-600" />
+                    <h1 className="text-2xl font-bold text-slate-950">Infraestructura / Preventivos de Equipamientos</h1>
+                  </div>
+                  <p className="mt-2 max-w-4xl text-sm text-muted-foreground">
+                    Planes preventivos, órdenes técnicas, historial y downtime para madurar el mantenimiento de máquinas y aparatos del gimnasio.
+                  </p>
+                </div>
+                <Button type="button" variant="outline" onClick={loadDashboard} disabled={loading || Boolean(saving)}>
+                  {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+                  Actualizar
+                </Button>
+              </div>
+            </Card>
+
+            {error ? (
+              <Card className="border-red-200 bg-red-50 p-4 text-sm text-red-800">
+                <div className="flex gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4" />
+                  <span>{error}</span>
+                </div>
+              </Card>
+            ) : null}
+
+            {success ? (
+              <Card className="border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800">
+                <div className="flex gap-2">
+                  <CheckCircle2 className="h-4 w-4" />
+                  <span>{success}</span>
+                </div>
+              </Card>
+            ) : null}
+
+            <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+              <MetricCard title="Planes" value={dashboard?.metricas.totalPlanes ?? 0} helper="Preventivos" tone="blue" />
+              <MetricCard title="Órdenes abiertas" value={dashboard?.metricas.ordenesAbiertas ?? 0} helper="Pendientes" tone="violet" />
+              <MetricCard title="Vencidas" value={dashboard?.metricas.ordenesVencidas ?? 0} helper="Atención" tone="amber" />
+              <MetricCard title="Fuera servicio" value={dashboard?.metricas.equiposFueraServicio ?? 0} helper="Equipos" tone="red" />
+              <MetricCard title="En mantenimiento" value={dashboard?.metricas.equiposEnMantenimiento ?? 0} helper="Seguimiento" />
+              <MetricCard title="Costo mes" value={formatCurrency(dashboard?.metricas.costoTecnicoMes)} helper="Técnico" tone="emerald" />
+            </section>
+
+            <section className="grid gap-6 xl:grid-cols-2">
+              <Card className="p-5">
+                <div className="mb-4 flex items-center gap-2">
+                  <ClipboardCheck className="h-5 w-5 text-sky-600" />
+                  <h2 className="text-lg font-semibold">Nuevo plan preventivo</h2>
+                </div>
+                <form className="space-y-3" onSubmit={handleCreatePlan}>
+                  <Field label="Nombre del plan">
+                    <Input value={planForm.nombre} onChange={(e) => setPlanForm((prev) => ({ ...prev, nombre: e.target.value }))} placeholder="Preventivo cinta de correr, revisión multigym..." />
+                  </Field>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <Field label="Tipo de equipo">
+                      <Input value={planForm.tipo_equipamiento ?? ''} onChange={(e) => setPlanForm((prev) => ({ ...prev, tipo_equipamiento: e.target.value }))} placeholder="Cinta, bicicleta, banco..." />
+                    </Field>
+                    <Field label="Frecuencia días">
+                      <Input type="number" value={String(planForm.frecuencia_dias ?? 90)} onChange={(e) => setPlanForm((prev) => ({ ...prev, frecuencia_dias: Number(e.target.value) }))} />
+                    </Field>
+                  </div>
+                  <Field label="Criticidad">
+                    <SelectField value={String(planForm.criticidad ?? 'media')} onChange={(value) => setPlanForm((prev) => ({ ...prev, criticidad: value }))}>
+                      <option value="baja">Baja</option>
+                      <option value="media">Media</option>
+                      <option value="alta">Alta</option>
+                      <option value="critica">Crítica</option>
+                    </SelectField>
+                  </Field>
+                  <Field label="Tareas técnicas">
+                    <div className="space-y-2">
+                      {(planForm.tareas ?? ['']).map((tarea, index) => (
+                        <Input key={index} value={tarea} onChange={(e) => updatePlanTask(index, e.target.value)} placeholder={`Tarea ${index + 1}`} />
+                      ))}
+                      <Button type="button" variant="outline" size="sm" onClick={() => setPlanForm((prev) => ({ ...prev, tareas: [...(prev.tareas ?? []), ''] }))}>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Agregar tarea
+                      </Button>
+                    </div>
+                  </Field>
+                  <Field label="Descripción">
+                    <textarea
+                      value={planForm.descripcion ?? ''}
+                      onChange={(e) => setPlanForm((prev) => ({ ...prev, descripcion: e.target.value }))}
+                      className="min-h-[78px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      placeholder="Detalle técnico del plan..."
+                    />
+                  </Field>
+                  <Button className="w-full" type="submit" disabled={saving === 'plan'}>
+                    {saving === 'plan' ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />}
+                    Crear plan preventivo
+                  </Button>
+                </form>
+              </Card>
+
+              <Card className="p-5">
+                <div className="mb-4 flex items-center gap-2">
+                  <Wrench className="h-5 w-5 text-violet-600" />
+                  <h2 className="text-lg font-semibold">Nueva orden técnica</h2>
+                </div>
+                <form className="space-y-3" onSubmit={handleCreateOrden}>
+                  <Field label="Equipamiento">
+                    <SelectField value={ordenForm.id_equipamiento} onChange={(value) => setOrdenForm((prev) => ({ ...prev, id_equipamiento: value }))}>
+                      <option value="">Seleccionar equipo</option>
+                      {(dashboard?.equipos ?? []).map((equipo) => <option key={equipo.id} value={equipo.id}>{equipo.nombre}</option>)}
+                    </SelectField>
+                  </Field>
+                  <Field label="Plan preventivo">
+                    <SelectField value={String(ordenForm.plan_id ?? '')} onChange={(value) => setOrdenForm((prev) => ({ ...prev, plan_id: value }))}>
+                      <option value="">Sin plan / correctivo manual</option>
+                      {(dashboard?.planes ?? []).map((plan) => <option key={plan.id} value={plan.id}>{plan.nombre}</option>)}
+                    </SelectField>
+                  </Field>
+                  <Field label="Título">
+                    <Input value={ordenForm.titulo} onChange={(e) => setOrdenForm((prev) => ({ ...prev, titulo: e.target.value }))} placeholder="Revisión cinta 1, ajuste polea, cambio tapizado..." />
+                  </Field>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <Field label="Tipo">
+                      <SelectField value={String(ordenForm.tipo_orden ?? 'preventivo')} onChange={(value) => setOrdenForm((prev) => ({ ...prev, tipo_orden: value }))}>
+                        <option value="preventivo">Preventivo</option>
+                        <option value="correctivo">Correctivo</option>
+                        <option value="inspeccion">Inspección</option>
+                        <option value="reparacion">Reparación</option>
+                        <option value="limpieza_tecnica">Limpieza técnica</option>
+                        <option value="cambio_pieza">Cambio de pieza</option>
+                      </SelectField>
+                    </Field>
+                    <Field label="Prioridad">
+                      <SelectField value={String(ordenForm.prioridad ?? 'media')} onChange={(value) => setOrdenForm((prev) => ({ ...prev, prioridad: value }))}>
+                        <option value="baja">Baja</option>
+                        <option value="media">Media</option>
+                        <option value="alta">Alta</option>
+                        <option value="critica">Crítica</option>
+                      </SelectField>
+                    </Field>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <Field label="Programada">
+                      <Input type="date" value={ordenForm.fecha_programada ?? ''} onChange={(e) => setOrdenForm((prev) => ({ ...prev, fecha_programada: e.target.value }))} />
+                    </Field>
+                    <Field label="Vencimiento">
+                      <Input type="date" value={ordenForm.fecha_vencimiento ?? ''} onChange={(e) => setOrdenForm((prev) => ({ ...prev, fecha_vencimiento: e.target.value }))} />
+                    </Field>
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <Field label="Técnico / proveedor">
+                      <Input value={ordenForm.tecnico_responsable ?? ''} onChange={(e) => setOrdenForm((prev) => ({ ...prev, tecnico_responsable: e.target.value }))} />
+                    </Field>
+                    <Field label="Costo estimado">
+                      <Input type="number" value={ordenForm.costo_estimado ? String(ordenForm.costo_estimado) : ''} onChange={(e) => setOrdenForm((prev) => ({ ...prev, costo_estimado: e.target.value ? Number(e.target.value) : null }))} />
+                    </Field>
+                  </div>
+                  <Field label="Descripción">
+                    <textarea
+                      value={ordenForm.descripcion ?? ''}
+                      onChange={(e) => setOrdenForm((prev) => ({ ...prev, descripcion: e.target.value }))}
+                      className="min-h-[78px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                      placeholder="Trabajo requerido, falla detectada, repuestos previstos..."
+                    />
+                  </Field>
+                  <Button className="w-full" type="submit" disabled={saving === 'orden'}>
+                    {saving === 'orden' ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Plus className="mr-2 h-4 w-4" />}
+                    Crear orden técnica
+                  </Button>
+                </form>
+              </Card>
+            </section>
+
+            <section className="grid gap-6 xl:grid-cols-2">
+              <Card className="p-5">
+                <div className="mb-4 flex items-center gap-2">
+                  <CalendarClock className="h-5 w-5 text-violet-600" />
+                  <h2 className="text-lg font-semibold">Órdenes técnicas abiertas</h2>
+                </div>
+                <div className="space-y-3">
+                  {activeOrders.length === 0 ? (
+                    <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">Sin órdenes técnicas abiertas.</p>
+                  ) : (
+                    activeOrders.map((orden) => (
+                      <div key={orden.id} className="rounded-lg border p-3">
+                        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                          <div>
+                            <p className="font-semibold text-slate-950">{orden.titulo}</p>
+                            <p className="text-xs text-muted-foreground">{orden.equipamiento?.nombre ?? 'Sin equipo'} · {labelFromValue(orden.tipo_orden)} · Vence {formatDate(orden.fecha_vencimiento)}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">Técnico: {orden.tecnico_responsable ?? '-'} · Estimado: {formatCurrency(orden.costo_estimado)}</p>
+                            {orden.tareas?.length ? <p className="mt-1 text-xs text-muted-foreground">Tareas del plan: {orden.tareas.length}</p> : null}
+                          </div>
+                          <Button size="sm" variant="outline" onClick={() => completeOrder(orden)} disabled={saving === orden.id}>
+                            {saving === orden.id ? <Loader2 className="mr-2 h-3 w-3 animate-spin" /> : <CheckCircle2 className="mr-2 h-3 w-3" />}
+                            Completar
+                          </Button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </Card>
+
+              <Card className="p-5">
+                <div className="mb-4 flex items-center gap-2">
+                  <ClipboardCheck className="h-5 w-5 text-emerald-600" />
+                  <h2 className="text-lg font-semibold">Historial técnico reciente</h2>
+                </div>
+                <div className="space-y-3">
+                  {(dashboard?.historial ?? []).length === 0 ? (
+                    <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">Todavía no hay historial técnico registrado.</p>
+                  ) : (
+                    (dashboard?.historial ?? []).slice(0, 8).map((item) => (
+                      <div key={item.id} className="rounded-lg border p-3">
+                        <p className="font-semibold text-slate-950">{item.titulo}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{labelFromValue(item.tipo_evento)} · {formatDate(item.creado_en)} · {formatCurrency(item.costo)}</p>
+                        {item.detalle ? <p className="mt-1 text-xs text-muted-foreground">{item.detalle}</p> : null}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </Card>
+            </section>
+
+            <Card className="p-5">
+              <div className="mb-4 flex items-center gap-2">
+                <ClipboardCheck className="h-5 w-5 text-sky-600" />
+                <h2 className="text-lg font-semibold">Planes preventivos activos</h2>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {(dashboard?.planes ?? []).map((plan) => (
+                  <div key={plan.id} className="rounded-lg border p-3">
+                    <p className="font-semibold text-slate-950">{plan.nombre}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{plan.tipo_equipamiento ?? 'General'} · cada {plan.frecuencia_dias} días · {labelFromValue(plan.criticidad)}</p>
+                    {plan.tareas?.length ? (
+                      <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                        {plan.tareas.slice(0, 4).map((tarea) => <li key={tarea.id}>{tarea.descripcion}</li>)}
+                      </ul>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </main>
+          <AppFooter />
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -130,6 +130,11 @@ export const sections: SidebarSectionType[] = [
         level: 2,
       },
       { title: "Equipamientos", link: "/dashboard/equipamientos", level: 2 },
+      {
+        title: "Preventivos Equipos",
+        link: "/dashboard/infraestructura/equipamientos/preventivos",
+        level: 2,
+      },
     ],
   },
   {

--- a/src/interfaces/equipamientoPreventivo.interface.ts
+++ b/src/interfaces/equipamientoPreventivo.interface.ts
@@ -1,0 +1,153 @@
+import type { Equipamento } from '@/interfaces/equipamiento.interface';
+
+export type EquipamientoOrdenTecnicaTipo =
+  | 'preventivo'
+  | 'correctivo'
+  | 'inspeccion'
+  | 'reparacion'
+  | 'calibracion'
+  | 'limpieza_tecnica'
+  | 'cambio_pieza';
+
+export type EquipamientoOrdenTecnicaEstado =
+  | 'abierta'
+  | 'en_progreso'
+  | 'completada'
+  | 'cancelada'
+  | 'vencida';
+
+export type EquipamientoOrdenTecnicaPrioridad = 'baja' | 'media' | 'alta' | 'critica';
+
+export interface EquipamientoPlanPreventivo {
+  id: string;
+  codigo: string;
+  nombre: string;
+  descripcion?: string | null;
+  tipo_equipamiento?: string | null;
+  id_tipo_equipamiento?: string | null;
+  frecuencia_dias: number;
+  criticidad: EquipamientoOrdenTecnicaPrioridad | string;
+  activo: boolean;
+  creado_en?: string;
+  actualizado_en?: string;
+  tareas?: EquipamientoPlanTarea[];
+}
+
+export interface EquipamientoPlanTarea {
+  id: string;
+  plan_id: string;
+  descripcion: string;
+  orden: number;
+  requerido: boolean;
+  activo: boolean;
+}
+
+export interface EquipamientoOrdenTecnica {
+  id: string;
+  id_equipamiento: string;
+  plan_id?: string | null;
+  tipo_orden: EquipamientoOrdenTecnicaTipo | string;
+  prioridad: EquipamientoOrdenTecnicaPrioridad | string;
+  estado: EquipamientoOrdenTecnicaEstado | string;
+  titulo: string;
+  descripcion?: string | null;
+  fecha_programada?: string | null;
+  fecha_vencimiento?: string | null;
+  fecha_inicio?: string | null;
+  fecha_cierre?: string | null;
+  tecnico_responsable?: string | null;
+  costo_estimado?: number | null;
+  costo_real?: number | null;
+  resultado?: string | null;
+  observaciones?: string | null;
+  fotos_antes_urls?: string[] | null;
+  fotos_despues_urls?: string[] | null;
+  downtime_inicio?: string | null;
+  downtime_fin?: string | null;
+  registrado_por?: string | null;
+  activo: boolean;
+  creado_en?: string;
+  actualizado_en?: string;
+  equipamiento?: Equipamento | null;
+  plan?: EquipamientoPlanPreventivo | null;
+  tareas?: EquipamientoOrdenTarea[];
+}
+
+export interface EquipamientoOrdenTarea {
+  id: string;
+  orden_id: string;
+  descripcion: string;
+  estado: 'pendiente' | 'ok' | 'observado' | 'critico' | string;
+  observacion?: string | null;
+  orden: number;
+  activo: boolean;
+}
+
+export interface EquipamientoHistorialTecnico {
+  id: string;
+  id_equipamiento: string;
+  orden_id?: string | null;
+  tipo_evento: string;
+  titulo: string;
+  detalle?: string | null;
+  costo?: number | null;
+  creado_en?: string;
+}
+
+export interface EquipamientoPreventivosMetricas {
+  totalPlanes: number;
+  totalOrdenes: number;
+  ordenesAbiertas: number;
+  ordenesVencidas: number;
+  equiposFueraServicio: number;
+  equiposEnMantenimiento: number;
+  costoTecnicoMes: number;
+  downtimeAbierto: number;
+}
+
+export interface EquipamientoPreventivosDashboard {
+  generated_at: string;
+  equipos: Equipamento[];
+  planes: EquipamientoPlanPreventivo[];
+  ordenes: EquipamientoOrdenTecnica[];
+  historial: EquipamientoHistorialTecnico[];
+  metricas: EquipamientoPreventivosMetricas;
+}
+
+export interface CreateEquipamientoPlanPreventivoDTO {
+  nombre: string;
+  codigo?: string | null;
+  descripcion?: string | null;
+  tipo_equipamiento?: string | null;
+  id_tipo_equipamiento?: string | null;
+  frecuencia_dias?: number | null;
+  criticidad?: EquipamientoOrdenTecnicaPrioridad | string;
+  tareas?: string[];
+}
+
+export interface CreateEquipamientoOrdenTecnicaDTO {
+  id_equipamiento: string;
+  plan_id?: string | null;
+  tipo_orden?: EquipamientoOrdenTecnicaTipo | string;
+  prioridad?: EquipamientoOrdenTecnicaPrioridad | string;
+  titulo: string;
+  descripcion?: string | null;
+  fecha_programada?: string | null;
+  fecha_vencimiento?: string | null;
+  tecnico_responsable?: string | null;
+  costo_estimado?: number | null;
+  registrado_por?: string | null;
+}
+
+export interface UpdateEquipamientoOrdenTecnicaDTO {
+  estado?: EquipamientoOrdenTecnicaEstado | string;
+  resultado?: string | null;
+  observaciones?: string | null;
+  costo_real?: number | null;
+  fecha_inicio?: string | null;
+  fecha_cierre?: string | null;
+  fotos_antes_urls?: string[] | null;
+  fotos_despues_urls?: string[] | null;
+  downtime_inicio?: string | null;
+  downtime_fin?: string | null;
+}

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -178,6 +178,13 @@ export const MENU_PERMISSION_GROUPS: Array<{
         group: "Infraestructura",
         roles: ["admin", "usuario"],
       },
+      {
+        key: "Preventivos Equipos",
+        label: "Preventivos Equipos",
+        path: "/dashboard/infraestructura/equipamientos/preventivos",
+        group: "Infraestructura",
+        roles: ["admin", "usuario"],
+      },
     ],
   },
   {

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -19,6 +19,63 @@ type OpenApiPathItem = Record<string, OpenApiOperation>;
 const endpointDefinitions: EndpointDefinition[] = [
 
   {
+    path: "/api/equipamientos/preventivos",
+    methods: ["GET"],
+    tag: "Equipamientos",
+    summary: "Dashboard preventivos de equipamientos",
+    description:
+      "Devuelve planes preventivos, órdenes técnicas, historial técnico, equipos y métricas de mantenimiento preventivo de máquinas.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [200, 401, 500],
+    queryParams: [],
+    source: "src/app/api/equipamientos/preventivos/route.ts",
+  },
+  {
+    path: "/api/equipamientos/preventivos/planes",
+    methods: ["POST"],
+    tag: "Equipamientos",
+    summary: "Crear plan preventivo de equipamiento",
+    description:
+      "Crea un plan preventivo por tipo de máquina con tareas técnicas y frecuencia en días.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [201, 400, 401, 500],
+    queryParams: [],
+    source: "src/app/api/equipamientos/preventivos/planes/route.ts",
+  },
+  {
+    path: "/api/equipamientos/preventivos/ordenes",
+    methods: ["POST"],
+    tag: "Equipamientos",
+    summary: "Crear orden técnica de equipamiento",
+    description:
+      "Crea una orden técnica preventiva, correctiva, de inspección, reparación o cambio de pieza para un equipamiento.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [201, 400, 401, 500],
+    queryParams: [],
+    source: "src/app/api/equipamientos/preventivos/ordenes/route.ts",
+  },
+  {
+    path: "/api/equipamientos/preventivos/ordenes/{id}",
+    methods: ["PATCH"],
+    tag: "Equipamientos",
+    summary: "Actualizar orden técnica de equipamiento",
+    description:
+      "Permite completar una orden técnica, registrar resultado, costo real, downtime y actualizar próxima revisión del equipo.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [200, 400, 401, 500],
+    queryParams: [],
+    source: "src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts",
+  },
+
+  {
     path: "/api/infraestructura/mantenimiento-edilicio",
     methods: ["GET"],
     tag: "Infraestructura",

--- a/src/services/equipamientoPreventivoClient.ts
+++ b/src/services/equipamientoPreventivoClient.ts
@@ -1,0 +1,52 @@
+import type {
+  CreateEquipamientoOrdenTecnicaDTO,
+  CreateEquipamientoPlanPreventivoDTO,
+  EquipamientoOrdenTecnica,
+  EquipamientoPlanPreventivo,
+  EquipamientoPreventivosDashboard,
+  UpdateEquipamientoOrdenTecnicaDTO,
+} from '@/interfaces/equipamientoPreventivo.interface';
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload?.error || payload?.message || 'Error en preventivos de equipamientos.');
+  }
+  return payload as T;
+}
+
+export async function getEquipamientosPreventivosDashboardClient() {
+  return parseJsonResponse<EquipamientoPreventivosDashboard>(
+    await fetch('/api/equipamientos/preventivos', {
+      method: 'GET',
+      cache: 'no-store',
+    }),
+  );
+}
+
+export async function createEquipamientoPlanPreventivoClient(payload: CreateEquipamientoPlanPreventivoDTO) {
+  const response = await fetch('/api/equipamientos/preventivos/planes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseJsonResponse<{ message: string; data: EquipamientoPlanPreventivo }>(response);
+}
+
+export async function createEquipamientoOrdenTecnicaClient(payload: CreateEquipamientoOrdenTecnicaDTO) {
+  const response = await fetch('/api/equipamientos/preventivos/ordenes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseJsonResponse<{ message: string; data: EquipamientoOrdenTecnica }>(response);
+}
+
+export async function updateEquipamientoOrdenTecnicaClient(id: string, payload: UpdateEquipamientoOrdenTecnicaDTO) {
+  const response = await fetch(`/api/equipamientos/preventivos/ordenes/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return parseJsonResponse<{ message: string; data: EquipamientoOrdenTecnica }>(response);
+}

--- a/src/services/server/equipamientoPreventivoService.ts
+++ b/src/services/server/equipamientoPreventivoService.ts
@@ -1,0 +1,304 @@
+import { createClient } from '@supabase/supabase-js';
+import dayjs from 'dayjs';
+
+import type { Equipamento } from '@/interfaces/equipamiento.interface';
+import type {
+  CreateEquipamientoOrdenTecnicaDTO,
+  CreateEquipamientoPlanPreventivoDTO,
+  EquipamientoHistorialTecnico,
+  EquipamientoOrdenTecnica,
+  EquipamientoPlanPreventivo,
+  EquipamientoPreventivosDashboard,
+  UpdateEquipamientoOrdenTecnicaDTO,
+} from '@/interfaces/equipamientoPreventivo.interface';
+
+function getEquipamientoPreventivoClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY no está configurada para operar preventivos de equipamientos.');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+function normalizeCode(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80);
+}
+
+function daysUntil(value?: string | null) {
+  if (!value) return null;
+  const date = new Date(`${String(value).slice(0, 10)}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Math.ceil((date.getTime() - today.getTime()) / 86_400_000);
+}
+
+function nextRevisionDate(baseDate: string, frecuenciaDias?: number | null) {
+  return dayjs(baseDate).add(Number(frecuenciaDias || 90), 'day').format('YYYY-MM-DD');
+}
+
+function calculateMetricas(equipos: Equipamento[], ordenes: EquipamientoOrdenTecnica[], planes: EquipamientoPlanPreventivo[]) {
+  const now = new Date();
+  const month = now.getMonth();
+  const year = now.getFullYear();
+
+  const activeOrders = ordenes.filter((orden) => orden.activo !== false);
+  const costoTecnicoMes = activeOrders.reduce((total, orden) => {
+    const fechaBase = orden.fecha_cierre || orden.fecha_inicio || orden.fecha_programada || orden.creado_en;
+    const fecha = fechaBase ? new Date(fechaBase) : null;
+    if (!fecha || Number.isNaN(fecha.getTime())) return total;
+    if (fecha.getMonth() !== month || fecha.getFullYear() !== year) return total;
+    return total + Number(orden.costo_real ?? orden.costo_estimado ?? 0);
+  }, 0);
+
+  return {
+    totalPlanes: planes.filter((plan) => plan.activo !== false).length,
+    totalOrdenes: activeOrders.length,
+    ordenesAbiertas: activeOrders.filter((orden) => ['abierta', 'en_progreso'].includes(String(orden.estado))).length,
+    ordenesVencidas: activeOrders.filter((orden) => {
+      const vencimiento = daysUntil(orden.fecha_vencimiento);
+      return orden.estado === 'vencida' || (vencimiento !== null && vencimiento < 0 && orden.estado !== 'completada');
+    }).length,
+    equiposFueraServicio: equipos.filter((equipo) => String(equipo.estado).toLowerCase() === 'fuera de servicio').length,
+    equiposEnMantenimiento: equipos.filter((equipo) => String(equipo.estado).toLowerCase() === 'en mantenimiento').length,
+    costoTecnicoMes,
+    downtimeAbierto: activeOrders.filter((orden) => orden.downtime_inicio && !orden.downtime_fin && orden.estado !== 'completada').length,
+  };
+}
+
+export async function getEquipamientosPreventivosDashboard(): Promise<EquipamientoPreventivosDashboard> {
+  const supabase = getEquipamientoPreventivoClient();
+
+  const [equiposResult, planesResult, ordenesResult, historialResult] = await Promise.all([
+    supabase.from('equipamiento').select('*').eq('activo', true).order('nombre', { ascending: true }),
+    supabase
+      .from('equipamiento_plan_preventivo')
+      .select('*, tareas:equipamiento_plan_tarea(*)')
+      .eq('activo', true)
+      .order('nombre', { ascending: true }),
+    supabase
+      .from('equipamiento_orden_tecnica')
+      .select('*, equipamiento(*), plan:equipamiento_plan_preventivo(*), tareas:equipamiento_orden_tarea(*)')
+      .eq('activo', true)
+      .order('fecha_vencimiento', { ascending: true, nullsFirst: false })
+      .order('creado_en', { ascending: false })
+      .limit(120),
+    supabase
+      .from('equipamiento_historial_tecnico')
+      .select('*')
+      .order('creado_en', { ascending: false })
+      .limit(40),
+  ]);
+
+  const firstError = equiposResult.error || planesResult.error || ordenesResult.error || historialResult.error;
+  if (firstError) throw new Error(firstError.message);
+
+  const equipos = (equiposResult.data ?? []) as Equipamento[];
+  const planes = ((planesResult.data ?? []) as EquipamientoPlanPreventivo[]).map((plan) => ({
+    ...plan,
+    tareas: [...(plan.tareas ?? [])].sort((a, b) => Number(a.orden ?? 0) - Number(b.orden ?? 0)),
+  }));
+  const ordenes = ((ordenesResult.data ?? []) as EquipamientoOrdenTecnica[]).map((orden) => ({
+    ...orden,
+    tareas: [...(orden.tareas ?? [])].sort((a, b) => Number(a.orden ?? 0) - Number(b.orden ?? 0)),
+  }));
+  const historial = (historialResult.data ?? []) as EquipamientoHistorialTecnico[];
+
+  return {
+    generated_at: new Date().toISOString(),
+    equipos,
+    planes,
+    ordenes,
+    historial,
+    metricas: calculateMetricas(equipos, ordenes, planes),
+  };
+}
+
+export async function createEquipamientoPlanPreventivo(
+  payload: CreateEquipamientoPlanPreventivoDTO,
+): Promise<EquipamientoPlanPreventivo> {
+  const supabase = getEquipamientoPreventivoClient();
+  const nombre = String(payload.nombre ?? '').trim();
+  if (!nombre) throw new Error('El nombre del plan preventivo es obligatorio.');
+
+  const codigo = payload.codigo?.trim() || normalizeCode(nombre);
+  const frecuencia = Number(payload.frecuencia_dias || 90);
+
+  const { data, error } = await supabase
+    .from('equipamiento_plan_preventivo')
+    .insert({
+      codigo,
+      nombre,
+      descripcion: payload.descripcion || null,
+      tipo_equipamiento: payload.tipo_equipamiento || null,
+      id_tipo_equipamiento: payload.id_tipo_equipamiento || null,
+      frecuencia_dias: frecuencia,
+      criticidad: payload.criticidad || 'media',
+      activo: true,
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const tareas = (payload.tareas ?? [])
+    .map((tarea) => String(tarea ?? '').trim())
+    .filter(Boolean);
+
+  if (tareas.length > 0) {
+    const { error: tareasError } = await supabase.from('equipamiento_plan_tarea').insert(
+      tareas.map((descripcion, index) => ({
+        plan_id: data.id,
+        descripcion,
+        orden: (index + 1) * 10,
+        requerido: true,
+        activo: true,
+      })),
+    );
+    if (tareasError) throw new Error(tareasError.message);
+  }
+
+  return data as EquipamientoPlanPreventivo;
+}
+
+export async function createEquipamientoOrdenTecnica(
+  payload: CreateEquipamientoOrdenTecnicaDTO,
+): Promise<EquipamientoOrdenTecnica> {
+  const supabase = getEquipamientoPreventivoClient();
+  const titulo = String(payload.titulo ?? '').trim();
+  if (!titulo) throw new Error('El título de la orden técnica es obligatorio.');
+  if (!payload.id_equipamiento) throw new Error('Seleccioná un equipamiento para crear la orden técnica.');
+
+  let plan: EquipamientoPlanPreventivo | null = null;
+  if (payload.plan_id) {
+    const { data: planData, error: planError } = await supabase
+      .from('equipamiento_plan_preventivo')
+      .select('*, tareas:equipamiento_plan_tarea(*)')
+      .eq('id', payload.plan_id)
+      .maybeSingle();
+    if (planError) throw new Error(planError.message);
+    plan = planData as EquipamientoPlanPreventivo | null;
+  }
+
+  const fechaBase = payload.fecha_programada || new Date().toISOString().slice(0, 10);
+  const fechaVencimiento = payload.fecha_vencimiento || fechaBase;
+
+  const { data, error } = await supabase
+    .from('equipamiento_orden_tecnica')
+    .insert({
+      id_equipamiento: payload.id_equipamiento,
+      plan_id: payload.plan_id || null,
+      tipo_orden: payload.tipo_orden || (payload.plan_id ? 'preventivo' : 'correctivo'),
+      prioridad: payload.prioridad || plan?.criticidad || 'media',
+      estado: 'abierta',
+      titulo,
+      descripcion: payload.descripcion || null,
+      fecha_programada: fechaBase,
+      fecha_vencimiento: fechaVencimiento,
+      tecnico_responsable: payload.tecnico_responsable || null,
+      costo_estimado: payload.costo_estimado ?? null,
+      registrado_por: payload.registrado_por || null,
+      activo: true,
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const tareas = (plan?.tareas ?? []) as Array<{ descripcion: string; orden?: number | null }>;
+  if (tareas.length > 0) {
+    const { error: tareasError } = await supabase.from('equipamiento_orden_tarea').insert(
+      tareas.map((tarea, index) => ({
+        orden_id: data.id,
+        descripcion: tarea.descripcion,
+        orden: Number(tarea.orden ?? (index + 1) * 10),
+        estado: 'pendiente',
+        activo: true,
+      })),
+    );
+    if (tareasError) throw new Error(tareasError.message);
+  }
+
+  await supabase
+    .from('equipamiento')
+    .update({ estado: 'en mantenimiento', observaciones: `Orden técnica abierta: ${titulo}` })
+    .eq('id', payload.id_equipamiento);
+
+  await supabase.from('equipamiento_historial_tecnico').insert({
+    id_equipamiento: payload.id_equipamiento,
+    orden_id: data.id,
+    tipo_evento: 'orden_abierta',
+    titulo: `Orden técnica abierta: ${titulo}`,
+    detalle: payload.descripcion || null,
+    costo: payload.costo_estimado ?? null,
+  });
+
+  return data as EquipamientoOrdenTecnica;
+}
+
+export async function updateEquipamientoOrdenTecnica(
+  id: string,
+  payload: UpdateEquipamientoOrdenTecnicaDTO,
+): Promise<EquipamientoOrdenTecnica> {
+  const supabase = getEquipamientoPreventivoClient();
+  if (!id) throw new Error('ID de orden técnica inválido.');
+
+  const updatePayload: Record<string, unknown> = {
+    ...payload,
+    actualizado_en: new Date().toISOString(),
+  };
+
+  if (payload.estado === 'completada' && !payload.fecha_cierre) {
+    updatePayload.fecha_cierre = new Date().toISOString();
+  }
+
+  const { data, error } = await supabase
+    .from('equipamiento_orden_tecnica')
+    .update(updatePayload)
+    .eq('id', id)
+    .select('*, plan:equipamiento_plan_preventivo(*)')
+    .single();
+
+  if (error) throw new Error(error.message);
+  const orden = data as EquipamientoOrdenTecnica;
+
+  if (payload.estado === 'completada') {
+    const fechaCierre = String(updatePayload.fecha_cierre || new Date().toISOString()).slice(0, 10);
+    const frecuencia = Number(orden.plan?.frecuencia_dias || 90);
+    await supabase
+      .from('equipamiento')
+      .update({
+        estado: 'operativo',
+        ultima_revision: fechaCierre,
+        proxima_revision: nextRevisionDate(fechaCierre, frecuencia),
+        observaciones: payload.resultado || payload.observaciones || 'Orden técnica completada.',
+      })
+      .eq('id', orden.id_equipamiento);
+
+    await supabase.from('equipamiento_historial_tecnico').insert({
+      id_equipamiento: orden.id_equipamiento,
+      orden_id: orden.id,
+      tipo_evento: 'orden_completada',
+      titulo: `Orden técnica completada: ${orden.titulo}`,
+      detalle: payload.resultado || payload.observaciones || null,
+      costo: payload.costo_real ?? orden.costo_estimado ?? null,
+    });
+  }
+
+  return orden;
+}


### PR DESCRIPTION
# PR — Gym Master · Infraestructura / Equipamientos Preventivos + Órdenes Técnicas v1

## Rama

`feature/infraestructura-equipamientos-preventivos-ordenes-tecnicas`

## Objetivo

Madurar el módulo de **Equipamientos** dentro del bloque **Infraestructura**, incorporando planes preventivos, tareas técnicas, órdenes técnicas, historial y métricas operativas para máquinas y aparatos del gimnasio.

## Alcance implementado

- Nueva pantalla `/dashboard/infraestructura/equipamientos/preventivos`.
- Nuevo ítem de menú `Infraestructura > Preventivos Equipos`.
- Dashboard con métricas de:
  - Planes preventivos.
  - Órdenes abiertas.
  - Órdenes vencidas.
  - Equipos fuera de servicio.
  - Equipos en mantenimiento.
  - Costo técnico mensual.
  - Downtime abierto.
- Alta rápida de planes preventivos.
- Tareas técnicas por plan preventivo.
- Creación de órdenes técnicas por equipamiento.
- Tipos de orden:
  - Preventivo.
  - Correctivo.
  - Inspección.
  - Reparación.
  - Limpieza técnica.
  - Cambio de pieza.
- Cierre de órdenes técnicas.
- Actualización automática del estado del equipamiento:
  - Al crear orden: `en mantenimiento`.
  - Al completar orden: `operativo`.
- Recalculo de próxima revisión según frecuencia del plan.
- Historial técnico por equipo.
- Swagger actualizado.
- Documentación técnica agregada.

## Base de datos privada

Migración privada:

`202606172030_equipamientos_preventivos_ordenes_tecnicas_v1.sql`

Validación privada:

`validar_equipamientos_preventivos_ordenes_tecnicas_v1.sql`

Tablas agregadas:

- `equipamiento_plan_preventivo`
- `equipamiento_plan_tarea`
- `equipamiento_orden_tecnica`
- `equipamiento_orden_tarea`
- `equipamiento_historial_tecnico`

## Archivos principales modificados

- `src/interfaces/equipamientoPreventivo.interface.ts`
- `src/services/server/equipamientoPreventivoService.ts`
- `src/services/equipamientoPreventivoClient.ts`
- `src/app/api/equipamientos/preventivos/route.ts`
- `src/app/api/equipamientos/preventivos/planes/route.ts`
- `src/app/api/equipamientos/preventivos/ordenes/route.ts`
- `src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts`
- `src/app/dashboard/infraestructura/equipamientos/preventivos/page.tsx`
- `src/components/sidebar/sidebarConfig.ts`
- `src/lib/permissions/menuPermissions.ts`
- `src/lib/swagger/openApiSpec.ts`
- `docs/infraestructura/equipamientos-preventivos-ordenes-tecnicas-v1.md`

## Validación funcional realizada

- Creación de plan preventivo.
- Agregado de tareas técnicas al plan.
- Creación de orden técnica para un equipamiento.
- Cambio automático del equipo a `en mantenimiento`.
- Cierre de orden técnica.
- Cambio automático del equipo a `operativo`.
- Registro de historial técnico.
- Visualización de métricas.
- Build correcto.
- SQL privado separado del commit público.

## Nota sobre QR de equipamientos

Los equipamientos también deben tener QR. La base técnica de QR/barra ya soporta `equipamiento` como target type desde la feature anterior de Infraestructura. En esta v1 se priorizó preventivos y órdenes técnicas. La siguiente feature recomendada debe exponer QR por equipamiento en UI, etiquetas imprimibles y acceso rápido a ficha/historial/orden técnica desde el lector.

## Próximas fases sugeridas

1. `feature/infraestructura-equipamientos-qr-etiquetas-historial`:
   - QR por equipamiento.
   - Etiquetas imprimibles.
   - Resolución desde lector QR/barra.
   - Acceso a ficha técnica e historial.
   - Crear orden técnica desde QR.

2. Repuestos y stock técnico:
   - Repuestos por equipo.
   - Stock mínimo.
   - Proveedores técnicos.
   - Uso de repuestos en órdenes.

3. BI y predicción de fallas:
   - Downtime.
   - Top equipos con fallas.
   - Costo acumulado por equipo.
   - Riesgo de reemplazo.

## Checklist PR

- [x] Planes preventivos implementados.
- [x] Órdenes técnicas implementadas.
- [x] Historial técnico implementado.
- [x] Métricas operativas implementadas.
- [x] Swagger actualizado.
- [x] DB privada validada.
- [x] Sin SQL privado en commit público.
- [x] Próxima fase QR de equipamientos identificada.
