### PR TITLE
feat: add direct POS sale for packs and promotions

### DIFF
--- a/docs/comercial/comercial-pos-packs-promociones-direct-sale-v1.md
+++ b/docs/comercial/comercial-pos-packs-promociones-direct-sale-v1.md
@@ -1,0 +1,55 @@
+# Comercial POS packs promociones direct sale v1
+
+## Objetivo
+
+Cerrar el ciclo del POS/Kiosco permitiendo vender packs comerciales, promociones y cupones desde la misma pantalla rápida de venta y desde el scanner móvil.
+
+## Alcance
+
+- El POS carga packs disponibles para venta (`comercial_pack.disponible_pos = true`).
+- El buscador permite encontrar productos y packs.
+- El ingreso manual por código/SKU también acepta el código comercial del pack.
+- El scanner móvil agrega packs al carrito cuando recibe un evento `item_tipo = pack`.
+- El carrito acepta líneas de tipo `pack` además de producto y servicio.
+- Al confirmar la venta, el backend expande cada pack a sus productos/servicios internos.
+- Los productos incluidos en packs descuentan stock y registran movimientos de stock como una venta normal.
+- Los servicios incluidos en packs quedan registrados como líneas de servicio.
+- El precio final del pack se distribuye proporcionalmente entre sus ítems internos para mantener compatibilidad con `venta_detalle` actual.
+- El POS acepta cupón/promoción opcional y aplica descuentos automáticos para promociones de tipo `descuento_porcentaje` o `descuento_fijo`.
+- El uso del cupón incrementa `comercial_cupon.usos_actuales`.
+- La venta mantiene trazabilidad en `venta.observaciones` indicando packs y cupón aplicado.
+
+## Decisión técnica
+
+No se agrega migración DB en esta versión porque el modelo actual de `venta_detalle` ya soporta productos y servicios, pero no packs como línea directa. Para evitar romper restricciones y reportes existentes, el pack se trata como una entidad comercial de captura en POS, pero se persiste expandido en los ítems vendibles reales.
+
+Esto permite:
+
+- mantener compatibilidad con reportes y stock ledger;
+- evitar cambios destructivos sobre `venta_detalle`;
+- descontar stock correctamente;
+- dejar trazabilidad mediante observaciones y movimientos de stock.
+
+## Validación funcional
+
+1. Abrir `/dashboard/comercial/kiosco`.
+2. Ver métricas de packs POS y promociones.
+3. Buscar un pack por nombre o código.
+4. Agregar pack al carrito manualmente.
+5. Conectar scanner móvil.
+6. Escanear QR/código de pack.
+7. Confirmar que se agrega al carrito como Pack comercial.
+8. Ingresar cupón vigente si corresponde.
+9. Confirmar venta.
+10. Verificar que los productos del pack descuentan stock.
+11. Verificar movimientos en stock ledger.
+12. Imprimir ticket.
+13. Confirmar que la venta queda registrada con observaciones de pack/cupón.
+
+## Pendientes futuros
+
+- Modelo analítico específico `venta_pack` si se requiere reportar packs vendidos como entidad independiente.
+- Anulación inteligente con trazabilidad explícita de pack.
+- Reportes de rentabilidad por pack.
+- Promociones combinables/acumulables más avanzadas.
+- Venta a socio desde POS avanzado.

--- a/src/app/dashboard/comercial/kiosco/page.tsx
+++ b/src/app/dashboard/comercial/kiosco/page.tsx
@@ -8,6 +8,7 @@ import {
   CreditCard,
   Loader2,
   PackagePlus,
+  Percent,
   Printer,
   RefreshCw,
   Smartphone,
@@ -47,6 +48,9 @@ import {
 
 const initialDashboard: ComercialPosDashboard = {
   productos: [],
+  packs: [],
+  promociones: [],
+  cupones: [],
   stockPorUbicacion: [],
   ubicaciones: [],
   ventasRecientes: [],
@@ -57,17 +61,21 @@ const initialDashboard: ComercialPosDashboard = {
     itemsHoy: 0,
     productosDisponibles: 0,
     productosCriticos: 0,
+    packsDisponibles: 0,
+    promocionesActivas: 0,
   },
 };
 
 type CartItem = {
   key: string;
-  item_tipo: 'producto' | 'servicio';
+  item_tipo: 'producto' | 'servicio' | 'pack';
   producto_id?: string | null;
   servicio_id?: string | null;
+  pack_id?: string | null;
   nombre: string;
   sku?: string | null;
   codigo_barras?: string | null;
+  codigo?: string | null;
   precio_unitario: number;
   cantidad: number;
   descuento: number;
@@ -149,6 +157,7 @@ export default function ComercialKioscoPosPage() {
   const [clienteNombre, setClienteNombre] = useState('');
   const [clienteDocumento, setClienteDocumento] = useState('');
   const [metodoPago, setMetodoPago] = useState('efectivo');
+  const [cuponCodigo, setCuponCodigo] = useState('');
   const [lastSale, setLastSale] = useState<ComercialPosVentaResumen | null>(null);
   const [scannerSession, setScannerSession] = useState<ComercialScannerSession | null>(null);
   const [scannerLoading, setScannerLoading] = useState(false);
@@ -200,6 +209,15 @@ export default function ComercialKioscoPosPage() {
       )
       .slice(0, 80);
   }, [dashboard, searchTerm, ubicacionId]);
+
+  const filteredPacks = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    const packs = dashboard.packs.filter((pack) => pack.activo !== false && pack.disponible_pos !== false);
+    if (!query) return packs.slice(0, 30);
+    return packs
+      .filter((pack) => [pack.nombre, pack.codigo, pack.descripcion].filter(Boolean).some((value) => String(value).toLowerCase().includes(query)))
+      .slice(0, 30);
+  }, [dashboard.packs, searchTerm]);
 
   const cartTotals = useMemo(() => {
     const subtotal = cart.reduce((sum, item) => sum + item.cantidad * item.precio_unitario, 0);
@@ -279,6 +297,35 @@ export default function ComercialKioscoPosPage() {
     });
   }
 
