### PR TITLE
feat: polish android installed pwa experience

### DIFF
--- a/docs/mobile/pwa-android-installed-app-polish-v1.md
+++ b/docs/mobile/pwa-android-installed-app-polish-v1.md
@@ -1,0 +1,57 @@
+# PWA Android Installed App Polish v1
+
+## Rama
+
+`feature/pwa-android-installed-app-polish-v1`
+
+## Objetivo
+
+Pulir la experiencia de Gym Master cuando se abre desde el ícono instalado en Android como PWA standalone, manteniendo compatibilidad con navegador web, mobile browser, admin y usuario interno.
+
+## Alcance
+
+- Controlador invisible para detectar modo standalone.
+- Clases globales `gm-pwa-standalone`, `gm-pwa-android` y `gm-pwa-ios`.
+- Variable CSS `--gm-vh` basada en `window.innerHeight` para evitar saltos visuales en Android.
+- Ajustes de safe-area para bottom navigation y banners flotantes.
+- Prompt de instalación reforzado para ocultarse si la app ya está instalada.
+- Banner offline/update más estable al recuperar conexión.
+- Manifest con splash/background oscuro coherente con `theme_color`.
+- Metadata mobile web app compatible con Android/iOS.
+- Página `/offline` ajustada a viewport real.
+
+## Archivos modificados
+
+- `src/components/header/AppHeader.tsx`
+- `src/components/pwa/PwaAndroidInstalledAppPolish.tsx`
+- `src/components/pwa/SocioPwaInstallPrompt.tsx`
+- `src/components/pwa/PwaConnectionUpdateBanner.tsx`
+- `src/components/navigation/SocioMobileBottomNavigation.tsx`
+- `src/app/layout.tsx`
+- `src/app/globals.css`
+- `src/app/offline/page.tsx`
+- `public/manifest.json`
+
+## Validación sugerida
+
+```bash
+npm run build
+git restore public/sw.js public/workbox-*.js public/fallback-*.js 2>/dev/null || true
+rm -f public/fallback-*.js
+```
+
+## QA Android real
+
+1. Abrir Gym Master desde Chrome Android.
+2. Instalar la app o abrirla desde el ícono instalado.
+3. Confirmar que el prompt de instalación no aparece en standalone.
+4. Confirmar que la bottom navigation no tapa contenido.
+5. Confirmar que offline/update no se superpone mal.
+6. Rotar pantalla y volver a portrait.
+7. Enviar app a segundo plano y volver.
+8. Confirmar que no hay flashes blancos notorios ni saltos de altura.
+9. Confirmar que admin y usuario interno no ven elementos específicos de socio.
+
+## Notas
+
+No incluye cambios en backend, base de datos ni autenticación.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,7 +11,7 @@
     "minimal-ui"
   ],
   "orientation": "portrait",
-  "background_color": "#ffffff",
+  "background_color": "#0f172a",
   "theme_color": "#0f172a",
   "categories": [
     "health",
@@ -106,5 +106,11 @@
         }
       ]
     }
-  ]
+  ],
+  "launch_handler": {
+    "client_mode": [
+      "navigate-existing",
+      "auto"
+    ]
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,3 +160,28 @@
     background: var(--background);
   }
 }
