### PR TITLE
feat: add commercial pack sales analytics

### DIFF
--- a/docs/comercial/comercial-venta-pack-analytics-v1.md
+++ b/docs/comercial/comercial-venta-pack-analytics-v1.md
@@ -1,0 +1,58 @@
+# Gym Master — Comercial venta pack analytics v1
+
+## Rama
+
+`feature/comercial-venta-pack-analytics-v1`
+
+## Objetivo
+
+Agregar trazabilidad y BI específico para packs/promociones vendidos desde POS/Kiosco.
+
+La feature anterior permitió vender packs directamente desde el POS expandiéndolos a productos/servicios para mantener compatibilidad con `venta_detalle`, stock ledger y reportes existentes. Esta feature agrega una capa analítica para saber qué pack fue vendido, cuántas veces, cuánto ingreso generó, qué cupón/promoción se aplicó y qué componentes tenía al momento de la venta.
+
+## Alcance
+
+- Nueva tabla privada `comercial_pack_venta`.
+- Nueva vista agregada `vw_comercial_pack_analytics`.
+- Registro automático de packs vendidos desde `createComercialKioscoPosVenta`.
+- Snapshot JSON de componentes del pack al momento de la venta.
+- Asociación opcional de cupón/promoción aplicada.
+- Descuento de cupón estimado por pack.
+- Nuevo endpoint `GET /api/comercial/pack-analytics`.
+- Nueva pantalla `/dashboard/comercial/pack-analytics`.
+- Métricas: ventas con pack, unidades vendidas, ingresos, ticket promedio, cupones usados y descuento estimado.
+- Ranking de packs.
+- Ranking de cupones/promociones.
+- Evolución mensual.
+- Últimas ventas con packs.
+- Menú y permisos en Comercial y Stock.
+- Swagger/OpenAPI actualizado.
+
+## Decisión técnica
+
+No se modifica `venta_detalle` para aceptar `item_tipo = pack`. El POS mantiene el diseño actual: el pack se captura como ítem comercial, pero al guardar la venta se expande a productos/servicios reales.
+
+Para BI se agrega `comercial_pack_venta`, que registra el pack vendido como entidad comercial analítica sin romper:
+
+- stock ledger,
+- tickets,
+- ventas existentes,
+- reportes actuales,
+- constraints de `venta_detalle`.
+
+## Validación
+
+1. Ejecutar migración privada.
+2. Ejecutar `database/scripts/validar_comercial_venta_pack_analytics_v1.sql`.
+3. Crear venta POS con pack.
+4. Verificar registro en `comercial_pack_venta`.
+5. Abrir `/dashboard/comercial/pack-analytics`.
+6. Confirmar métricas y tablas.
+7. Probar filtro de fechas.
+8. Confirmar que venta anulada no impacte como activa en la vista agregada.
+
+## Pendientes derivados
+
+- Exportar PDF/Excel específico de BI Packs si se requiere.
+- Integrar estos indicadores al dashboard comercial principal de forma más avanzada.
+- Analítica de rentabilidad real por pack comparando precio de venta vs costo de productos incluidos.

