### PR TITLE
test: add socio mobile final e2e qa

### DIFF
--- a/docs/mobile/hotfix-socio-mobile-e2e-playwright-device-v1.md
+++ b/docs/mobile/hotfix-socio-mobile-e2e-playwright-device-v1.md
@@ -1,0 +1,36 @@
+# Hotfix Socio Mobile E2E Playwright Device v1
+
+## Rama
+
+`feature/socio-mobile-e2e-final-qa-v1`
+
+## Motivo
+
+Durante la ejecución de `npm run test:e2e -- e2e/socio-mobile-final-qa.spec.ts`, Playwright reportó el error:
+
+```txt
+Cannot use({ defaultBrowserType }) in a describe group, because it forces a new worker.
+```
+
+El problema se originaba porque `devices['iPhone 12 Pro']` incluye la propiedad `defaultBrowserType`, y esa opción no puede declararse dentro de `test.describe()`.
+
+## Corrección
+
+- Se extrajo `defaultBrowserType` del perfil `iPhone 12 Pro`.
+- Se mantuvo la emulación mobile mediante viewport, userAgent, isMobile, hasTouch y deviceScaleFactor.
+- Se movió `test.use()` a nivel superior del archivo.
+- No se modificó lógica de negocio ni rutas probadas.
+
+## Archivo modificado
+
+- `e2e/socio-mobile-final-qa.spec.ts`
+
+## Validación
+
+```bash
+export E2E_SOCIO_EMAIL="celsosoria2026@gmail.com"
+export E2E_SOCIO_PASSWORD="GymMaster2026!"
+npm run test:e2e -- e2e/socio-mobile-final-qa.spec.ts
+```
+
+La advertencia de `baseline-browser-mapping` no bloquea la ejecución del test; es solo un aviso de dependencia desactualizada.

--- a/docs/mobile/socio-mobile-e2e-final-qa-v1.md
+++ b/docs/mobile/socio-mobile-e2e-final-qa-v1.md
@@ -1,0 +1,124 @@
+# Socio Mobile E2E Final QA v1
+
+## Rama
+
+`feature/socio-mobile-e2e-final-qa-v1`
+
+## Objetivo
+
+Consolidar una pasada final de QA del flujo socio mobile/PWA luego de las mejoras aplicadas al dashboard, navegación inferior, PWA instalada, tarjetas funcionales y módulos principales del socio.
+
+Esta feature no agrega lógica de negocio nueva. Su foco es dejar una base de validación repetible para evitar regresiones en el recorrido mobile del socio.
+
+## Alcance
+
+- Se agregan helpers E2E para credenciales de socio.
+- Se agrega test Playwright mobile para recorrer rutas críticas del socio.
+- Se valida que el dashboard mobile muestre el feed priorizado.
+- Se valida que las rutas del socio no caigan en bloqueo RBAC.
+- Se valida ausencia de errores críticos de renderizado.
+- Se documenta checklist manual para Android real, Vercel y Supabase remoto.
+
+## Archivos modificados
+
+- `e2e/helpers/auth.ts`
+- `e2e/helpers/assertions.ts`
+- `e2e/socio-mobile-final-qa.spec.ts`
+- `docs/mobile/socio-mobile-e2e-final-qa-v1.md`
+
+## Variables E2E requeridas
+
+Para correr las pruebas autenticadas de socio:
+
+```bash
+E2E_SOCIO_EMAIL="socio-demo@gymmaster.local"
+E2E_SOCIO_PASSWORD="password-demo"
+```
+
+También se puede usar contra Vercel o contra local:
+
+```bash
+E2E_BASE_URL="http://127.0.0.1:3000"
+E2E_SKIP_WEBSERVER=1
+```
+
+## Comandos sugeridos
+
+### Local con servidor iniciado por Playwright
+
+```bash
+npm run test:e2e -- e2e/socio-mobile-final-qa.spec.ts
+```
+
+### Contra servidor ya iniciado
+
+```bash
+E2E_SKIP_WEBSERVER=1 E2E_BASE_URL="http://localhost:3000" npm run test:e2e -- e2e/socio-mobile-final-qa.spec.ts
+```
+
+### Contra Vercel
+
+```bash
+E2E_SKIP_WEBSERVER=1 E2E_BASE_URL="https://TU_DEPLOY.vercel.app" npm run test:e2e -- e2e/socio-mobile-final-qa.spec.ts
+```
+
+## Rutas cubiertas
+
+- `/dashboard`
+- `/dashboard/control-asistencia`
+- `/dashboard/mi-cuenta/pagar-cuota`
+- `/dashboard/mi-cuenta/historial-pagos`
+- `/dashboard/rutinas`
+- `/dashboard/rutinas/asistente`
+- `/dashboard/dietas`
+- `/dashboard/coach`
+- `/dashboard/evolucion-fisica`
+- `/dashboard/ficha-medica`
+- `/dashboard/mensajes`
+
+## Validación automática
+
+El test verifica:
+
+- Login como socio desde `/auth/login/socio`.
+- Carga del dashboard mobile.
+- Presencia de secciones clave:
+  - Tu plan de acción.
+  - Acceso y estado.
+  - Pagos y recibos / cuota.
+  - Mi salud / ficha médica.
+  - Agenda del gimnasio.
+  - Soporte / mensajes.
+- Ausencia del mensaje `USTED NO TIENE ACCESO A ESTE MENÚ`.
+- Ausencia de errores críticos tipo `Application error`, `Internal Server Error`, `ChunkLoadError` o errores runtime relevantes.
+
+## Checklist manual Android/PWA
+
+Validar en Android real después de deploy:
+
+1. Abrir Gym Master desde el ícono instalado.
+2. Login como socio.
+3. Confirmar que no aparece prompt de instalación si ya está instalada.
+4. Recorrer el dashboard completo.
+5. Confirmar scroll fluido sin trabas.
+6. Confirmar que la bottom navigation no tapa contenido.
+7. Abrir QR de ingreso.
+8. Revisar pagos y recibos.
+9. Revisar rutina/dieta de hoy.
+10. Abrir detalle de rutina y probar ayuda de series/repeticiones.
+11. Revisar evolución física.
+12. Revisar ficha médica.
+13. Revisar mensajes/soporte.
+14. Revisar agenda informativa de actividades.
+15. Cortar conexión y confirmar aviso offline.
+16. Restaurar conexión y confirmar aviso online.
+
+## Checklist desktop
+
+- `/dashboard` como socio no debe dejar franja blanca excesiva debajo del footer.
+- El layout desktop debe conservar hero, estado de cuota y footer correctamente.
+- Las tarjetas mobile deben permanecer ocultas en desktop cuando corresponda.
+
+## Resultado esperado
+
+La experiencia mobile del socio queda validada como flujo completo, con cobertura automática de rutas críticas y checklist manual para Android real/PWA instalada.