+/* PWA instalada en Android/iOS: evita saltos de alto y flashes blancos al abrir desde el ícono. */
+body.gm-pwa-standalone {
+  min-height: calc(var(--gm-vh, 1vh) * 100);
+  overscroll-behavior-y: contain;
+  touch-action: manipulation;
+  background: var(--background);
+}
+
+body.gm-pwa-standalone .gm-pwa-bottom-nav {
+  padding-bottom: calc(0.65rem + env(safe-area-inset-bottom));
+}
+
+body.gm-pwa-standalone .gm-pwa-floating-card {
+  bottom: calc(10.65rem + env(safe-area-inset-bottom));
+}
+
+body.gm-pwa-android {
+  -webkit-tap-highlight-color: transparent;
+}
+
+@media (max-width: 1023px) {
+  body.gm-pwa-standalone.gm-socio-bottom-nav main:not([data-slot="sidebar-inset"]) {
+    padding-bottom: calc(7.25rem + env(safe-area-inset-bottom)) !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,12 @@ export const metadata: Metadata = {
     title: 'Gym Master',
     statusBarStyle: 'black-translucent',
   },
+  other: {
+    'mobile-web-app-capable': 'yes',
+    'apple-mobile-web-app-capable': 'yes',
+    'apple-mobile-web-app-title': 'Gym Master',
+    'msapplication-TileColor': '#0f172a',
+  },
   formatDetection: {
     telephone: false,
   },

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -5,7 +5,7 @@ import { WifiOff } from 'lucide-react';
 
 export default function OfflinePage() {
   return (
-    <main className='flex min-h-dvh items-center justify-center bg-slate-950 px-4 py-10 text-white'>
+    <main className='flex min-h-[calc(var(--gm-vh,1vh)*100)] items-center justify-center bg-slate-950 px-4 py-[calc(2.5rem+env(safe-area-inset-top))] text-white'>
       <section className='w-full max-w-md rounded-3xl border border-white/10 bg-white/10 p-6 text-center shadow-2xl backdrop-blur'>
         <div className='mx-auto flex h-14 w-14 items-center justify-center rounded-3xl bg-amber-400/15 text-amber-200'>
           <WifiOff className='h-7 w-7' aria-hidden='true' />

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -8,6 +8,7 @@ import { HeaderNotificationsBell } from '@/components/header/HeaderNotifications
 import { SocioMobileBottomNavigation } from '@/components/navigation/SocioMobileBottomNavigation';
 import { SocioPwaInstallPrompt } from '@/components/pwa/SocioPwaInstallPrompt';
 import { PwaConnectionUpdateBanner } from '@/components/pwa/PwaConnectionUpdateBanner';
+import { PwaAndroidInstalledAppPolish } from '@/components/pwa/PwaAndroidInstalledAppPolish';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -220,6 +221,7 @@ export const AppHeader = ({ title }: AppHeaderProps) => {
       <SocioMobileBottomNavigation />
       <SocioPwaInstallPrompt />
       <PwaConnectionUpdateBanner />
+      <PwaAndroidInstalledAppPolish />
     </>
   );
 };

--- a/src/components/navigation/SocioMobileBottomNavigation.tsx
+++ b/src/components/navigation/SocioMobileBottomNavigation.tsx
@@ -81,7 +81,7 @@ export function SocioMobileBottomNavigation() {
   return (
     <nav
       aria-label='Navegación principal del socio'
-      className='fixed inset-x-0 bottom-0 z-[80] border-t border-slate-200/80 bg-white/95 px-2 pb-[calc(0.55rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-12px_32px_rgba(15,23,42,0.14)] backdrop-blur md:hidden dark:border-slate-800 dark:bg-slate-950/95'
+      className='gm-pwa-bottom-nav fixed inset-x-0 bottom-0 z-[80] border-t border-slate-200/80 bg-white/95 px-2 pb-[calc(0.55rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-12px_32px_rgba(15,23,42,0.14)] backdrop-blur md:hidden dark:border-slate-800 dark:bg-slate-950/95'
     >
       <div className='mx-auto grid max-w-md grid-cols-5 gap-1'>
         {socioBottomNavItems.map((item) => {

--- a/src/components/pwa/PwaAndroidInstalledAppPolish.tsx
+++ b/src/components/pwa/PwaAndroidInstalledAppPolish.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect } from 'react';
+
+function isStandaloneMode() {
+  if (typeof window === 'undefined') return false;
+
+  const navigatorWithStandalone = window.navigator as Navigator & {
+    standalone?: boolean;
+  };
+
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    navigatorWithStandalone.standalone === true
+  );
+}
+
+function isAndroidDevice() {
+  if (typeof window === 'undefined') return false;
+  return /android/i.test(window.navigator.userAgent);
+}
+
+function isIosDevice() {
+  if (typeof window === 'undefined') return false;
+
+  const ua = window.navigator.userAgent.toLowerCase();
+  const platform = window.navigator.platform?.toLowerCase() ?? '';
+
+  return (
+    /iphone|ipad|ipod/.test(ua) ||
+    (platform === 'macintel' && window.navigator.maxTouchPoints > 1)
+  );
+}
+
+function updateViewportHeightVariable() {
+  if (typeof window === 'undefined') return;
+
+  document.documentElement.style.setProperty('--gm-vh', `${window.innerHeight * 0.01}px`);
+}
+
+export function PwaAndroidInstalledAppPolish() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+
+    const syncInstalledModeClasses = () => {
+      const standalone = isStandaloneMode();
+      const android = isAndroidDevice();
+      const ios = isIosDevice();
+
+      document.body.classList.toggle('gm-pwa-standalone', standalone);
+      document.body.classList.toggle('gm-pwa-android', standalone && android);
+      document.body.classList.toggle('gm-pwa-ios', standalone && ios);
+
+      updateViewportHeightVariable();
+    };
+
+    syncInstalledModeClasses();
+
+    window.addEventListener('resize', syncInstalledModeClasses);
+    window.addEventListener('orientationchange', syncInstalledModeClasses);
+    window.addEventListener('pageshow', syncInstalledModeClasses);
+    document.addEventListener('visibilitychange', syncInstalledModeClasses);
+    mediaQuery.addEventListener('change', syncInstalledModeClasses);
+
+    return () => {
+      window.removeEventListener('resize', syncInstalledModeClasses);
+      window.removeEventListener('orientationchange', syncInstalledModeClasses);
+      window.removeEventListener('pageshow', syncInstalledModeClasses);
+      document.removeEventListener('visibilitychange', syncInstalledModeClasses);
+      mediaQuery.removeEventListener('change', syncInstalledModeClasses);
+
+      document.body.classList.remove('gm-pwa-standalone', 'gm-pwa-android', 'gm-pwa-ios');
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/pwa/PwaConnectionUpdateBanner.tsx
+++ b/src/components/pwa/PwaConnectionUpdateBanner.tsx
@@ -28,13 +28,13 @@ export function PwaConnectionUpdateBanner() {
   const { user, isAuthenticated } = useAuthStore();
 
   const [isOnline, setIsOnline] = useState(true);
-  const [wasOffline, setWasOffline] = useState(false);
   const [showOnlineRestored, setShowOnlineRestored] = useState(false);
   const [updateReady, setUpdateReady] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isStandalone, setIsStandalone] = useState(false);
 
   const onlineRestoredTimerRef = useRef<number | null>(null);
+  const wasOfflineRef = useRef(false);
 
   const isSocio = user?.rol?.trim().toLowerCase() === 'socio';
   const shouldTargetSocioPwa = isAuthenticated && isSocio && (isMobile || isStandalone);
@@ -42,7 +42,10 @@ export function PwaConnectionUpdateBanner() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    setIsOnline(window.navigator.onLine);
+    const initialOnline = window.navigator.onLine;
+
+    wasOfflineRef.current = !initialOnline;
+    setIsOnline(initialOnline);
     setIsStandalone(isStandaloneMode());
 
     const handleDisplayModeChange = () => {
@@ -50,15 +53,15 @@ export function PwaConnectionUpdateBanner() {
     };
 
     const handleOffline = () => {
+      wasOfflineRef.current = true;
       setIsOnline(false);
-      setWasOffline(true);
       setShowOnlineRestored(false);
     };
 
     const handleOnline = () => {
       setIsOnline(true);
 
-      if (wasOffline) {
+      if (wasOfflineRef.current) {
         setShowOnlineRestored(true);
 
         if (onlineRestoredTimerRef.current) {
@@ -66,8 +69,8 @@ export function PwaConnectionUpdateBanner() {
         }
 
         onlineRestoredTimerRef.current = window.setTimeout(() => {
+          wasOfflineRef.current = false;
           setShowOnlineRestored(false);
-          setWasOffline(false);
         }, ONLINE_RESTORED_VISIBLE_MS);
       }
     };
@@ -87,7 +90,7 @@ export function PwaConnectionUpdateBanner() {
         window.clearTimeout(onlineRestoredTimerRef.current);
       }
     };
-  }, [wasOffline]);
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
@@ -212,7 +215,7 @@ export function PwaConnectionUpdateBanner() {
 
   return (
     <aside
-      className='fixed inset-x-3 bottom-[calc(10.2rem+env(safe-area-inset-bottom))] z-[76] mx-auto max-w-md rounded-3xl border border-slate-200 bg-white/95 p-3 shadow-[0_18px_48px_rgba(15,23,42,0.18)] backdrop-blur md:hidden dark:border-slate-800 dark:bg-slate-950/95'
+      className='fixed inset-x-3 bottom-[calc(10.2rem+env(safe-area-inset-bottom))] z-[76] mx-auto max-w-md rounded-3xl border border-slate-200 bg-white/95 p-3 shadow-[0_18px_48px_rgba(15,23,42,0.18)] backdrop-blur md:hidden dark:border-slate-800 dark:bg-slate-950/95 gm-pwa-floating-card'
       role='status'
       aria-live='polite'
     >

--- a/src/components/pwa/SocioPwaInstallPrompt.tsx
+++ b/src/components/pwa/SocioPwaInstallPrompt.tsx
@@ -89,18 +89,30 @@ export function SocioPwaInstallPrompt() {
   }, [canInstallWithPrompt, isIos]);
 
   useEffect(() => {
-    setIsStandalone(isStandaloneMode());
-    setIsIos(isIosDevice());
+    const syncInstalledState = () => {
+      const standalone = isStandaloneMode();
 
-    const handleDisplayModeChange = () => {
-      setIsStandalone(isStandaloneMode());
+      setIsStandalone(standalone);
+      setIsIos(isIosDevice());
+
+      if (standalone) {
+        setShowPrompt(false);
+        setInstallEvent(null);
+      }
     };
 
+    syncInstalledState();
+
     const mediaQuery = window.matchMedia('(display-mode: standalone)');
-    mediaQuery.addEventListener('change', handleDisplayModeChange);
+
+    window.addEventListener('pageshow', syncInstalledState);
+    document.addEventListener('visibilitychange', syncInstalledState);
+    mediaQuery.addEventListener('change', syncInstalledState);
 
     return () => {
-      mediaQuery.removeEventListener('change', handleDisplayModeChange);
+      window.removeEventListener('pageshow', syncInstalledState);
+      document.removeEventListener('visibilitychange', syncInstalledState);
+      mediaQuery.removeEventListener('change', syncInstalledState);
     };
   }, []);
 


### PR DESCRIPTION
# PR: PWA Android Installed App Polish v1

## Rama

`feature/pwa-android-installed-app-polish-v1`

## Resumen

Esta feature realiza un pulido específico de la experiencia de Gym Master cuando se abre desde el ícono instalado en Android como PWA standalone. El objetivo es que la aplicación se comporte de forma más estable y nativa en mobile, sin afectar la experiencia web tradicional, admin ni usuario interno.

## Motivación

Después de validar la instalación PWA, la navegación mobile, el modo offline/update y el uso desde Vercel, quedaba una capa de refinamiento para Android real instalado como app. En este escenario aparecen detalles propios del navegador móvil y del modo standalone: viewport dinámico, safe-area, prompt de instalación, splash/background y superposición de banners con la navegación inferior.

## Cambios principales

- Se agregó un controlador invisible `PwaAndroidInstalledAppPolish` para detectar modo standalone y plataforma.
- Se incorporaron clases globales `gm-pwa-standalone`, `gm-pwa-android` y `gm-pwa-ios` sobre el documento.
- Se añadió la variable CSS `--gm-vh`, calculada desde `window.innerHeight`, para evitar saltos visuales en Android.
- Se ajustó la safe-area inferior para bottom navigation y banners flotantes.
- Se reforzó el prompt de instalación para ocultarse cuando la app ya está instalada.
- Se estabilizó el banner de conexión/update para evitar superposiciones incorrectas.
- Se actualizó el manifest para un splash/background más coherente con la marca.
- Se ajustó la página `/offline` para usar altura real del dispositivo.
- Se documentó la feature en `docs/mobile/pwa-android-installed-app-polish-v1.md`.

## Archivos modificados

- `public/manifest.json`
- `src/app/layout.tsx`
- `src/app/globals.css`
- `src/app/offline/page.tsx`
- `src/components/header/AppHeader.tsx`
- `src/components/navigation/SocioMobileBottomNavigation.tsx`
- `src/components/pwa/PwaAndroidInstalledAppPolish.tsx`
- `src/components/pwa/PwaConnectionUpdateBanner.tsx`
- `src/components/pwa/SocioPwaInstallPrompt.tsx`
- `docs/mobile/pwa-android-installed-app-polish-v1.md`

## Validación técnica

```bash
npm run build
git restore public/sw.js public/workbox-*.js public/fallback-*.js 2>/dev/null || true
rm -f public/fallback-*.js
```

> Nota: los archivos generados por next-pwa en `public/sw.js`, `public/workbox-*.js` y `public/fallback-*.js` no deben quedar versionados en este PR.

## QA recomendado en Android real

1. Abrir Gym Master desde Chrome Android.
2. Instalar la app o abrirla desde el ícono instalado.
3. Confirmar que el prompt “Instalá Gym Master” no aparece en standalone.
4. Confirmar que la bottom navigation no tapa contenido.
5. Confirmar que el banner offline/update no se superpone incorrectamente.
6. Rotar pantalla y volver a portrait.
7. Enviar la app a segundo plano y volver.
8. Confirmar que no hay flashes blancos notorios ni saltos de altura.
9. Confirmar que admin y usuario interno no ven elementos exclusivos de socio.

## Alcance

- Frontend only.
- Sin cambios en base de datos.
- Sin cambios backend.
- Sin cambios en autenticación.
- Compatible con Vercel.
- Compatible con el flujo PWA ya implementado.

## Riesgo y rollback

Riesgo bajo-moderado por tratarse de ajustes de experiencia mobile/PWA. Si Android real muestra algún comportamiento no deseado, se puede revertir este PR o aplicar un fix puntual sobre una rama corta:

`fix/pwa-android-installed-app-qa-v1`

## Resultado esperado

Gym Master debe sentirse más estable y nativo cuando el socio lo abre desde el ícono instalado en Android, manteniendo una experiencia limpia, sin prompts innecesarios, sin superposiciones y con mejor comportamiento visual ante viewport móvil, modo standalone y navegación inferior.