--- a/src/app/api/comercial/pack-analytics/route.ts
+++ b/src/app/api/comercial/pack-analytics/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getComercialPackAnalyticsDashboard } from '@/services/server/comercialPackAnalyticsServerService';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  try {
+    await authMiddleware(req);
+    const { searchParams } = new URL(req.url);
+    const data = await getComercialPackAnalyticsDashboard({
+      desde: searchParams.get('desde'),
+      hasta: searchParams.get('hasta'),
+    });
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error: any) {
+    const message = error?.message || 'Error al obtener analítica de packs comerciales';
+    const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/dashboard/comercial/pack-analytics/page.tsx
+++ b/src/app/dashboard/comercial/pack-analytics/page.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { BarChart3, CalendarDays, Gift, Loader2, PackageCheck, ReceiptText, RefreshCw, Tags, TrendingUp } from 'lucide-react';
+import { toast } from 'sonner';
+import { AppHeader } from '@/components/header/AppHeader';
+import { AppSidebar } from '@/components/sidebar/AppSidebar';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useAuthStore } from '@/stores/authStore';
+import type { ComercialPackAnalyticsDashboard } from '@/interfaces/comercialPackAnalytics.interface';
+import { getComercialPackAnalytics } from '@/services/comercialPackAnalyticsService';
+import { formatCurrencyARS } from '@/lib/comercial/productos';
+
+const emptyDashboard: ComercialPackAnalyticsDashboard = {
+  registros: [],
+  topPacks: [],
+  cupones: [],
+  mensual: [],
+  metricas: {
+    ventasConPack: 0,
+    packsVendidos: 0,
+    ingresoPacks: 0,
+    ticketPromedioPack: 0,
+    descuentoCuponEstimado: 0,
+    packsDistintos: 0,
+    cuponesUsados: 0,
+  },
+  filtros: {},
+};
+
+function todayInput() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function firstDayOfMonth() {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), 1).toISOString().slice(0, 10);
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return '-';
+  const date = String(value).slice(0, 10);
+  const [year, month, day] = date.split('-');
+  if (!year || !month || !day) return date;
+  return `${day}/${month}/${year}`;
+}
+
+function MetricCard({ title, value, description, icon: Icon }: any) {
+  return (
+    <Card>
+      <CardContent className='flex items-center justify-between gap-4 p-5'>
+        <div className='space-y-1'>
+          <p className='text-sm text-muted-foreground'>{title}</p>
+          <p className='text-2xl font-bold'>{value}</p>
+          <p className='text-xs text-muted-foreground'>{description}</p>
+        </div>
+        <div className='rounded-full bg-fuchsia-50 p-3 text-fuchsia-600'>
+          <Icon className='h-5 w-5' />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function ComercialPackAnalyticsPage() {
+  const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const router = useRouter();
+  const [dashboard, setDashboard] = useState<ComercialPackAnalyticsDashboard>(emptyDashboard);
+  const [loading, setLoading] = useState(true);
+  const [desde, setDesde] = useState(firstDayOfMonth());
+  const [hasta, setHasta] = useState(todayInput());
+
+  useEffect(() => { initializeAuth(); }, [initializeAuth]);
+  useEffect(() => { if (isInitialized && !isAuthenticated) router.push('/auth/login'); }, [isAuthenticated, isInitialized, router]);
+
+  async function loadDashboard() {
+    setLoading(true);
+    try {
+      const data = await getComercialPackAnalytics({ desde, hasta });
+      setDashboard(data);
+    } catch (error: any) {
+      toast.error(error.message || 'No se pudo cargar analítica de packs');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (isInitialized && isAuthenticated) loadDashboard();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isInitialized, isAuthenticated]);
+
+  const latestRows = useMemo(() => dashboard.registros.slice(0, 20), [dashboard.registros]);
+
+  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isAuthenticated) return null;
+
+  return (
+    <SidebarProvider>
+      <div className='flex min-h-screen w-full'>
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader title='BI Packs / Promos' />
+          <main className='flex-1 space-y-6 p-6'>
+            <section className='rounded-2xl border bg-white p-6 shadow-sm'>
+              <div className='flex flex-col justify-between gap-4 lg:flex-row lg:items-center'>
+                <div className='space-y-2'>
+                  <p className='text-xs font-semibold uppercase tracking-[0.24em] text-fuchsia-600'>Comercial y Stock</p>
+                  <h1 className='text-2xl font-bold'>Analítica de packs, promociones y cupones</h1>
+                  <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground'>
+                    Medí qué packs se venden, cuántas unidades se movieron, qué cupones se usaron y cuánto ingreso generan las promociones del POS/Kiosco.
+                  </p>
+                </div>
+                <div className='flex flex-wrap gap-2'>
+                  <Button asChild variant='outline'><Link href='/dashboard/comercial/kiosco'>Abrir POS</Link></Button>
+                  <Button asChild variant='outline'><Link href='/dashboard/comercial/servicios-promociones'>Gestionar packs</Link></Button>
+                  <Button onClick={loadDashboard} disabled={loading} className='bg-[#02a8e1] hover:bg-[#0288b1]'>
+                    {loading ? <Loader2 className='mr-2 h-4 w-4 animate-spin' /> : <RefreshCw className='mr-2 h-4 w-4' />}
+                    Actualizar
+                  </Button>
+                </div>
+              </div>
+            </section>
+
+            <Card>
+              <CardContent className='grid gap-4 p-5 md:grid-cols-[1fr_1fr_auto] md:items-end'>
+                <div className='space-y-2'>
+                  <Label>Desde</Label>
+                  <Input type='date' value={desde} onChange={(event) => setDesde(event.target.value)} />
+                </div>
+                <div className='space-y-2'>
+                  <Label>Hasta</Label>
+                  <Input type='date' value={hasta} onChange={(event) => setHasta(event.target.value)} />
+                </div>
+                <Button onClick={loadDashboard} disabled={loading} variant='outline'>Aplicar filtros</Button>
+              </CardContent>
+            </Card>
+
+            <section className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
+              <MetricCard title='Ventas con pack' value={loading ? '...' : String(dashboard.metricas.ventasConPack)} description='Ventas POS que incluyeron al menos un pack' icon={ReceiptText} />
+              <MetricCard title='Packs vendidos' value={loading ? '...' : String(dashboard.metricas.packsVendidos)} description='Unidades vendidas en el período' icon={PackageCheck} />
+              <MetricCard title='Ingreso packs' value={loading ? '...' : formatCurrencyARS(dashboard.metricas.ingresoPacks)} description='Ingreso atribuido a packs activos' icon={TrendingUp} />
+              <MetricCard title='Cupones usados' value={loading ? '...' : String(dashboard.metricas.cuponesUsados)} description={`Descuento estimado: ${formatCurrencyARS(dashboard.metricas.descuentoCuponEstimado)}`} icon={Gift} />
+            </section>
+
+            <section className='grid gap-4 xl:grid-cols-2'>
+              <Card>
+                <CardHeader><CardTitle className='flex items-center gap-2'><BarChart3 className='h-5 w-5 text-fuchsia-600' /> Top packs vendidos</CardTitle></CardHeader>
+                <CardContent className='space-y-3'>
+                  {dashboard.topPacks.length === 0 && <p className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>Todavía no hay packs vendidos para el período seleccionado.</p>}
+                  {dashboard.topPacks.map((pack) => (
+                    <div key={`${pack.pack_id ?? pack.pack_codigo}`} className='rounded-xl border p-4'>
+                      <div className='flex items-start justify-between gap-4'>
+                        <div>
+                          <p className='font-semibold'>{pack.pack_nombre}</p>
+                          <p className='text-xs text-muted-foreground'>{pack.pack_codigo} · Última venta: {formatDate(pack.ultima_venta)}</p>
+                        </div>
+                        <p className='font-bold'>{formatCurrencyARS(pack.ingreso_total)}</p>
+                      </div>
+                      <div className='mt-3 grid gap-2 text-sm text-muted-foreground sm:grid-cols-3'>
+                        <span>{pack.cantidad_vendida} unidades</span>
+                        <span>{pack.ventas} registros</span>
+                        <span>{formatCurrencyARS(pack.descuento_cupon_estimado)} desc.</span>
+                      </div>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader><CardTitle className='flex items-center gap-2'><Tags className='h-5 w-5 text-fuchsia-600' /> Cupones y promociones</CardTitle></CardHeader>
+                <CardContent className='space-y-3'>
+                  {dashboard.cupones.length === 0 && <p className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>No hay cupones aplicados a packs en el período.</p>}
+                  {dashboard.cupones.map((cupon) => (
+                    <div key={`${cupon.cupon_id ?? cupon.cupon_codigo}`} className='rounded-xl border p-4'>
+                      <div className='flex items-start justify-between gap-4'>
+                        <div>
+                          <p className='font-semibold'>{cupon.cupon_codigo}</p>
+                          <p className='text-xs text-muted-foreground'>{cupon.promocion_nombre ?? 'Promoción sin nombre'}</p>
+                        </div>
+                        <p className='font-bold text-emerald-600'>-{formatCurrencyARS(cupon.descuento_estimado)}</p>
+                      </div>
+                      <p className='mt-2 text-sm text-muted-foreground'>{cupon.usos} usos · {cupon.packs_vendidos} packs · {formatCurrencyARS(cupon.ingreso_asociado)} asociado</p>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </section>
+
+            <Card>
+              <CardHeader><CardTitle className='flex items-center gap-2'><CalendarDays className='h-5 w-5 text-fuchsia-600' /> Evolución mensual</CardTitle></CardHeader>
+              <CardContent className='overflow-x-auto'>
+                <table className='w-full min-w-[720px] text-sm'>
+                  <thead className='border-b bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500'>
+                    <tr><th className='p-3'>Período</th><th className='p-3'>Packs vendidos</th><th className='p-3'>Ventas</th><th className='p-3'>Ingreso</th><th className='p-3'>Descuento</th></tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.mensual.map((row) => (
+                      <tr key={row.periodo} className='border-b last:border-0'>
+                        <td className='p-3 font-medium'>{row.periodo}</td>
+                        <td className='p-3'>{row.packs_vendidos}</td>
+                        <td className='p-3'>{row.ventas}</td>
+                        <td className='p-3'>{formatCurrencyARS(row.ingreso_total)}</td>
+                        <td className='p-3'>{formatCurrencyARS(row.descuento_cupon_estimado)}</td>
+                      </tr>
+                    ))}
+                    {dashboard.mensual.length === 0 && <tr><td colSpan={5} className='p-6 text-center text-muted-foreground'>Sin datos mensuales para mostrar.</td></tr>}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader><CardTitle>Últimas ventas con packs</CardTitle></CardHeader>
+              <CardContent className='overflow-x-auto'>
+                <table className='w-full min-w-[960px] text-sm'>
+                  <thead className='border-b bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500'>
+                    <tr><th className='p-3'>Fecha</th><th className='p-3'>Pack</th><th className='p-3'>Cantidad</th><th className='p-3'>Total pack</th><th className='p-3'>Cupón</th><th className='p-3'>Venta</th><th className='p-3'>Componentes</th></tr>
+                  </thead>
+                  <tbody>
+                    {latestRows.map((row) => (
+                      <tr key={row.id} className='border-b align-top last:border-0'>
+                        <td className='p-3'>{formatDate(row.venta?.fecha ?? row.creado_en)}</td>
+                        <td className='p-3'><p className='font-medium'>{row.pack_nombre}</p><p className='text-xs text-muted-foreground'>{row.pack_codigo}</p></td>
+                        <td className='p-3'>{row.cantidad}</td>
+                        <td className='p-3'>{formatCurrencyARS(row.total_pack)}</td>
+                        <td className='p-3'>{row.cupon_codigo ? `${row.cupon_codigo} · -${formatCurrencyARS(row.descuento_cupon_estimado)}` : '-'}</td>
+                        <td className='p-3'><p>{row.venta?.comprobante_codigo ?? row.venta_id}</p><p className='text-xs text-muted-foreground'>{row.venta?.cliente_nombre ?? row.venta?.cliente_tipo ?? 'Cliente'}</p></td>
+                        <td className='p-3 text-xs text-muted-foreground'>{row.componentes?.map((item) => `${item.cantidad} x ${item.nombre}`).join(' · ') || '-'}</td>
+                      </tr>
+                    ))}
+                    {latestRows.length === 0 && <tr><td colSpan={7} className='p-6 text-center text-muted-foreground'>No hay ventas con packs en el período.</td></tr>}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          </main>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/app/dashboard/comercial/page.tsx
+++ b/src/app/dashboard/comercial/page.tsx
@@ -9,6 +9,7 @@ import {
   Banknote,
   Boxes,
   DollarSign,
+  Gift,
   ClipboardList,
   Package,
   ReceiptText,
@@ -339,6 +340,12 @@ export default function ComercialKioscoPage() {
                 description='Servicios vendibles, packs de clases, promociones, cupones, canales y grupos de cliente.'
                 href='/dashboard/comercial/servicios-promociones'
                 icon={Store}
+              />
+              <ActionCard
+                title='BI Packs / Promos'
+                description='Trazabilidad de packs vendidos, cupones usados, ingreso generado y ranking comercial por promoción.'
+                href='/dashboard/comercial/pack-analytics'
+                icon={Gift}
               />
 
               <ActionCard

--- a/src/components/sidebar/sidebarConfig.ts
+++ b/src/components/sidebar/sidebarConfig.ts
@@ -181,6 +181,7 @@ export const sections: SidebarSectionType[] = [
       { title: "Productos", link: "/dashboard/productos", level: 2 },
       { title: "Stock Ledger", link: "/dashboard/comercial/stock-ledger", level: 2 },
       { title: "Códigos / Etiquetas", link: "/dashboard/comercial/codigos-etiquetas", level: 2 },
+      { title: "BI Packs / Promos", link: "/dashboard/comercial/pack-analytics", level: 2 },
       { title: "Proveedores", link: "/dashboard/proveedores", level: 2 },
       { title: "Servicios", link: "/dashboard/servicios", level: 2 },
       { title: "Servicios / Packs / Promos", link: "/dashboard/comercial/servicios-promociones", level: 2 },

--- a/src/interfaces/comercialPackAnalytics.interface.ts
+++ b/src/interfaces/comercialPackAnalytics.interface.ts
@@ -1,0 +1,91 @@
+export interface ComercialPackVentaComponente {
+  item_tipo: 'producto' | 'servicio';
+  producto_id?: string | null;
+  servicio_id?: string | null;
+  nombre: string;
+  cantidad: number;
+  precio_referencia?: number | null;
+}
+
+export interface ComercialPackVentaRegistro {
+  id: string;
+  venta_id: string;
+  pack_id?: string | null;
+  pack_codigo: string;
+  pack_nombre: string;
+  cantidad: number;
+  precio_unitario: number;
+  descuento_pack: number;
+  total_pack: number;
+  cupon_id?: string | null;
+  cupon_codigo?: string | null;
+  promocion_id?: string | null;
+  promocion_nombre?: string | null;
+  descuento_cupon_estimado: number;
+  componentes: ComercialPackVentaComponente[];
+  creado_en?: string | null;
+  actualizado_en?: string | null;
+  venta?: {
+    id: string;
+    fecha?: string | null;
+    total?: number | null;
+    estado?: string | null;
+    activo?: boolean | null;
+    cliente_tipo?: string | null;
+    cliente_nombre?: string | null;
+    cliente_documento?: string | null;
+    metodo_pago?: string | null;
+    comprobante_codigo?: string | null;
+    creado_en?: string | null;
+  } | null;
+}
+
+export interface ComercialPackAnalyticsTopPack {
+  pack_id?: string | null;
+  pack_codigo: string;
+  pack_nombre: string;
+  cantidad_vendida: number;
+  ventas: number;
+  ingreso_total: number;
+  descuento_cupon_estimado: number;
+  ultima_venta?: string | null;
+}
+
+export interface ComercialPackAnalyticsCuponUso {
+  cupon_id?: string | null;
+  cupon_codigo: string;
+  promocion_id?: string | null;
+  promocion_nombre?: string | null;
+  usos: number;
+  packs_vendidos: number;
+  descuento_estimado: number;
+  ingreso_asociado: number;
+}
+
+export interface ComercialPackAnalyticsMes {
+  periodo: string;
+  packs_vendidos: number;
+  ventas: number;
+  ingreso_total: number;
+  descuento_cupon_estimado: number;
+}
+
+export interface ComercialPackAnalyticsDashboard {
+  registros: ComercialPackVentaRegistro[];
+  topPacks: ComercialPackAnalyticsTopPack[];
+  cupones: ComercialPackAnalyticsCuponUso[];
+  mensual: ComercialPackAnalyticsMes[];
+  metricas: {
+    ventasConPack: number;
+    packsVendidos: number;
+    ingresoPacks: number;
+    ticketPromedioPack: number;
+    descuentoCuponEstimado: number;
+    packsDistintos: number;
+    cuponesUsados: number;
+  };
+  filtros: {
+    desde?: string | null;
+    hasta?: string | null;
+  };
+}

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -294,6 +294,13 @@ export const MENU_PERMISSION_GROUPS: Array<{
         roles: ["admin", "usuario"],
       },
       {
+        key: "BI Packs / Promos",
+        label: "BI Packs / Promos",
+        path: "/dashboard/comercial/pack-analytics",
+        group: "Comercial y Stock",
+        roles: ["admin", "usuario"],
+      },
+      {
         key: "Proveedores",
         label: "Proveedores",
         path: "/dashboard/proveedores",

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -19,6 +19,21 @@ type OpenApiPathItem = Record<string, OpenApiOperation>;
 const endpointDefinitions: EndpointDefinition[] = [
 
   {
+    path: "/api/comercial/pack-analytics",
+    methods: ["GET"],
+    tag: "Comercial",
+    summary: "Analítica comercial de packs y promociones",
+    description:
+      "Devuelve trazabilidad y BI de packs vendidos desde POS/Kiosco: ranking de packs, uso de cupones, ingresos, descuentos estimados, evolución mensual y últimas ventas con packs.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [200, 401, 500],
+    queryParams: ["desde", "hasta"],
+    source: "src/app/api/comercial/pack-analytics/route.ts",
+  },
+
+  {
     path: "/api/comercial/codigos/labels",
     methods: ["GET"],
     tag: "Comercial",

--- a/src/services/comercialPackAnalyticsService.ts
+++ b/src/services/comercialPackAnalyticsService.ts
@@ -1,0 +1,29 @@
+import type { ComercialPackAnalyticsDashboard } from '@/interfaces/comercialPackAnalytics.interface';
+import { getToken } from './storageService';
+
+function buildHeaders(): HeadersInit {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export async function getComercialPackAnalytics(params?: {
+  desde?: string | null;
+  hasta?: string | null;
+}): Promise<ComercialPackAnalyticsDashboard> {
+  const search = new URLSearchParams();
+  if (params?.desde) search.set('desde', params.desde);
+  if (params?.hasta) search.set('hasta', params.hasta);
+
+  const res = await fetch(`/api/comercial/pack-analytics${search.toString() ? `?${search.toString()}` : ''}`, {
+    method: 'GET',
+    headers: buildHeaders(),
+    cache: 'no-store',
+  });
+
+  const payload = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(payload?.error || 'No se pudo obtener analítica de packs');
+  }
+
+  return payload.data as ComercialPackAnalyticsDashboard;
+}

--- a/src/services/server/comercialKioscoPosServerService.ts
+++ b/src/services/server/comercialKioscoPosServerService.ts
@@ -301,6 +301,25 @@ type NormalizedVentaItem = CreateComercialPosVentaItemDTO & {
   pack_nombre?: string | null;
 };
 
+type PackVentaDraft = {
+  pack_id: string;
+  pack_codigo: string;
+  pack_nombre: string;
+  cantidad: number;
+  precio_unitario: number;
+  descuento_pack: number;
+  total_pack: number;
+  descuento_cupon_estimado: number;
+  componentes: Array<{
+    item_tipo: 'producto' | 'servicio';
+    producto_id?: string | null;
+    servicio_id?: string | null;
+    nombre: string;
+    cantidad: number;
+    precio_referencia: number;
+  }>;
+};
+
 function getPackReferenceLine(item: any, cantidadPack: number) {
   const cantidad = Number(item.cantidad ?? 1) * cantidadPack;
   const precioReferencia = Number(item.precio_referencia ?? 0) > 0
@@ -438,6 +457,7 @@ export async function createComercialKioscoPosVenta(
   const productosById = new Map<string, any>((productosResult.data ?? []).map((producto: any) => [String(producto.id), producto]));
   const serviciosById = new Map<string, any>((serviciosResult.data ?? []).map((servicio: any) => [String(servicio.id), servicio]));
   const normalizedItems: NormalizedVentaItem[] = [];
+  const packVentaDrafts: PackVentaDraft[] = [];
   const packNotes: string[] = [];
 
   for (const item of items) {
@@ -515,6 +535,15 @@ export async function createComercialKioscoPosVenta(
     if (referenceTotal <= 0) throw new Error(`El pack ${pack.nombre} no tiene precios de referencia válidos`);
 
     let accumulated = 0;
+    const componentesSnapshot = componentLines.map((line: any) => ({
+      item_tipo: line.item_tipo,
+      producto_id: line.item_tipo === 'producto' ? String(line.producto_id) : null,
+      servicio_id: line.item_tipo === 'servicio' ? String(line.servicio_id) : null,
+      nombre: line.nombre,
+      cantidad: line.cantidad,
+      precio_referencia: line.precioReferencia,
+    }));
+
     componentLines.forEach((line: any, index: number) => {
       const referenceLineTotal = line.cantidad * line.precioReferencia;
       const targetLineTotal = index === componentLines.length - 1
@@ -540,6 +569,18 @@ export async function createComercialKioscoPosVenta(
         costo: line.item_tipo === 'producto' ? asNumber(source.costo, 0) : 0,
       });
     });
+
+    packVentaDrafts.push({
+      pack_id: pack.id,
+      pack_codigo: pack.codigo,
+      pack_nombre: pack.nombre,
+      cantidad,
+      precio_unitario: packUnitPrice,
+      descuento_pack: packDiscount,
+      total_pack: packTargetTotal,
+      descuento_cupon_estimado: 0,
+      componentes: componentesSnapshot,
+    });
     packNotes.push(`${cantidad} x ${pack.nombre} (${pack.codigo})`);
   }
 
@@ -552,6 +593,17 @@ export async function createComercialKioscoPosVenta(
       ? roundMoney(subtotalBeforeCoupon * (Number(promo.valor ?? 0) / 100))
       : Math.min(roundMoney(Number(promo.valor ?? 0)), subtotalBeforeCoupon);
     const applied = applyDistributedDiscount(normalizedItems, discount, `Cupón ${coupon.codigo}`);
+    if (applied > 0 && packVentaDrafts.length) {
+      const totalPackBeforeCoupon = packVentaDrafts.reduce((sum, row) => sum + row.total_pack, 0);
+      let accumulatedPackCoupon = 0;
+      packVentaDrafts.forEach((row, index) => {
+        const estimated = index === packVentaDrafts.length - 1
+          ? roundMoney(applied - accumulatedPackCoupon)
+          : roundMoney(applied * (row.total_pack / Math.max(totalPackBeforeCoupon, 1)));
+        row.descuento_cupon_estimado = Math.max(estimated, 0);
+        accumulatedPackCoupon = roundMoney(accumulatedPackCoupon + estimated);
+      });
+    }
     couponNote = `Cupón ${coupon.codigo} / ${promo.nombre}: -${applied}`;
   }
 
@@ -662,6 +714,31 @@ export async function createComercialKioscoPosVenta(
       motivo: item.pack_nombre ? `Venta POS/Kiosco ${comprobanteCodigo} / Pack ${item.pack_nombre}` : `Venta POS/Kiosco ${comprobanteCodigo}`,
       creado_por: user?.id ?? null,
     });
+  }
+
+  if (packVentaDrafts.length) {
+    const promo = coupon?.promocion as any;
+    const { error: packVentaError } = await supabase.from('comercial_pack_venta').insert(
+      packVentaDrafts.map((row) => ({
+        venta_id: venta.id,
+        pack_id: row.pack_id,
+        pack_codigo: row.pack_codigo,
+        pack_nombre: row.pack_nombre,
+        cantidad: row.cantidad,
+        precio_unitario: row.precio_unitario,
+        descuento_pack: row.descuento_pack,
+        total_pack: row.total_pack,
+        cupon_id: coupon?.id ?? null,
+        cupon_codigo: coupon?.codigo ?? null,
+        promocion_id: promo?.id ?? null,
+        promocion_nombre: promo?.nombre ?? null,
+        descuento_cupon_estimado: row.descuento_cupon_estimado,
+        componentes: row.componentes,
+        creado_por: user?.id ?? null,
+      }))
+    );
+
+    if (packVentaError) throw new Error(packVentaError.message);
   }
 
   if (coupon) {

--- a/src/services/server/comercialPackAnalyticsServerService.ts
+++ b/src/services/server/comercialPackAnalyticsServerService.ts
@@ -1,0 +1,205 @@
+import { createClient } from '@supabase/supabase-js';
+import type {
+  ComercialPackAnalyticsCuponUso,
+  ComercialPackAnalyticsDashboard,
+  ComercialPackAnalyticsMes,
+  ComercialPackAnalyticsTopPack,
+  ComercialPackVentaRegistro,
+} from '@/interfaces/comercialPackAnalytics.interface';
+
+function getComercialDbClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY no está configurada para consultar analítica comercial.');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+function asNumber(value: unknown, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function roundMoney(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+function normalizeDate(value: string | null | undefined) {
+  const raw = String(value ?? '').trim();
+  return /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw : null;
+}
+
+function monthKey(dateValue?: string | null) {
+  const raw = String(dateValue ?? '').slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(raw) ? raw.slice(0, 7) : 'sin-fecha';
+}
+
+function isActiveSale(row: ComercialPackVentaRegistro) {
+  return row.venta?.estado !== 'anulada' && row.venta?.activo !== false;
+}
+
+function mapRegistro(row: any): ComercialPackVentaRegistro {
+  const venta = row.venta ?? null;
+  return {
+    id: row.id,
+    venta_id: row.venta_id,
+    pack_id: row.pack_id ?? null,
+    pack_codigo: row.pack_codigo ?? '',
+    pack_nombre: row.pack_nombre ?? 'Pack sin nombre',
+    cantidad: asNumber(row.cantidad, 0),
+    precio_unitario: asNumber(row.precio_unitario, 0),
+    descuento_pack: asNumber(row.descuento_pack, 0),
+    total_pack: asNumber(row.total_pack, 0),
+    cupon_id: row.cupon_id ?? null,
+    cupon_codigo: row.cupon_codigo ?? null,
+    promocion_id: row.promocion_id ?? null,
+    promocion_nombre: row.promocion_nombre ?? null,
+    descuento_cupon_estimado: asNumber(row.descuento_cupon_estimado, 0),
+    componentes: Array.isArray(row.componentes) ? row.componentes : [],
+    creado_en: row.creado_en ?? null,
+    actualizado_en: row.actualizado_en ?? null,
+    venta: venta ? {
+      id: venta.id,
+      fecha: venta.fecha ?? null,
+      total: asNumber(venta.total, 0),
+      estado: venta.estado ?? null,
+      activo: venta.activo ?? null,
+      cliente_tipo: venta.cliente_tipo ?? null,
+      cliente_nombre: venta.cliente_nombre ?? null,
+      cliente_documento: venta.cliente_documento ?? null,
+      metodo_pago: venta.metodo_pago ?? null,
+      comprobante_codigo: venta.comprobante_codigo ?? null,
+      creado_en: venta.creado_en ?? null,
+    } : null,
+  };
+}
+
+export async function getComercialPackAnalyticsDashboard(filters?: {
+  desde?: string | null;
+  hasta?: string | null;
+}): Promise<ComercialPackAnalyticsDashboard> {
+  const supabase = getComercialDbClient();
+  const desde = normalizeDate(filters?.desde);
+  const hasta = normalizeDate(filters?.hasta);
+
+  let query = supabase
+    .from('comercial_pack_venta')
+    .select(`
+      *,
+      venta:venta_id(
+        id,
+        fecha,
+        total,
+        estado,
+        activo,
+        cliente_tipo,
+        cliente_nombre,
+        cliente_documento,
+        metodo_pago,
+        comprobante_codigo,
+        creado_en
+      )
+    `)
+    .order('creado_en', { ascending: false })
+    .limit(500);
+
+  if (desde) query = query.gte('creado_en', `${desde}T00:00:00`);
+  if (hasta) query = query.lte('creado_en', `${hasta}T23:59:59`);
+
+  const { data, error } = await query;
+  if (error) throw new Error(error.message);
+
+  const registros = (data ?? []).map(mapRegistro);
+  const activos = registros.filter(isActiveSale);
+
+  const ventaIds = new Set(activos.map((row) => row.venta_id));
+  const packIds = new Set(activos.map((row) => row.pack_id ?? row.pack_codigo).filter(Boolean));
+  const cuponIds = new Set(activos.map((row) => row.cupon_id ?? row.cupon_codigo).filter(Boolean));
+  const packsVendidos = activos.reduce((sum, row) => sum + row.cantidad, 0);
+  const ingresoPacks = roundMoney(activos.reduce((sum, row) => sum + row.total_pack, 0));
+  const descuentoCuponEstimado = roundMoney(activos.reduce((sum, row) => sum + row.descuento_cupon_estimado, 0));
+
+  const topMap = new Map<string, ComercialPackAnalyticsTopPack>();
+  const cuponMap = new Map<string, ComercialPackAnalyticsCuponUso>();
+  const monthMap = new Map<string, ComercialPackAnalyticsMes>();
+
+  for (const row of activos) {
+    const packKey = row.pack_id ?? row.pack_codigo;
+    const top = topMap.get(packKey) ?? {
+      pack_id: row.pack_id ?? null,
+      pack_codigo: row.pack_codigo,
+      pack_nombre: row.pack_nombre,
+      cantidad_vendida: 0,
+      ventas: 0,
+      ingreso_total: 0,
+      descuento_cupon_estimado: 0,
+      ultima_venta: row.venta?.fecha ?? row.creado_en ?? null,
+    };
+    top.cantidad_vendida += row.cantidad;
+    top.ventas += 1;
+    top.ingreso_total = roundMoney(top.ingreso_total + row.total_pack);
+    top.descuento_cupon_estimado = roundMoney(top.descuento_cupon_estimado + row.descuento_cupon_estimado);
+    if (String(row.venta?.fecha ?? row.creado_en ?? '') > String(top.ultima_venta ?? '')) {
+      top.ultima_venta = row.venta?.fecha ?? row.creado_en ?? null;
+    }
+    topMap.set(packKey, top);
+
+    if (row.cupon_codigo) {
+      const cuponKey = row.cupon_id ?? row.cupon_codigo;
+      const cupon = cuponMap.get(cuponKey) ?? {
+        cupon_id: row.cupon_id ?? null,
+        cupon_codigo: row.cupon_codigo,
+        promocion_id: row.promocion_id ?? null,
+        promocion_nombre: row.promocion_nombre ?? null,
+        usos: 0,
+        packs_vendidos: 0,
+        descuento_estimado: 0,
+        ingreso_asociado: 0,
+      };
+      cupon.usos += 1;
+      cupon.packs_vendidos += row.cantidad;
+      cupon.descuento_estimado = roundMoney(cupon.descuento_estimado + row.descuento_cupon_estimado);
+      cupon.ingreso_asociado = roundMoney(cupon.ingreso_asociado + row.total_pack);
+      cuponMap.set(cuponKey, cupon);
+    }
+
+    const month = monthKey(row.venta?.fecha ?? row.creado_en);
+    const monthly = monthMap.get(month) ?? {
+      periodo: month,
+      packs_vendidos: 0,
+      ventas: 0,
+      ingreso_total: 0,
+      descuento_cupon_estimado: 0,
+    };
+    monthly.packs_vendidos += row.cantidad;
+    monthly.ventas += 1;
+    monthly.ingreso_total = roundMoney(monthly.ingreso_total + row.total_pack);
+    monthly.descuento_cupon_estimado = roundMoney(monthly.descuento_cupon_estimado + row.descuento_cupon_estimado);
+    monthMap.set(month, monthly);
+  }
+
+  return {
+    registros,
+    topPacks: Array.from(topMap.values()).sort((a, b) => b.ingreso_total - a.ingreso_total).slice(0, 20),
+    cupones: Array.from(cuponMap.values()).sort((a, b) => b.descuento_estimado - a.descuento_estimado).slice(0, 20),
+    mensual: Array.from(monthMap.values()).sort((a, b) => a.periodo.localeCompare(b.periodo)),
+    metricas: {
+      ventasConPack: ventaIds.size,
+      packsVendidos,
+      ingresoPacks,
+      ticketPromedioPack: packsVendidos > 0 ? roundMoney(ingresoPacks / packsVendidos) : 0,
+      descuentoCuponEstimado,
+      packsDistintos: packIds.size,
+      cuponesUsados: cuponIds.size,
+    },
+    filtros: { desde, hasta },
+  };
+}


### PR DESCRIPTION
# PR: Comercial — Venta Pack Analytics v1

## Rama

`feature/comercial-venta-pack-analytics-v1`

## Tipo de cambio

- [x] Feature funcional
- [x] Backend / API Routes
- [x] Frontend / Dashboard
- [x] Base de datos / migración privada
- [x] BI / reporting comercial
- [x] Swagger / documentación
- [x] Validación QA

## Resumen

Esta PR agrega trazabilidad analítica para packs vendidos desde el POS/Kiosco de Gym Master.

La feature anterior permitió vender packs/promociones directamente desde el POS, manteniendo compatibilidad con el modelo actual de `venta_detalle` mediante expansión del pack a productos y servicios. Esta nueva feature agrega una capa BI específica para responder preguntas comerciales clave:

- qué pack fue vendido;
- cuántas unidades se vendieron;
- cuánto ingreso generó cada pack;
- qué cupón o promoción intervino;
- qué descuento se atribuyó al pack;
- qué componentes tenía el pack al momento de la venta.

## Objetivo funcional

Permitir que el administrador pueda medir el rendimiento comercial de packs, promociones y cupones sin depender de observaciones de texto ni inferencias manuales sobre ventas.

## Cambios principales

### Base de datos

Se agrega migración privada:

`supabase/migrations/202606261930_comercial_venta_pack_analytics_v1.sql`

Incluye:

- nueva tabla `public.comercial_pack_venta`;
- índices por venta, pack, fecha y cupón;
- constraints de integridad para importes, cantidad y componentes;
- RLS habilitado con política para `service_role`;
- vista `public.vw_comercial_pack_analytics` para agregación BI.

### Backend POS/Kiosco

Archivo modificado:

`src/services/server/comercialKioscoPosServerService.ts`

Cambios:

- registra automáticamente cada pack vendido en `comercial_pack_venta`;
- conserva el modelo actual de expansión del pack a productos/servicios;
- guarda snapshot JSON de componentes;
- asocia cupón y promoción cuando corresponda;
- calcula descuento estimado atribuible al pack;
- mantiene descuentos de stock, movimientos y venta_detalle existentes.

### Nuevo endpoint

`GET /api/comercial/pack-analytics`

Archivo:

`src/app/api/comercial/pack-analytics/route.ts`

Permite consultar el dashboard BI de packs con filtros opcionales:

- `desde=YYYY-MM-DD`
- `hasta=YYYY-MM-DD`

### Nueva pantalla

`/dashboard/comercial/pack-analytics`

Archivo:

`src/app/dashboard/comercial/pack-analytics/page.tsx`

Incluye:

- ventas con pack;
- unidades vendidas;
- ingreso generado por packs;
- ticket promedio por pack;
- cupones usados;
- descuento estimado;
- ranking de packs;
- ranking de cupones/promociones;
- evolución mensual;
- últimas ventas con packs.

### Menú y permisos

Se agrega entrada:

`Comercial y Stock → BI Packs / Promos`

Archivos:

- `src/components/sidebar/sidebarConfig.ts`
- `src/lib/permissions/menuPermissions.ts`

### Dashboard comercial

Se incorpora acceso rápido/card desde el dashboard comercial principal.

Archivo:

`src/app/dashboard/comercial/page.tsx`

### Servicios e interfaces

Nuevos archivos:

- `src/interfaces/comercialPackAnalytics.interface.ts`
- `src/services/comercialPackAnalyticsService.ts`
- `src/services/server/comercialPackAnalyticsServerService.ts`

### Swagger

Se documenta el nuevo endpoint en:

`src/lib/swagger/openApiSpec.ts`

### Documentación técnica

Se agrega:

`docs/comercial/comercial-venta-pack-analytics-v1.md`

## Decisión técnica

No se modifica `venta_detalle` para aceptar `item_tipo = pack`.

El POS sigue expandiendo el pack a productos/servicios reales para mantener compatibilidad con:

- stock ledger;
- tickets;
- reportes existentes;
- BI de ventas actual;
- constraints de `venta_detalle`.

La nueva tabla `comercial_pack_venta` funciona como una tabla analítica complementaria para trazar la entidad comercial “pack vendido”.

## Validación realizada

- [x] Migración local/remote alineada hasta `202606222245` antes de aplicar la feature.
- [x] Migración privada preparada para `202606261930_comercial_venta_pack_analytics_v1.sql`.
- [x] Script de validación preparado: `database/scripts/validar_comercial_venta_pack_analytics_v1.sql`.
- [x] Pruebas funcionales realizadas satisfactoriamente.
- [x] Login administrador recuperado y validado para continuar QA.
- [x] Venta POS con pack probada.
- [x] BI Packs / Promos validado visual y funcionalmente.

## Checklist de QA sugerido

- [x] Crear o seleccionar pack disponible en POS.
- [x] Vender pack desde `/dashboard/comercial/kiosco`.
- [x] Confirmar registro en `venta` y `venta_detalle`.
- [x] Confirmar descuento de stock de productos incluidos.
- [x] Confirmar registro en `comercial_pack_venta`.
- [x] Abrir `/dashboard/comercial/pack-analytics`.
- [x] Verificar métricas principales.
- [x] Verificar ranking de packs.
- [x] Verificar últimas ventas con pack.
- [x] Probar filtro de fechas.
- [x] Probar venta con cupón/promoción.

## Archivos modificados/agregados

```txt
src/app/api/comercial/pack-analytics/route.ts
src/app/dashboard/comercial/pack-analytics/page.tsx
src/app/dashboard/comercial/page.tsx
src/components/sidebar/sidebarConfig.ts
src/interfaces/comercialPackAnalytics.interface.ts
src/lib/permissions/menuPermissions.ts
src/lib/swagger/openApiSpec.ts
src/services/comercialPackAnalyticsService.ts
src/services/server/comercialKioscoPosServerService.ts
src/services/server/comercialPackAnalyticsServerService.ts
docs/comercial/comercial-venta-pack-analytics-v1.md
supabase/migrations/202606261930_comercial_venta_pack_analytics_v1.sql
database/scripts/validar_comercial_venta_pack_analytics_v1.sql
```

## Notas de seguridad

Los archivos `.sql` de migración/validación son operativos privados y deben mantenerse fuera del commit público si el flujo del proyecto así lo requiere.

Antes del commit se recomienda validar:

```bash
git status --short | grep -E "supabase/migrations|database/scripts|database/private|\.sql|supabase/config.toml" || echo "OK: no hay SQL/config privado para commitear"
```

## Resultado

El módulo Comercial/POS queda con trazabilidad completa para packs/promociones:

- venta operativa desde POS;
- expansión compatible con productos/servicios;
- stock descontado;
- cupones/promos asociados;
- BI específico para packs vendidos;
- dashboard administrativo para decisiones comerciales.

## Título sugerido del PR

`feat: add commercial pack sales analytics`