--- a/e2e/helpers/assertions.ts
+++ b/e2e/helpers/assertions.ts
@@ -22,3 +22,10 @@ export async function waitForAppReady(page: Page) {
   await page.waitForTimeout(500);
   await expectNoCriticalAppError(page);
 }
+
+export async function expectNoAccessDenied(page: Page) {
+  const body = page.locator('body');
+
+  await expect(body).not.toContainText(/USTED NO TIENE ACCESO A ESTE MENÚ/i);
+  await expect(body).not.toContainText(/Tu usuario no tiene permisos para ingresar a esta sección/i);
+}

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -15,9 +15,22 @@ export function getAdminCredentials() {
   };
 }
 
+export function getSocioCredentials() {
+  return {
+    email: process.env.E2E_SOCIO_EMAIL,
+    password: process.env.E2E_SOCIO_PASSWORD,
+    role: 'socio' as const,
+  };
+}
+
 export function skipIfMissingAdminCredentials() {
   const { email, password } = getAdminCredentials();
   test.skip(!email || !password, 'Definir E2E_ADMIN_EMAIL y E2E_ADMIN_PASSWORD para ejecutar pruebas autenticadas.');
+}
+
+export function skipIfMissingSocioCredentials() {
+  const { email, password } = getSocioCredentials();
+  test.skip(!email || !password, 'Definir E2E_SOCIO_EMAIL y E2E_SOCIO_PASSWORD para ejecutar pruebas socio mobile.');
 }
 
 export async function loginAsAdmin(page: Page, options: LoginOptions = {}) {
@@ -47,4 +60,15 @@ export async function loginAsAdmin(page: Page, options: LoginOptions = {}) {
 
   await expect(page).toHaveURL(/\/dashboard(\/.*)?$/);
   await waitForAppReady(page);
+}
+
+export async function loginAsSocio(page: Page, options: LoginOptions = {}) {
+  const defaults = getSocioCredentials();
+
+  return loginAsAdmin(page, {
+    ...options,
+    email: options.email ?? defaults.email,
+    password: options.password ?? defaults.password,
+    role: 'socio',
+  });
 }

--- a/e2e/socio-mobile-final-qa.spec.ts
+++ b/e2e/socio-mobile-final-qa.spec.ts
@@ -1,0 +1,65 @@
+import { devices, expect, test } from '@playwright/test';
+import { expectNoAccessDenied, expectNoCriticalAppError, waitForAppReady } from './helpers/assertions';
+import { loginAsSocio, skipIfMissingSocioCredentials } from './helpers/auth';
+
+const socioMobileRoutes = [
+  '/dashboard',
+  '/dashboard/control-asistencia',
+  '/dashboard/mi-cuenta/pagar-cuota',
+  '/dashboard/mi-cuenta/historial-pagos',
+  '/dashboard/rutinas',
+  '/dashboard/rutinas/asistente',
+  '/dashboard/dietas',
+  '/dashboard/coach',
+  '/dashboard/evolucion-fisica',
+  '/dashboard/ficha-medica',
+  '/dashboard/mensajes',
+];
+
+const { defaultBrowserType: _defaultBrowserType, ...iPhone12ProDevice } = devices['iPhone 12 Pro'];
+
+// No usamos defaultBrowserType dentro de describe porque Playwright lo trata como opción
+// de worker y no permite configurarlo en un grupo de tests. El perfil mobile se mantiene
+// con viewport, userAgent, isMobile, hasTouch y deviceScaleFactor.
+test.use({
+  ...iPhone12ProDevice,
+  viewport: { width: 390, height: 844 },
+});
+
+test.describe('Smoke E2E socio mobile/PWA final', () => {
+  test.beforeEach(() => {
+    skipIfMissingSocioCredentials();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsSocio(page);
+  });
+
+  test('dashboard mobile muestra el feed priorizado sin errores críticos', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForAppReady(page);
+
+    const body = page.locator('body');
+
+    await expect(body).toContainText(/Tu plan de acción/i);
+    await expect(body).toContainText(/Acceso y estado/i);
+    await expect(body).toContainText(/Pagos y recibos|Mi cuota|Pagar cuota/i);
+    await expect(body).toContainText(/Mi salud|Ficha médica/i);
+    await expect(body).toContainText(/Agenda del gimnasio/i);
+    await expect(body).toContainText(/Soporte del gimnasio|Mensajes/i);
+
+    await expectNoAccessDenied(page);
+    await expectNoCriticalAppError(page);
+  });
+
+  for (const path of socioMobileRoutes) {
+    test(`carga ${path} como socio mobile sin bloqueo RBAC`, async ({ page }) => {
+      await page.goto(path);
+      await waitForAppReady(page);
+
+      await expect(page).toHaveURL(new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      await expectNoAccessDenied(page);
+      await expectNoCriticalAppError(page);
+    });
+  }
+});


### PR DESCRIPTION
# PR: Socio Mobile E2E Final QA v1

## Rama

`feature/socio-mobile-e2e-final-qa-v1`

## Resumen

Este PR incorpora una suite E2E final para validar el recorrido mobile/PWA del socio en Gym Master, luego del bloque de mejoras aplicadas sobre el dashboard mobile, PWA instalada, navegación inferior, tarjetas del socio y rutas principales.

La validación automatizada recorre las rutas críticas del socio y verifica que no aparezcan bloqueos RBAC indebidos, errores críticos de frontend ni pantallas de acceso denegado en los módulos habilitados para el rol.

## Cambios realizados

- Se agregó un test Playwright específico para QA final del socio mobile/PWA.
- Se incorporaron helpers reutilizables de autenticación E2E.
- Se incorporaron helpers de aserciones para detectar errores críticos, pantallas de acceso denegado y fallos de frontend.
- Se emuló viewport mobile con soporte touch para validar experiencia tipo celular.
- Se agregó documentación manual de QA para Android real, PWA instalada, Vercel y Supabase remoto.
- Se aplicó hotfix Playwright para evitar el error de `defaultBrowserType` dentro de `describe`.

## Archivos incluidos

- `e2e/helpers/auth.ts`
- `e2e/helpers/assertions.ts`
- `e2e/socio-mobile-final-qa.spec.ts`
- `docs/mobile/socio-mobile-e2e-final-qa-v1.md`
- `docs/mobile/hotfix-socio-mobile-e2e-playwright-device-v1.md`

## Validación ejecutada

Se ejecutó:

```bash
export E2E_SOCIO_EMAIL="celsosoria2026@gmail.com"
export E2E_SOCIO_PASSWORD="GymMaster2026!"

npm run test:e2e -- e2e/socio-mobile-final-qa.spec.ts
```

Resultado:

```txt
12 passed (2.4m)
```

Rutas validadas:

- `/dashboard`
- `/dashboard/control-asistencia`
- `/dashboard/mi-cuenta/pagar-cuota`
- `/dashboard/mi-cuenta/historial-pagos`
- `/dashboard/rutinas`
- `/dashboard/rutinas/asistente`
- `/dashboard/dietas`
- `/dashboard/coach`
- `/dashboard/evolucion-fisica`
- `/dashboard/ficha-medica`
- `/dashboard/mensajes`

## Notas técnicas

- Los warnings de `baseline-browser-mapping` no bloquean la ejecución.
- Los mensajes de Fast Refresh durante Playwright no representan fallo funcional.
- Los archivos generados por PWA (`public/sw.js`, `public/workbox-*.js`, `public/fallback-*.js`) deben excluirse del commit.

## Tipo de cambio

- Test E2E
- QA mobile/PWA
- Documentación técnica
- Sin cambios de base de datos
- Sin cambios backend