+  function addPackToCart(pack: NonNullable<ComercialPosDashboard['packs']>[number]) {
+    if (!pack?.id) return;
+    if (pack.activo === false || pack.disponible_pos === false) {
+      toast.error('El pack no está disponible para POS');
+      return;
+    }
+    const key = `pack:${pack.id}`;
+    setCart((current) => {
+      const existing = current.find((item) => item.key === key);
+      if (existing) return current.map((item) => item.key === key ? { ...item, cantidad: item.cantidad + 1 } : item);
+      return [
+        ...current,
+        {
+          key,
+          item_tipo: 'pack',
+          producto_id: null,
+          servicio_id: null,
+          pack_id: pack.id,
+          nombre: pack.nombre,
+          codigo: pack.codigo,
+          precio_unitario: Number(pack.precio ?? 0),
+          cantidad: 1,
+          descuento: 0,
+          stockDisponible: 999999,
+        },
+      ];
+    });
+  }
+
   function updateCartQuantity(key: string, quantity: number) {
     setCart((current) =>
       current.map((item) => {
@@ -304,16 +351,23 @@ export default function ComercialKioscoPosPage() {
         .some((value) => String(value).toLowerCase() === query)
     );
 
-    if (!match) {
-      toast.error('No se encontró producto por código/SKU');
+    if (match) {
+      addToCart({
+        ...match,
+        stock_ubicacion: ubicacionId ? getStockForLocation(match.producto_id, ubicacionId, dashboard) : match.stock_total,
+      });
+      setBarcodeTerm('');
       return;
     }
 
-    addToCart({
-      ...match,
-      stock_ubicacion: ubicacionId ? getStockForLocation(match.producto_id, ubicacionId, dashboard) : match.stock_total,
-    });
-    setBarcodeTerm('');
+    const packMatch = dashboard.packs.find((pack) => String(pack.codigo ?? '').toLowerCase() === query && pack.disponible_pos !== false && pack.activo !== false);
+    if (packMatch) {
+      addPackToCart(packMatch);
+      setBarcodeTerm('');
+      return;
+    }
+
+    toast.error('No se encontró producto o pack por código/SKU');
   }
 
   async function handleSubmitSale() {
@@ -335,10 +389,12 @@ export default function ComercialKioscoPosPage() {
         metodo_pago: metodoPago as any,
         ubicacion_stock_id: ubicacionId,
         observaciones: 'Venta rápida POS/Kiosco',
+        cupon_codigo: cuponCodigo.trim() || null,
         items: cart.map((item) => ({
           item_tipo: item.item_tipo,
           producto_id: item.producto_id ?? null,
           servicio_id: item.servicio_id ?? null,
+          pack_id: item.pack_id ?? null,
           cantidad: item.cantidad,
           precio_unitario: item.precio_unitario,
           descuento: item.descuento,
@@ -348,6 +404,7 @@ export default function ComercialKioscoPosPage() {
       setCart([]);
       setClienteNombre('');
       setClienteDocumento('');
+      setCuponCodigo('');
       toast.success('Venta POS/Kiosco registrada');
       await loadDashboard();
     } catch (error: any) {
@@ -422,8 +479,14 @@ export default function ComercialKioscoPosPage() {
       } else if (event.item_tipo === 'servicio' && event.servicio_id) {
         addServiceToCart(event);
         toast.success(`Servicio agregado al carrito: ${event.item_nombre || event.codigo}`);
-      } else if (event.item_tipo === 'pack') {
-        toast.info(`Pack detectado: ${event.item_nombre || event.codigo}. La venta directa de packs queda para la integración POS avanzada.`);
+      } else if (event.item_tipo === 'pack' && event.pack_id) {
+        const pack = dashboard.packs.find((item) => item.id === event.pack_id);
+        if (!pack) {
+          toast.error(`Pack escaneado no disponible en el POS: ${event.item_nombre || event.codigo}`);
+        } else {
+          addPackToCart(pack);
+          toast.success(`Pack agregado al carrito: ${pack.nombre}`);
+        }
       } else if (event.tipo_resuelto === 'infraestructura') {
         toast.info(`Código recibido pero no es vendible en POS: ${event.item_nombre || event.codigo}`);
       } else {
@@ -515,7 +578,7 @@ export default function ComercialKioscoPosPage() {
                       <div>
                         <p className='text-xs font-semibold uppercase tracking-[0.24em] text-emerald-600'>Scanner móvil</p>
                         <h2 className='text-xl font-bold'>Celular conectado al POS</h2>
-                        <p className='mt-1 text-sm text-muted-foreground'>El celular envía códigos al carrito en tiempo casi real. Funciona con productos por SKU/barcode y QR internos de producto o servicio.</p>
+                        <p className='mt-1 text-sm text-muted-foreground'>El celular envía códigos al carrito en tiempo casi real. Funciona con productos por SKU/barcode, QR internos de producto/servicio y códigos de packs.</p>
                       </div>
                       <div className='flex flex-wrap gap-2'>
                         <Button variant='outline' onClick={pollScannerEvents}>Verificar ahora</Button>
@@ -546,11 +609,13 @@ export default function ComercialKioscoPosPage() {
               </section>
             )}
 
-            <section className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5'>
+            <section className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-7'>
               <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Ventas hoy</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.ventasHoy}</p></div><Store className='h-6 w-6 text-sky-600' /></CardContent></Card>
               <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Total hoy</p><p className='text-xl font-bold'>{loading ? '...' : formatCurrencyARS(dashboard.metricas.totalHoy)}</p></div><CreditCard className='h-6 w-6 text-emerald-600' /></CardContent></Card>
               <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Ítems hoy</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.itemsHoy}</p></div><ShoppingCart className='h-6 w-6 text-indigo-600' /></CardContent></Card>
-              <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Productos disp.</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.productosDisponibles}</p></div><PackagePlus className='h-6 w-6 text-violet-600' /></CardContent></Card>
+              <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Productos</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.productosDisponibles}</p></div><PackagePlus className='h-6 w-6 text-violet-600' /></CardContent></Card>
+              <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Packs POS</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.packsDisponibles}</p></div><PackagePlus className='h-6 w-6 text-fuchsia-600' /></CardContent></Card>
+              <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Promos</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.promocionesActivas}</p></div><Percent className='h-6 w-6 text-rose-600' /></CardContent></Card>
               <Card><CardContent className='flex items-center justify-between p-5'><div><p className='text-sm text-muted-foreground'>Críticos</p><p className='text-2xl font-bold'>{loading ? '...' : dashboard.metricas.productosCriticos}</p></div><Warehouse className='h-6 w-6 text-orange-600' /></CardContent></Card>
             </section>
 
@@ -560,10 +625,10 @@ export default function ComercialKioscoPosPage() {
                   <CardHeader>
                     <div className='grid grid-cols-1 gap-3 md:grid-cols-[1fr_220px] md:items-end'>
                       <div className='space-y-2'>
-                        <Label>Buscar producto</Label>
+                        <Label>Buscar producto o pack</Label>
                         <div className='relative'>
                           <Search className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
-                          <Input className='pl-9' value={searchTerm} placeholder='Nombre, SKU o código de barras...' onChange={(event) => setSearchTerm(event.target.value)} />
+                          <Input className='pl-9' value={searchTerm} placeholder='Nombre, SKU, código de barras o pack...' onChange={(event) => setSearchTerm(event.target.value)} />
                         </div>
                       </div>
                       <div className='space-y-2'>
@@ -578,7 +643,7 @@ export default function ComercialKioscoPosPage() {
                     <form className='mb-4 flex gap-2' onSubmit={handleBarcodeSubmit}>
                       <div className='relative flex-1'>
                         <Barcode className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
-                        <Input className='pl-9' value={barcodeTerm} placeholder='Escanear o pegar código/SKU y presionar Enter' onChange={(event) => setBarcodeTerm(event.target.value)} />
+                        <Input className='pl-9' value={barcodeTerm} placeholder='Escanear o pegar código/SKU/pack y presionar Enter' onChange={(event) => setBarcodeTerm(event.target.value)} />
                       </div>
                       <Button type='submit' variant='outline'>Agregar</Button>
                     </form>
@@ -601,6 +666,32 @@ export default function ComercialKioscoPosPage() {
                       ))}
                       {!loading && filteredProducts.length === 0 && <p className='text-sm text-muted-foreground'>No hay productos para mostrar.</p>}
                     </div>
+
+                    {filteredPacks.length > 0 && (
+                      <div className='mt-6 space-y-3'>
+                        <div className='flex items-center justify-between'>
+                          <h3 className='text-sm font-semibold uppercase tracking-[0.18em] text-fuchsia-700'>Packs / promociones vendibles</h3>
+                          <span className='text-xs text-muted-foreground'>Se expanden en productos/servicios al vender</span>
+                        </div>
+                        <div className='grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3'>
+                          {filteredPacks.map((pack) => (
+                            <button key={pack.id} type='button' className='rounded-xl border border-fuchsia-100 bg-fuchsia-50/40 p-4 text-left shadow-sm transition hover:border-fuchsia-300 hover:shadow-md' onClick={() => addPackToCart(pack)}>
+                              <div className='flex items-start justify-between gap-2'>
+                                <div>
+                                  <p className='font-semibold'>{pack.nombre}</p>
+                                  <p className='text-xs text-muted-foreground'>{pack.codigo} · {(pack.items ?? []).length} ítems</p>
+                                </div>
+                                <span className='rounded-full bg-fuchsia-100 px-2 py-1 text-xs text-fuchsia-700'>Pack</span>
+                              </div>
+                              <div className='mt-3 flex items-center justify-between'>
+                                <span className='text-lg font-bold'>{formatCurrencyARS(pack.precio)}</span>
+                                <span className='text-xs text-muted-foreground'>POS</span>
+                              </div>
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
                   </CardContent>
                 </Card>
 
@@ -645,13 +736,17 @@ export default function ComercialKioscoPosPage() {
                         {metodoPagoOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
                       </select>
                     </div>
+                    <div className='space-y-2'>
+                      <Label>Cupón / promo opcional</Label>
+                      <Input value={cuponCodigo} onChange={(event) => setCuponCodigo(event.target.value.toUpperCase())} placeholder='Ej: PROMO10' />
+                    </div>
                   </div>
 
                   <div className='space-y-3'>
                     {cart.map((item) => (
                       <div key={item.key} className='rounded-lg border p-3'>
                         <div className='flex items-start justify-between gap-2'>
-                          <div><p className='font-medium'>{item.nombre}</p><p className='text-xs text-muted-foreground'>{item.item_tipo === 'servicio' ? 'Servicio escaneado' : `Disponible: ${item.stockDisponible}`}</p></div>
+                          <div><p className='font-medium'>{item.nombre}</p><p className='text-xs text-muted-foreground'>{item.item_tipo === 'pack' ? 'Pack comercial' : item.item_tipo === 'servicio' ? 'Servicio escaneado' : `Disponible: ${item.stockDisponible}`}</p></div>
                           <Button size='icon' variant='ghost' onClick={() => removeFromCart(item.key)}><Trash2 className='h-4 w-4' /></Button>
                         </div>
                         <div className='mt-3 grid grid-cols-3 gap-2'>
@@ -662,7 +757,7 @@ export default function ComercialKioscoPosPage() {
                         <p className='mt-2 text-right text-sm font-semibold'>{formatCurrencyARS(item.cantidad * item.precio_unitario - item.descuento)}</p>
                       </div>
                     ))}
-                    {cart.length === 0 && <p className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>Agregá productos para iniciar la venta.</p>}
+                    {cart.length === 0 && <p className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>Agregá productos, servicios o packs para iniciar la venta.</p>}
                   </div>
 
                   <div className='rounded-lg bg-slate-50 p-4 text-sm'>

--- a/src/interfaces/comercialPos.interface.ts
+++ b/src/interfaces/comercialPos.interface.ts
@@ -1,4 +1,5 @@
 import type { VentaClienteTipo, VentaMetodoPago } from './venta.interface';
+import type { ComercialCupon, ComercialPack, ComercialPromocion } from './comercialServiciosPromociones.interface';
 
 export interface ComercialPosUbicacion {
   id: string;
@@ -31,6 +32,8 @@ export interface ComercialPosStockUbicacion {
   ubicacion?: ComercialPosUbicacion | null;
 }
 
+export type ComercialPosItemTipo = 'producto' | 'servicio' | 'pack';
+
 export interface ComercialPosVentaDetalle {
   id: string;
   item_tipo: 'producto' | 'servicio';
@@ -56,12 +59,16 @@ export interface ComercialPosVentaResumen {
   comprobante_codigo?: string | null;
   estado?: string | null;
   creado_en?: string | null;
+  observaciones?: string | null;
   venta_detalle?: ComercialPosVentaDetalle[];
   detalles?: ComercialPosVentaDetalle[];
 }
 
 export interface ComercialPosDashboard {
   productos: ComercialPosProducto[];
+  packs: ComercialPack[];
+  promociones: ComercialPromocion[];
+  cupones: ComercialCupon[];
   stockPorUbicacion: ComercialPosStockUbicacion[];
   ubicaciones: ComercialPosUbicacion[];
   ventasRecientes: ComercialPosVentaResumen[];
@@ -72,13 +79,16 @@ export interface ComercialPosDashboard {
     itemsHoy: number;
     productosDisponibles: number;
     productosCriticos: number;
+    packsDisponibles: number;
+    promocionesActivas: number;
   };
 }
 
 export interface CreateComercialPosVentaItemDTO {
-  item_tipo?: 'producto' | 'servicio';
+  item_tipo?: ComercialPosItemTipo;
   producto_id?: string | null;
   servicio_id?: string | null;
+  pack_id?: string | null;
   cantidad: number;
   precio_unitario?: number | null;
   descuento?: number | null;
@@ -91,5 +101,6 @@ export interface CreateComercialPosVentaDTO {
   metodo_pago: VentaMetodoPago;
   observaciones?: string | null;
   ubicacion_stock_id?: string | null;
+  cupon_codigo?: string | null;
   items: CreateComercialPosVentaItemDTO[];
 }

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -1666,7 +1666,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     tag: "Comercial / POS",
     summary: "POS/Kiosco venta rápida",
     description:
-      "Devuelve productos, ubicaciones, stock por ubicación y ventas recientes para POS/Kiosco. También registra ventas rápidas, crea cabecera/detalle, descuenta stock desde la ubicación seleccionada, actualiza producto.stock, registra stock ledger y deja ticket imprimible.",
+      "Devuelve productos, packs, promociones, cupones, ubicaciones, stock por ubicación y ventas recientes para POS/Kiosco. También registra ventas rápidas, crea cabecera/detalle, permite packs escaneables que se expanden a productos/servicios, aplica cupones de descuento, descuenta stock desde la ubicación seleccionada, actualiza producto.stock, registra stock ledger y deja ticket imprimible.",
     auth: true,
     admin: true,
     notImplemented: false,

--- a/src/services/server/comercialKioscoPosServerService.ts
+++ b/src/services/server/comercialKioscoPosServerService.ts
@@ -8,6 +8,7 @@ import type {
   CreateComercialPosVentaDTO,
   CreateComercialPosVentaItemDTO,
 } from '@/interfaces/comercialPos.interface';
+import type { ComercialCupon, ComercialPack, ComercialPromocion } from '@/interfaces/comercialServiciosPromociones.interface';
 import type { JwtUser } from '@/interfaces/jwtUser.interface';
 
 function getComercialDbClient() {
@@ -31,6 +32,10 @@ function asNumber(value: unknown, fallback = 0) {
   return Number.isFinite(numeric) ? numeric : fallback;
 }
 
+function roundMoney(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
 function parsePositiveInteger(value: unknown, label: string) {
   const numeric = Number(value);
   if (!Number.isInteger(numeric) || numeric <= 0) {
@@ -44,7 +49,7 @@ function parseMoney(value: unknown, label: string) {
   if (!Number.isFinite(numeric) || numeric < 0) {
     throw new Error(`${label} debe ser un importe mayor o igual a 0`);
   }
-  return Math.round(numeric * 100) / 100;
+  return roundMoney(numeric);
 }
 
 function normalizeClienteTipo(value: unknown) {
@@ -57,12 +62,21 @@ function normalizeMetodoPago(value: unknown) {
   return allowed.includes(String(value)) ? String(value) : 'efectivo';
 }
 
-function normalizeItemTipo(value: unknown) {
-  return value === 'servicio' ? 'servicio' : 'producto';
+function normalizeItemTipo(value: unknown): 'producto' | 'servicio' | 'pack' {
+  if (value === 'servicio') return 'servicio';
+  if (value === 'pack') return 'pack';
+  return 'producto';
 }
 
 function buildComprobanteCodigo() {
   return `GM-POS-${Date.now().toString(36).toUpperCase()}`;
+}
+
+function isDateActive(start?: string | null, end?: string | null) {
+  const today = new Date().toISOString().slice(0, 10);
+  if (start && String(start).slice(0, 10) > today) return false;
+  if (end && String(end).slice(0, 10) < today) return false;
+  return true;
 }
 
 async function getDefaultLocation(supabase: ReturnType<typeof getComercialDbClient>, requestedId?: string | null) {
@@ -154,16 +168,22 @@ function mapVenta(venta: any): ComercialPosVentaResumen {
     comprobante_codigo: venta.comprobante_codigo ?? null,
     estado: venta.estado ?? 'pagada',
     creado_en: venta.creado_en ?? null,
+    observaciones: venta.observaciones ?? null,
     venta_detalle: detalles,
     detalles,
   };
+}
+
+function mapPack(row: any): ComercialPack {
+  const items = row.items ?? row.comercial_pack_item ?? [];
+  return { ...row, items, comercial_pack_item: items };
 }
 
 export async function getComercialKioscoPosDashboard(): Promise<ComercialPosDashboard> {
   const supabase = getComercialDbClient();
   const today = new Date().toISOString().slice(0, 10);
 
-  const [productosResult, stockResult, ubicacionesResult, ventasResult] = await Promise.all([
+  const [productosResult, stockResult, ubicacionesResult, ventasResult, packsResult, promocionesResult, cuponesResult] = await Promise.all([
     supabase
       .from('vw_comercial_stock_resumen')
       .select('*')
@@ -201,17 +221,47 @@ export async function getComercialKioscoPosDashboard(): Promise<ComercialPosDash
       .eq('estado', 'pagada')
       .order('creado_en', { ascending: false })
       .limit(30),
+    supabase
+      .from('comercial_pack')
+      .select('*, canal:canal_venta_id(*), grupo_cliente:grupo_cliente_id(*), items:comercial_pack_item(*, producto:producto_id(id, nombre, precio, stock, activo), servicio:servicio_id(id, nombre, precio, categoria, activo))')
+      .eq('activo', true)
+      .eq('disponible_pos', true)
+      .order('nombre', { ascending: true })
+      .limit(80),
+    supabase
+      .from('comercial_promocion')
+      .select('*, canal:canal_venta_id(*), grupo_cliente:grupo_cliente_id(*)')
+      .eq('activo', true)
+      .order('creado_en', { ascending: false })
+      .limit(80),
+    supabase
+      .from('comercial_cupon')
+      .select('*, promocion:promocion_id(id, codigo, nombre, tipo, valor, fecha_inicio, fecha_fin, activo)')
+      .eq('activo', true)
+      .order('creado_en', { ascending: false })
+      .limit(80),
   ]);
 
   if (productosResult.error) throw new Error(productosResult.error.message);
   if (stockResult.error) throw new Error(stockResult.error.message);
   if (ubicacionesResult.error) throw new Error(ubicacionesResult.error.message);
   if (ventasResult.error) throw new Error(ventasResult.error.message);
+  if (packsResult.error) throw new Error(packsResult.error.message);
+  if (promocionesResult.error) throw new Error(promocionesResult.error.message);
+  if (cuponesResult.error) throw new Error(cuponesResult.error.message);
 
   const productos = (productosResult.data ?? []) as ComercialPosProducto[];
   const stockPorUbicacion = (stockResult.data ?? []) as ComercialPosStockUbicacion[];
   const ubicaciones = (ubicacionesResult.data ?? []) as ComercialPosUbicacion[];
   const ventasRecientes = (ventasResult.data ?? []).map(mapVenta);
+  const packs = (packsResult.data ?? []).map(mapPack);
+  const promociones = (promocionesResult.data ?? []).filter((promo: any) => isDateActive(promo.fecha_inicio, promo.fecha_fin)) as ComercialPromocion[];
+  const cupones = (cuponesResult.data ?? []).filter((cupon: any) => {
+    const promo = cupon.promocion as any;
+    if (cupon.fecha_expiracion && String(cupon.fecha_expiracion).slice(0, 10) < today) return false;
+    if (cupon.max_usos && Number(cupon.usos_actuales ?? 0) >= Number(cupon.max_usos)) return false;
+    return promo?.activo !== false && isDateActive(promo?.fecha_inicio, promo?.fecha_fin);
+  }) as ComercialCupon[];
   const ubicacionDefault = ubicaciones.find((ubicacion) => ubicacion.codigo === 'kiosco') ?? ubicaciones[0] ?? null;
 
   const ventasHoy = ventasRecientes.filter((venta) => String(venta.fecha).slice(0, 10) === today);
@@ -222,6 +272,9 @@ export async function getComercialKioscoPosDashboard(): Promise<ComercialPosDash
 
   return {
     productos,
+    packs,
+    promociones,
+    cupones,
     stockPorUbicacion,
     ubicaciones,
     ventasRecientes,
@@ -232,8 +285,101 @@ export async function getComercialKioscoPosDashboard(): Promise<ComercialPosDash
       itemsHoy,
       productosDisponibles: productos.filter((producto) => Number(producto.stock_total ?? 0) > 0).length,
       productosCriticos: productos.filter((producto) => producto.estado_stock === 'critico' || producto.estado_stock === 'bajo_minimo' || producto.estado_stock === 'sin_stock').length,
+      packsDisponibles: packs.length,
+      promocionesActivas: promociones.length,
     },
   };
+}
+
+type NormalizedVentaItem = CreateComercialPosVentaItemDTO & {
+  item_tipo: 'producto' | 'servicio';
+  precio_final: number;
+  total_linea: number;
+  item_nombre: string;
+  costo: number;
+  pack_id?: string | null;
+  pack_nombre?: string | null;
+};
+
+function getPackReferenceLine(item: any, cantidadPack: number) {
+  const cantidad = Number(item.cantidad ?? 1) * cantidadPack;
+  const precioReferencia = Number(item.precio_referencia ?? 0) > 0
+    ? Number(item.precio_referencia)
+    : item.item_tipo === 'servicio'
+      ? Number(item.servicio?.precio ?? 0)
+      : Number(item.producto?.precio ?? 0);
+  return {
+    item_tipo: item.item_tipo === 'servicio' ? 'servicio' as const : 'producto' as const,
+    producto_id: item.producto_id ?? null,
+    servicio_id: item.servicio_id ?? null,
+    cantidad,
+    precioReferencia: roundMoney(precioReferencia),
+    nombre: item.item_tipo === 'servicio'
+      ? (item.servicio?.nombre ?? 'Servicio del pack')
+      : (item.producto?.nombre ?? 'Producto del pack'),
+    costo: item.item_tipo === 'producto' ? asNumber(item.producto?.costo, 0) : 0,
+  };
+}
+
+function applyDistributedDiscount(items: NormalizedVentaItem[], discount: number, reason: string) {
+  const targetDiscount = roundMoney(Math.max(discount, 0));
+  if (!targetDiscount) return 0;
+
+  const available = items.reduce((sum, item) => sum + Math.max(item.cantidad * item.precio_final - Number(item.descuento ?? 0), 0), 0);
+  if (available <= 0) return 0;
+
+  let remaining = Math.min(targetDiscount, roundMoney(available));
+  items.forEach((item, index) => {
+    const lineAvailable = Math.max(item.cantidad * item.precio_final - Number(item.descuento ?? 0), 0);
+    if (lineAvailable <= 0 || remaining <= 0) return;
+    const share = index === items.length - 1 ? remaining : roundMoney(targetDiscount * (lineAvailable / available));
+    const applied = Math.min(lineAvailable, share, remaining);
+    item.descuento = roundMoney(Number(item.descuento ?? 0) + applied);
+    item.total_linea = roundMoney(item.cantidad * item.precio_final - Number(item.descuento ?? 0));
+    remaining = roundMoney(remaining - applied);
+  });
+
+  if (remaining > 0.01) {
+    const last = [...items].reverse().find((item) => Math.max(item.cantidad * item.precio_final - Number(item.descuento ?? 0), 0) > 0);
+    if (last) {
+      const lineAvailable = Math.max(last.cantidad * last.precio_final - Number(last.descuento ?? 0), 0);
+      const applied = Math.min(lineAvailable, remaining);
+      last.descuento = roundMoney(Number(last.descuento ?? 0) + applied);
+      last.total_linea = roundMoney(last.cantidad * last.precio_final - Number(last.descuento ?? 0));
+      remaining = roundMoney(remaining - applied);
+    }
+  }
+
+  return roundMoney(targetDiscount - remaining);
+}
+
+async function resolveCoupon(supabase: ReturnType<typeof getComercialDbClient>, rawCode?: string | null) {
+  const codigo = String(rawCode ?? '').trim().toUpperCase();
+  if (!codigo) return null;
+
+  const { data, error } = await supabase
+    .from('comercial_cupon')
+    .select('*, promocion:promocion_id(*)')
+    .eq('codigo', codigo)
+    .eq('activo', true)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error('Cupón no encontrado o inactivo');
+  if (data.fecha_expiracion && String(data.fecha_expiracion).slice(0, 10) < new Date().toISOString().slice(0, 10)) {
+    throw new Error('El cupón está vencido');
+  }
+  if (data.max_usos && Number(data.usos_actuales ?? 0) >= Number(data.max_usos)) {
+    throw new Error('El cupón ya alcanzó su máximo de usos');
+  }
+  const promo = data.promocion;
+  if (!promo || promo.activo === false || !isDateActive(promo.fecha_inicio, promo.fecha_fin)) {
+    throw new Error('La promoción asociada al cupón no está vigente');
+  }
+  if (!['descuento_porcentaje', 'descuento_fijo'].includes(promo.tipo)) {
+    throw new Error('Este cupón pertenece a una promoción informativa/combo y no puede aplicarse como descuento automático en POS');
+  }
+  return data;
 }
 
 export async function createComercialKioscoPosVenta(
@@ -249,9 +395,33 @@ export async function createComercialKioscoPosVenta(
   if (clienteTipo === 'socio') throw new Error('La venta POS v1 opera consumidor final o visitante. La venta a socio queda para la etapa de POS avanzado.');
 
   const ubicacion = await getDefaultLocation(supabase, payload.ubicacion_stock_id ?? null);
-  const productoIds = Array.from(new Set(items.map((item) => normalizeItemTipo(item.item_tipo) === 'producto' ? String(item.producto_id ?? '').trim() : '').filter(Boolean)));
-  const servicioIds = Array.from(new Set(items.map((item) => normalizeItemTipo(item.item_tipo) === 'servicio' ? String(item.servicio_id ?? '').trim() : '').filter(Boolean)));
-  if (!productoIds.length && !servicioIds.length) throw new Error('Debe seleccionar productos o servicios válidos');
+  const directProductoIds = Array.from(new Set(items.map((item) => normalizeItemTipo(item.item_tipo) === 'producto' ? String(item.producto_id ?? '').trim() : '').filter(Boolean)));
+  const directServicioIds = Array.from(new Set(items.map((item) => normalizeItemTipo(item.item_tipo) === 'servicio' ? String(item.servicio_id ?? '').trim() : '').filter(Boolean)));
+  const packIds = Array.from(new Set(items.map((item) => normalizeItemTipo(item.item_tipo) === 'pack' ? String(item.pack_id ?? '').trim() : '').filter(Boolean)));
+
+  if (!directProductoIds.length && !directServicioIds.length && !packIds.length) throw new Error('Debe seleccionar productos, servicios o packs válidos');
+
+  const packsResult = packIds.length
+    ? await supabase
+      .from('comercial_pack')
+      .select('*, items:comercial_pack_item(*, producto:producto_id(id, nombre, precio, costo, stock, activo), servicio:servicio_id(id, nombre, precio, categoria, activo))')
+      .in('id', packIds)
+    : { data: [], error: null } as any;
+
+  if (packsResult.error) throw new Error(packsResult.error.message);
+  const packsById = new Map<string, any>((packsResult.data ?? []).map((pack: any) => [String(pack.id), mapPack(pack)]));
+
+  const packProductoIds: string[] = [];
+  const packServicioIds: string[] = [];
+  for (const pack of packsById.values()) {
+    for (const packItem of pack.items ?? []) {
+      if (packItem.item_tipo === 'servicio' && packItem.servicio_id) packServicioIds.push(String(packItem.servicio_id));
+      if (packItem.item_tipo !== 'servicio' && packItem.producto_id) packProductoIds.push(String(packItem.producto_id));
+    }
+  }
+
+  const productoIds = Array.from(new Set([...directProductoIds, ...packProductoIds]));
+  const servicioIds = Array.from(new Set([...directServicioIds, ...packServicioIds]));
 
   const [productosResult, serviciosResult] = await Promise.all([
     productoIds.length
@@ -267,13 +437,8 @@ export async function createComercialKioscoPosVenta(
 
   const productosById = new Map<string, any>((productosResult.data ?? []).map((producto: any) => [String(producto.id), producto]));
   const serviciosById = new Map<string, any>((serviciosResult.data ?? []).map((servicio: any) => [String(servicio.id), servicio]));
-  const normalizedItems: Array<CreateComercialPosVentaItemDTO & {
-    item_tipo: 'producto' | 'servicio';
-    precio_final: number;
-    total_linea: number;
-    item_nombre: string;
-    costo: number;
-  }> = [];
+  const normalizedItems: NormalizedVentaItem[] = [];
+  const packNotes: string[] = [];
 
   for (const item of items) {
     const itemTipo = normalizeItemTipo(item.item_tipo);
@@ -304,39 +469,98 @@ export async function createComercialKioscoPosVenta(
         precio_unitario: precio,
         descuento,
         precio_final: precio,
-        total_linea: subtotal - descuento,
+        total_linea: roundMoney(subtotal - descuento),
         item_nombre: producto.nombre,
         costo: asNumber(producto.costo, 0),
       });
       continue;
     }
 
-    const servicioId = String(item.servicio_id ?? '').trim();
-    const servicio = serviciosById.get(servicioId);
-    if (!servicio || servicio.activo === false) throw new Error('Uno de los servicios no existe o está inactivo');
-    const precio = parseMoney(item.precio_unitario ?? servicio.precio, `Precio de ${servicio.nombre}`);
-    const descuento = parseMoney(item.descuento ?? 0, `Descuento de ${servicio.nombre}`);
-    const subtotal = cantidad * precio;
-    if (descuento > subtotal) throw new Error(`El descuento no puede superar el subtotal de ${servicio.nombre}`);
+    if (itemTipo === 'servicio') {
+      const servicioId = String(item.servicio_id ?? '').trim();
+      const servicio = serviciosById.get(servicioId);
+      if (!servicio || servicio.activo === false) throw new Error('Uno de los servicios no existe o está inactivo');
+      const precio = parseMoney(item.precio_unitario ?? servicio.precio, `Precio de ${servicio.nombre}`);
+      const descuento = parseMoney(item.descuento ?? 0, `Descuento de ${servicio.nombre}`);
+      const subtotal = cantidad * precio;
+      if (descuento > subtotal) throw new Error(`El descuento no puede superar el subtotal de ${servicio.nombre}`);
 
-    normalizedItems.push({
-      ...item,
-      item_tipo: 'servicio',
-      producto_id: null,
-      servicio_id: servicioId,
-      cantidad,
-      precio_unitario: precio,
-      descuento,
-      precio_final: precio,
-      total_linea: subtotal - descuento,
-      item_nombre: servicio.nombre,
-      costo: 0,
+      normalizedItems.push({
+        ...item,
+        item_tipo: 'servicio',
+        producto_id: null,
+        servicio_id: servicioId,
+        cantidad,
+        precio_unitario: precio,
+        descuento,
+        precio_final: precio,
+        total_linea: roundMoney(subtotal - descuento),
+        item_nombre: servicio.nombre,
+        costo: 0,
+      });
+      continue;
+    }
+
+    const packId = String(item.pack_id ?? '').trim();
+    const pack = packsById.get(packId);
+    if (!pack || pack.activo === false || pack.disponible_pos === false) throw new Error('Uno de los packs no existe, está inactivo o no está disponible para POS');
+    const packItems = Array.isArray(pack.items) ? pack.items : [];
+    if (!packItems.length) throw new Error(`El pack ${pack.nombre} no tiene ítems configurados`);
+
+    const packUnitPrice = parseMoney(item.precio_unitario ?? pack.precio, `Precio del pack ${pack.nombre}`);
+    const packDiscount = parseMoney(item.descuento ?? 0, `Descuento del pack ${pack.nombre}`);
+    const packTargetTotal = Math.max(roundMoney(cantidad * packUnitPrice - packDiscount), 0);
+    const componentLines = packItems.map((packItem: any) => getPackReferenceLine(packItem, cantidad));
+    const referenceTotal = componentLines.reduce((sum: number, line: any) => sum + line.cantidad * line.precioReferencia, 0);
+    if (referenceTotal <= 0) throw new Error(`El pack ${pack.nombre} no tiene precios de referencia válidos`);
+
+    let accumulated = 0;
+    componentLines.forEach((line: any, index: number) => {
+      const referenceLineTotal = line.cantidad * line.precioReferencia;
+      const targetLineTotal = index === componentLines.length - 1
+        ? roundMoney(packTargetTotal - accumulated)
+        : roundMoney(packTargetTotal * (referenceLineTotal / referenceTotal));
+      accumulated = roundMoney(accumulated + targetLineTotal);
+      const precioFinal = roundMoney(targetLineTotal / line.cantidad);
+      const source = line.item_tipo === 'servicio' ? serviciosById.get(String(line.servicio_id)) : productosById.get(String(line.producto_id));
+      if (!source || source.activo === false) throw new Error(`El pack ${pack.nombre} contiene un ítem inactivo o inexistente`);
+
+      normalizedItems.push({
+        item_tipo: line.item_tipo,
+        producto_id: line.item_tipo === 'producto' ? String(line.producto_id) : null,
+        servicio_id: line.item_tipo === 'servicio' ? String(line.servicio_id) : null,
+        pack_id: pack.id,
+        pack_nombre: pack.nombre,
+        cantidad: line.cantidad,
+        precio_unitario: precioFinal,
+        descuento: 0,
+        precio_final: precioFinal,
+        total_linea: roundMoney(line.cantidad * precioFinal),
+        item_nombre: `${line.nombre} (${pack.nombre})`,
+        costo: line.item_tipo === 'producto' ? asNumber(source.costo, 0) : 0,
+      });
     });
+    packNotes.push(`${cantidad} x ${pack.nombre} (${pack.codigo})`);
   }
 
-  const total = normalizedItems.reduce((sum, item) => sum + item.total_linea, 0);
+  const subtotalBeforeCoupon = normalizedItems.reduce((sum, item) => sum + roundMoney(item.cantidad * item.precio_final - Number(item.descuento ?? 0)), 0);
+  const coupon = await resolveCoupon(supabase, payload.cupon_codigo);
+  let couponNote = '';
+  if (coupon) {
+    const promo = coupon.promocion as any;
+    const discount = promo.tipo === 'descuento_porcentaje'
+      ? roundMoney(subtotalBeforeCoupon * (Number(promo.valor ?? 0) / 100))
+      : Math.min(roundMoney(Number(promo.valor ?? 0)), subtotalBeforeCoupon);
+    const applied = applyDistributedDiscount(normalizedItems, discount, `Cupón ${coupon.codigo}`);
+    couponNote = `Cupón ${coupon.codigo} / ${promo.nombre}: -${applied}`;
+  }
+
+  const total = roundMoney(normalizedItems.reduce((sum, item) => sum + roundMoney(item.cantidad * item.precio_final - Number(item.descuento ?? 0)), 0));
   const comprobanteCodigo = buildComprobanteCodigo();
   const cajaSesionId = await getOpenCashSessionId(supabase);
+  const obsParts = [payload.observaciones?.trim() || `Venta POS/Kiosco desde ${ubicacion.nombre}`];
+  if (packNotes.length) obsParts.push(`Packs: ${packNotes.join(', ')}`);
+  if (couponNote) obsParts.push(couponNote);
 
   const { data: venta, error: ventaError } = await supabase
     .from('venta')
@@ -346,7 +570,7 @@ export async function createComercialKioscoPosVenta(
       cliente_nombre: payload.cliente_nombre?.trim() || (clienteTipo === 'visitante' ? 'Visitante' : 'Consumidor Final'),
       cliente_documento: payload.cliente_documento?.trim() || null,
       metodo_pago: metodoPago,
-      observaciones: payload.observaciones?.trim() || `Venta POS/Kiosco desde ${ubicacion.nombre}`,
+      observaciones: obsParts.filter(Boolean).join(' | '),
       fecha: new Date().toISOString().slice(0, 10),
       total,
       estado: 'pagada',
@@ -421,7 +645,7 @@ export async function createComercialKioscoPosVenta(
       stock_nuevo_total: stockNuevoTotal,
       costo_unitario: item.costo,
       precio_unitario: item.precio_final,
-      motivo: `Venta POS/Kiosco ${comprobanteCodigo}`,
+      motivo: item.pack_nombre ? `Venta POS/Kiosco ${comprobanteCodigo} / Pack ${item.pack_nombre}` : `Venta POS/Kiosco ${comprobanteCodigo}`,
       referencia_tipo: 'venta',
       referencia_id: venta.id,
       creado_por: user?.id ?? null,
@@ -435,9 +659,16 @@ export async function createComercialKioscoPosVenta(
       cantidad: item.cantidad,
       stock_anterior: stockAnteriorTotal,
       stock_nuevo: stockNuevoTotal,
-      motivo: `Venta POS/Kiosco ${comprobanteCodigo}`,
+      motivo: item.pack_nombre ? `Venta POS/Kiosco ${comprobanteCodigo} / Pack ${item.pack_nombre}` : `Venta POS/Kiosco ${comprobanteCodigo}`,
       creado_por: user?.id ?? null,
     });
+  }
+
+  if (coupon) {
+    await supabase
+      .from('comercial_cupon')
+      .update({ usos_actuales: Number(coupon.usos_actuales ?? 0) + 1, actualizado_en: new Date().toISOString() })
+      .eq('id', coupon.id);
   }
 
   if (detallesCreados[0]?.id) {


### PR DESCRIPTION
# feat: add direct POS sale for packs and promotions

## Rama

`feature/comercial-pos-packs-promociones-direct-sale-v1`

## Objetivo

Cerrar el ciclo comercial del POS/Kiosco permitiendo vender packs, promociones y cupones desde el punto de venta, tanto por selección manual como por código/QR escaneado desde el scanner móvil.

La feature complementa el flujo ya cerrado de scanner móvil realtime y códigos comerciales para productos/servicios, resolviendo el hueco pendiente: que un pack detectado por código pueda entrar al carrito, calcular su precio, descontar stock y registrarse correctamente en la venta.

## Alcance funcional

- Se agregan packs disponibles al POS/Kiosco.
- Se permite buscar packs por nombre o código.
- Se permite agregar packs manualmente al carrito.
- Se permite agregar packs desde el scanner móvil cuando llega un evento `item_tipo = pack`.
- Se incorpora campo de cupón/promoción opcional en el POS.
- Se aplica descuento por cupón porcentual o fijo cuando corresponde.
- Se incrementa el contador de uso del cupón.
- Se expande el pack en sus productos/servicios internos al confirmar la venta.
- Se descuentan stocks de productos incluidos en packs.
- Se registran movimientos de stock para los productos del pack.
- Se registran servicios incluidos como líneas de venta compatibles.
- Se deja trazabilidad del pack/cupón aplicado en `venta.observaciones`.

## Decisión técnica

No se agregó migración de base de datos en esta versión.

El modelo actual de `venta_detalle` opera con productos y servicios. Para mantener compatibilidad con reportes, BI, stock ledger, ticket y ventas existentes, el pack se trata como ítem comercial del carrito, pero al persistir la venta se expande en sus componentes reales.

Esto evita tocar constraints sensibles y mantiene estable el modelo actual. Una futura feature puede agregar analítica específica de packs vendidos si se requiere.

## Archivos modificados

- `src/app/dashboard/comercial/kiosco/page.tsx`
- `src/interfaces/comercialPos.interface.ts`
- `src/services/server/comercialKioscoPosServerService.ts`
- `src/lib/swagger/openApiSpec.ts`
- `docs/comercial/comercial-pos-packs-promociones-direct-sale-v1.md`

## Endpoints / Swagger

Se actualiza la documentación Swagger/OpenAPI relacionada con el POS/Kiosco comercial para reflejar el soporte de packs y cupones en la venta directa.

No se agregan endpoints nuevos.

## Migraciones

No requiere migración DB.

## Validación funcional

Prueba funcional reportada como satisfactoria.

Checklist validado/recomendado:

- Entrar a `/dashboard/comercial/kiosco`.
- Ver packs disponibles para POS.
- Buscar pack por nombre/código.
- Agregar pack manualmente al carrito.
- Conectar scanner móvil.
- Escanear código/QR de pack.
- Confirmar que el pack entra al carrito.
- Confirmar venta.
- Verificar descuento de stock de productos incluidos.
- Verificar registro de servicios incluidos.
- Verificar movimientos en stock ledger.
- Probar cupón vigente.
- Confirmar incremento de `usos_actuales` del cupón.

## Impacto funcional

Con esta feature queda cerrado el ciclo comercial principal:

- Scanner móvil realtime.
- Códigos de producto/servicio/pack.
- Etiquetas QR/barcode.
- POS/Kiosco con productos y servicios.
- POS/Kiosco con packs/promociones/cupones.
- Venta con impacto en stock, servicios, ticket y BI.

## Riesgos / consideraciones

- Los packs se expanden internamente al persistir la venta; no quedan como línea `pack` en `venta_detalle`.
- La analítica específica de packs vendidos puede requerir una feature posterior.
- Conviene validar en Vercel si el flujo depende del scanner móvil desde celular.

## Pendientes derivados

- `feature/comercial-venta-pack-analytics-v1` para reportes específicos de packs vendidos como entidad comercial, si el negocio lo requiere.
- Refinar ticket/recibo si se desea mostrar el pack como cabecera agrupadora con sus componentes debajo.

## Comandos sugeridos

```bash
npm run build
git restore public/sw.js public/workbox-*.js 2>/dev/null || true
git status --short

git add \
 src/app/dashboard/comercial/kiosco/page.tsx \
 src/interfaces/comercialPos.interface.ts \
 src/services/server/comercialKioscoPosServerService.ts \
 src/lib/swagger/openApiSpec.ts \
 docs/comercial/comercial-pos-packs-promociones-direct-sale-v1.md

git commit -m "feat: add direct POS sale for packs and promotions"
git push -u origin feature/comercial-pos-packs-promociones-direct-sale-v1
```
