### PR TITLE
feat: add pwa offline and update experience

### DIFF
--- a/docs/mobile/pwa-offline-update-experience-v1.md
+++ b/docs/mobile/pwa-offline-update-experience-v1.md
@@ -1,0 +1,91 @@
+# PWA Offline & Update Experience v1
+
+## Rama
+
+`feature/pwa-offline-update-experience-v1`
+
+## Objetivo
+
+Mejorar la experiencia PWA de Gym Master cuando el socio usa la aplicación desde mobile o desde el modo instalado en Android/iOS.
+
+## Alcance
+
+- Detección de estado online/offline.
+- Aviso discreto cuando se pierde conexión.
+- Aviso de conexión recuperada.
+- Detección de service worker con nueva versión disponible.
+- Botón para actualizar la app cuando corresponde.
+- Página `/offline` como fallback documental para navegación sin conexión.
+- Fallback PWA de documento configurado en `next.config.js`.
+- Experiencia visible únicamente para socio en mobile/PWA.
+
+## Archivos modificados
+
+- `next.config.js`
+- `src/components/header/AppHeader.tsx`
+- `src/components/pwa/PwaConnectionUpdateBanner.tsx`
+- `src/app/offline/page.tsx`
+
+## Decisiones técnicas
+
+### Filtro por rol y contexto
+
+El nuevo banner se monta desde `AppHeader`, pero internamente solo se muestra si:
+
+- el usuario está autenticado,
+- el rol normalizado es `socio`,
+- el dispositivo es mobile o la app está corriendo en `display-mode: standalone`.
+
+Esto evita molestar a administradores y usuarios internos en el panel web de escritorio.
+
+### Online / offline
+
+Se utilizan los eventos nativos del navegador:
+
+- `online`
+- `offline`
+- `navigator.onLine`
+
+Cuando el usuario queda sin conexión, se muestra un aviso persistente. Cuando la conexión vuelve, se muestra una confirmación temporal.
+
+### Actualización PWA
+
+Se observa el service worker registrado mediante:
+
+- `navigator.serviceWorker.ready`
+- `registration.updatefound`
+- `registration.waiting`
+- `controllerchange`
+
+Cuando existe una nueva versión, se muestra un aviso con acción de actualización. El botón intenta enviar `SKIP_WAITING` al service worker disponible y recarga la página para tomar los assets actualizados.
+
+### Fallback offline
+
+Se agrega una ruta `/offline` y se configura `fallbacks.document` en `next-pwa` para mejorar la respuesta visual cuando una navegación no puede resolverse offline.
+
+## Validación sugerida
+
+```bash
+npm run build
+git restore public/sw.js public/workbox-*.js 2>/dev/null || true
+```
+
+## QA manual
+
+Validar en Android/Chrome desde Vercel:
+
+- Instalar PWA o abrir desde navegador mobile.
+- Login como socio.
+- Cortar conexión.
+- Confirmar aviso “Sin conexión”.
+- Restaurar conexión.
+- Confirmar aviso “Conexión recuperada”.
+- Publicar un nuevo deploy y abrir la app instalada.
+- Confirmar aviso de nueva versión cuando el navegador detecte el nuevo service worker.
+- Confirmar que admin y usuario interno no reciben avisos molestos en desktop.
+
+## Sin cambios
+
+- No toca base de datos.
+- No agrega migraciones.
+- No modifica endpoints backend.

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ const withPWA = require('next-pwa')({
   register: true,
   skipWaiting: true,
   disable: process.env.NODE_ENV === 'development', // evita errores en desarrollo
+  fallbacks: {
+    document: '/offline',
+  },
 });
 
 const nextConfig = {

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { WifiOff } from 'lucide-react';
+
+export default function OfflinePage() {
+  return (
+    <main className='flex min-h-dvh items-center justify-center bg-slate-950 px-4 py-10 text-white'>
+      <section className='w-full max-w-md rounded-3xl border border-white/10 bg-white/10 p-6 text-center shadow-2xl backdrop-blur'>
+        <div className='mx-auto flex h-14 w-14 items-center justify-center rounded-3xl bg-amber-400/15 text-amber-200'>
+          <WifiOff className='h-7 w-7' aria-hidden='true' />
+        </div>
+
+        <h1 className='mt-5 text-2xl font-black tracking-tight'>Estás sin conexión</h1>
+        <p className='mt-3 text-sm leading-6 text-slate-200'>
+          Gym Master no pudo cargar esta pantalla porque el dispositivo está offline. Revisá tu conexión e intentá nuevamente.
+        </p>
+
+        <div className='mt-6 grid gap-3'>
+          <Link
+            href='/dashboard'
+            className='rounded-full bg-white px-5 py-3 text-sm font-bold text-slate-950 transition hover:bg-slate-100'
+          >
+            Volver al inicio
+          </Link>
+          <button
+            type='button'
+            className='rounded-full border border-white/20 px-5 py-3 text-sm font-semibold text-white transition hover:bg-white/10'
+            onClick={() => window.location.reload()}
+          >
+            Reintentar
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -7,6 +7,7 @@ import ProfileImage from '@/components/perfil/ProfileImage';
 import { HeaderNotificationsBell } from '@/components/header/HeaderNotificationsBell';
 import { SocioMobileBottomNavigation } from '@/components/navigation/SocioMobileBottomNavigation';
 import { SocioPwaInstallPrompt } from '@/components/pwa/SocioPwaInstallPrompt';
+import { PwaConnectionUpdateBanner } from '@/components/pwa/PwaConnectionUpdateBanner';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -218,6 +219,7 @@ export const AppHeader = ({ title }: AppHeaderProps) => {
 
       <SocioMobileBottomNavigation />
       <SocioPwaInstallPrompt />
+      <PwaConnectionUpdateBanner />
     </>
   );
 };

--- a/src/components/pwa/PwaConnectionUpdateBanner.tsx
+++ b/src/components/pwa/PwaConnectionUpdateBanner.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { CheckCircle2, RefreshCw, WifiOff, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { useAuthStore } from '@/stores/authStore';
+
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const ONLINE_RESTORED_VISIBLE_MS = 4500;
+
+function isStandaloneMode() {
+  if (typeof window === 'undefined') return false;
+
+  const navigatorWithStandalone = window.navigator as Navigator & {
+    standalone?: boolean;
+  };
+
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    navigatorWithStandalone.standalone === true
+  );
+}
+
+export function PwaConnectionUpdateBanner() {
+  const isMobile = useIsMobile();
+  const { user, isAuthenticated } = useAuthStore();
+
+  const [isOnline, setIsOnline] = useState(true);
+  const [wasOffline, setWasOffline] = useState(false);
+  const [showOnlineRestored, setShowOnlineRestored] = useState(false);
+  const [updateReady, setUpdateReady] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isStandalone, setIsStandalone] = useState(false);
+
+  const onlineRestoredTimerRef = useRef<number | null>(null);
+
+  const isSocio = user?.rol?.trim().toLowerCase() === 'socio';
+  const shouldTargetSocioPwa = isAuthenticated && isSocio && (isMobile || isStandalone);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    setIsOnline(window.navigator.onLine);
+    setIsStandalone(isStandaloneMode());
+
+    const handleDisplayModeChange = () => {
+      setIsStandalone(isStandaloneMode());
+    };
+
+    const handleOffline = () => {
+      setIsOnline(false);
+      setWasOffline(true);
+      setShowOnlineRestored(false);
+    };
+
+    const handleOnline = () => {
+      setIsOnline(true);
+
+      if (wasOffline) {
+        setShowOnlineRestored(true);
+
+        if (onlineRestoredTimerRef.current) {
+          window.clearTimeout(onlineRestoredTimerRef.current);
+        }
+
+        onlineRestoredTimerRef.current = window.setTimeout(() => {
+          setShowOnlineRestored(false);
+          setWasOffline(false);
+        }, ONLINE_RESTORED_VISIBLE_MS);
+      }
+    };
+
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
+    mediaQuery.addEventListener('change', handleDisplayModeChange);
+
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+      mediaQuery.removeEventListener('change', handleDisplayModeChange);
+
+      if (onlineRestoredTimerRef.current) {
+        window.clearTimeout(onlineRestoredTimerRef.current);
+      }
+    };
+  }, [wasOffline]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+
+    let intervalId: number | null = null;
+    const hadControllerAtMount = Boolean(navigator.serviceWorker.controller);
+
+    const markUpdateReady = () => {
+      if (!isRefreshing) {
+        setUpdateReady(true);
+      }
+    };
+
+    const watchRegistration = (registration: ServiceWorkerRegistration) => {
+      if (registration.waiting && navigator.serviceWorker.controller) {
+        markUpdateReady();
+      }
+
+      const handleUpdateFound = () => {
+        const newWorker = registration.installing;
+        if (!newWorker) return;
+
+        newWorker.addEventListener('statechange', () => {
+          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+            markUpdateReady();
+          }
+        });
+      };
+
+      registration.addEventListener('updatefound', handleUpdateFound);
+
+      return () => {
+        registration.removeEventListener('updatefound', handleUpdateFound);
+      };
+    };
+
+    let cleanupRegistrationWatch: (() => void) | undefined;
+
+    navigator.serviceWorker.ready
+      .then((registration) => {
+        cleanupRegistrationWatch = watchRegistration(registration);
+
+        intervalId = window.setInterval(() => {
+          registration.update().catch(() => {
+            // La actualización del SW no debe romper la UI si el navegador falla o está offline.
+          });
+        }, UPDATE_CHECK_INTERVAL_MS);
+      })
+      .catch(() => {
+        // Si no hay SW disponible, la experiencia online/offline sigue funcionando.
+      });
+
+    const handleControllerChange = () => {
+      if (hadControllerAtMount) {
+        markUpdateReady();
+      }
+    };
+
+    navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);
+
+    return () => {
+      cleanupRegistrationWatch?.();
+      navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
+
+      if (intervalId) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, [isRefreshing]);
+
+  const handleUpdateNow = useCallback(async () => {
+    setIsRefreshing(true);
+
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      registration?.waiting?.postMessage({ type: 'SKIP_WAITING' });
+    } catch {
+      // Si el SW no responde, forzamos la recarga igualmente para tomar los assets nuevos.
+    }
+
+    window.location.reload();
+  }, []);
+
+  const handleDismissUpdate = () => {
+    setUpdateReady(false);
+  };
+
+  const banner = useMemo(() => {
+    if (!isOnline) {
+      return {
+        kind: 'offline' as const,
+        icon: WifiOff,
+        title: 'Sin conexión',
+        body: 'Podés seguir viendo contenido ya cargado. Algunas acciones volverán cuando tengas internet.',
+      };
+    }
+
+    if (updateReady) {
+      return {
+        kind: 'update' as const,
+        icon: RefreshCw,
+        title: 'Nueva versión disponible',
+        body: 'Actualizá Gym Master para usar la última versión de la app.',
+      };
+    }
+
+    if (showOnlineRestored) {
+      return {
+        kind: 'online' as const,
+        icon: CheckCircle2,
+        title: 'Conexión recuperada',
+        body: 'Ya podés seguir usando Gym Master normalmente.',
+      };
+    }
+
+    return null;
+  }, [isOnline, showOnlineRestored, updateReady]);
+
+  if (!shouldTargetSocioPwa || !banner) return null;
+
+  const Icon = banner.icon;
+
+  return (
+    <aside
+      className='fixed inset-x-3 bottom-[calc(10.2rem+env(safe-area-inset-bottom))] z-[76] mx-auto max-w-md rounded-3xl border border-slate-200 bg-white/95 p-3 shadow-[0_18px_48px_rgba(15,23,42,0.18)] backdrop-blur md:hidden dark:border-slate-800 dark:bg-slate-950/95'
+      role='status'
+      aria-live='polite'
+    >
+      <div className='flex items-start gap-3'>
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl ${
+            banner.kind === 'offline'
+              ? 'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-200'
+              : banner.kind === 'update'
+                ? 'bg-sky-50 text-sky-700 dark:bg-sky-950 dark:text-sky-200'
+                : 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-200'
+          }`}
+        >
+          <Icon className='h-5 w-5' aria-hidden='true' />
+        </div>
+
+        <div className='min-w-0 flex-1'>
+          <p className='text-sm font-bold text-slate-950 dark:text-slate-50'>{banner.title}</p>
+          <p className='mt-0.5 text-xs leading-5 text-slate-600 dark:text-slate-300'>
+            {banner.body}
+          </p>
+
+          {banner.kind === 'update' ? (
+            <div className='mt-3 flex items-center gap-2'>
+              <Button
+                size='sm'
+                className='h-8 rounded-full px-4 text-xs'
+                onClick={handleUpdateNow}
+                disabled={isRefreshing}
+              >
+                {isRefreshing ? 'Actualizando...' : 'Actualizar'}
+              </Button>
+              <Button
+                size='sm'
+                variant='ghost'
+                className='h-8 rounded-full px-3 text-xs'
+                onClick={handleDismissUpdate}
+              >
+                Después
+              </Button>
+            </div>
+          ) : null}
+        </div>
+
+        {banner.kind === 'update' ? (
+          <button
+            type='button'
+            className='rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-900 dark:hover:text-slate-200'
+            onClick={handleDismissUpdate}
+            aria-label='Ocultar aviso de actualización'
+          >
+            <X className='h-4 w-4' aria-hidden='true' />
+          </button>
+        ) : null}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
# PR: PWA Offline & Update Experience v1

## Rama

`feature/pwa-offline-update-experience-v1`

## Commit sugerido

`feat: add pwa offline and update experience`

## Resumen

Este PR mejora la experiencia PWA de Gym Master cuando se usa desde mobile o como aplicación instalada. La feature agrega un banner discreto para comunicar pérdida y recuperación de conexión, prepara una pantalla `/offline` como fallback visual, y deja una base para avisar al usuario cuando exista una nueva versión de la app disponible desde el service worker.

El foco principal es el rol **socio**, especialmente en experiencia mobile/PWA Android. Admin y usuario interno no reciben avisos molestos.

## Problema detectado

Después de dejar Gym Master con experiencia app-like e instalable como PWA, quedaban dos escenarios reales sin resolver:

- El socio podía perder conexión y no tener una señal clara de lo ocurrido.
- La PWA podía quedar usando una versión cacheada sin una comunicación clara cuando hubiera una actualización disponible.

Esta feature deja una experiencia más profesional para uso desde celular, especialmente cuando Gym Master se abre desde el ícono instalado.

## Cambios principales

### 1. Banner de conexión y actualización

Se incorpora el componente:

`src/components/pwa/PwaConnectionUpdateBanner.tsx`

Responsabilidades:

- Detectar estado online/offline del navegador.
- Mostrar aviso cuando se pierde conexión.
- Mostrar aviso breve cuando vuelve la conexión.
- Preparar aviso de nueva versión disponible.
- Permitir refrescar la app cuando corresponda.
- Ejecutarse principalmente para socio mobile/PWA.

### 2. Integración en el header del dashboard

Se actualiza:

`src/components/header/AppHeader.tsx`

El header mantiene:

- `SocioMobileBottomNavigation`
- `SocioPwaInstallPrompt`
- `PwaConnectionUpdateBanner`

De esta manera la experiencia mobile del socio queda centralizada sin afectar el flujo de admin o usuario interno.

### 3. Página offline

Se agrega:

`src/app/offline/page.tsx`

La pantalla `/offline` sirve como fallback visual para el caso de navegación sin conexión o fallback PWA. Informa al usuario que la conexión no está disponible y evita una experiencia en blanco o confusa.

### 4. Ajuste de configuración PWA

Se actualiza:

`next.config.js`

La configuración agrega soporte documental para fallback offline dentro del flujo PWA/next-pwa, manteniendo compatibilidad con Vercel.

### 5. Documentación técnica

Se agrega:

`docs/mobile/pwa-offline-update-experience-v1.md`

La documentación describe objetivo, alcance, comportamiento esperado, validación y consideraciones de QA.

## Archivos modificados

```txt
next.config.js
src/components/header/AppHeader.tsx
src/components/pwa/PwaConnectionUpdateBanner.tsx
src/app/offline/page.tsx
docs/mobile/pwa-offline-update-experience-v1.md
```

## Archivos generados por build que NO deben commitearse

Durante la validación local puede aparecer un archivo similar a:

```txt
public/fallback-*.js
```

Ese archivo es generado por el build/next-pwa y posee hash dinámico. No debe versionarse. Se debe eliminar antes del commit:

```bash
rm -f public/fallback-*.js
git restore public/sw.js public/workbox-*.js 2>/dev/null || true
```

## Validación realizada / recomendada

```bash
npm run build
git restore public/sw.js public/workbox-*.js 2>/dev/null || true
```

QA recomendado en Vercel + Android:

- Abrir Gym Master desde Chrome Android.
- Instalar/abrir como PWA si corresponde.
- Iniciar sesión como socio.
- Validar `/dashboard`.
- Cortar conexión y confirmar aviso offline.
- Restaurar conexión y confirmar aviso online.
- Abrir `/offline`.
- Confirmar que admin y usuario interno no reciben banners molestos.
- Confirmar que la bottom navigation del socio sigue funcionando.
- Confirmar que el footer y el scroll siguen correctos.

## Impacto funcional

- Mejora la claridad del estado de conexión para socios.
- Reduce confusión cuando la PWA queda sin internet.
- Prepara una base para actualización controlada de versiones PWA.
- Mantiene la experiencia app-like en mobile.
- No requiere migraciones ni cambios de backend.

## Riesgo y rollback

Riesgo bajo. Los cambios son frontend/PWA y no alteran datos persistentes. En caso de rollback, revertir los archivos modificados en esta rama.

## Checklist

- [x] Frontend only.
- [x] Sin migraciones de DB.
- [x] Sin cambios backend.
- [x] Compatible con Vercel.
- [x] Compatible con experiencia socio mobile.
- [x] Admin y usuario interno sin banners molestos.
- [x] Documentación incluida.
