### PR TITLE
feat: add Dragon Pyramid grace period warnings

### DIFF
--- a/docs/mobile/dragon-pyramid-grace-period-warning-v1.md
+++ b/docs/mobile/dragon-pyramid-grace-period-warning-v1.md
@@ -1,0 +1,64 @@
+# Gym Master — Dragon Pyramid grace period warning v1
+
+## Rama
+
+`feature/dragon-pyramid-grace-period-warning-v1`
+
+## Objetivo
+
+Agregar una capa informativa de advertencias comerciales para administradores del gimnasio cuando la licencia o el estado de pago SaaS de Dragon Pyramid indican riesgo operativo.
+
+Esta feature no bloquea el sistema. Solo informa estados como pago pendiente, vencido, período de gracia, licencia próxima a vencer o candidato a suspensión futura. El bloqueo real queda reservado para `feature/dragon-pyramid-app-suspension-by-nonpayment-v1`.
+
+## Cambios principales
+
+- Nuevo endpoint seguro `GET /api/dragon-pyramid/license/warning` para roles `admin` y `masteradmin`.
+- Nuevo helper compartido `buildDragonPyramidGraceWarning` para calcular severidad y mensajes.
+- Banner visible en `/dashboard` para rol `admin` cuando existe riesgo comercial.
+- Banner detallado en `/dashboard/masteradmin/license` para el usuario Dragon Pyramid Master Admin.
+- Swagger actualizado con el nuevo endpoint.
+- Sin cambios de base de datos.
+- Sin bloqueo de login, dashboard ni rutas operativas.
+
+## Reglas funcionales
+
+Se genera advertencia cuando aparece alguno de estos casos:
+
+- `payment_status = pending`
+- `payment_status = overdue`
+- `payment_status = grace`
+- `payment_status = suspended_candidate`
+- `license_status = grace`
+- `license_status = suspended`
+- `license_status = cancelled`
+- `next_due_at` próximo o vencido
+- `expires_at` próximo o vencido
+- `grace_until` próximo o vencido cuando el cliente está en gracia
+
+## Roles
+
+- `admin`: ve aviso resumido en `/dashboard`.
+- `masteradmin`: ve aviso detallado en `/dashboard/masteradmin/license`.
+- `usuario`: no ve avisos comerciales en esta etapa.
+- `socio`: no ve avisos comerciales.
+
+## Seguridad
+
+El endpoint solo expone un resumen operativo para advertencias y requiere JWT. No permite modificar licencia ni pagos.
+
+## QA sugerido
+
+1. Entrar como `masteradmin` a `/dashboard/masteradmin/license`.
+2. Cambiar estado de pago a `overdue`, `grace` o `suspended_candidate`.
+3. Guardar y confirmar que aparece advertencia en el panel Master Admin.
+4. Entrar como `admin` a `/dashboard`.
+5. Confirmar que aparece banner informativo.
+6. Entrar como socio y confirmar que no ve aviso comercial.
+7. Probar `GET /api/dragon-pyramid/license/warning` como admin.
+8. Probar el mismo endpoint como socio y confirmar 403.
+9. Confirmar que no se bloquea el sistema.
+10. Ejecutar `npm run build`.
+
+## Notas
+
+Esta feature prepara la comunicación previa al bloqueo. No aplica suspensión real ni cierre de sesión. La suspensión se implementará en una feature separada para controlar cuidadosamente excepciones, soporte y recuperación.

--- a/src/app/api/dragon-pyramid/license/warning/route.ts
+++ b/src/app/api/dragon-pyramid/license/warning/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getDragonPyramidLicense } from '@/services/server/dragonPyramidLicenseService';
+import { buildDragonPyramidGraceWarning } from '@/utils/dragonPyramidLicenseWarning';
+
+export const dynamic = 'force-dynamic';
+
+function assertCanReadLicenseWarning(role?: string | null) {
+  if (role !== 'admin' && role !== 'masteradmin') {
+    throw new Error('No tenés permisos para consultar avisos de licencia Dragon Pyramid');
+  }
+}
+
+function resolveStatus(message: string) {
+  if (message.includes('Token')) return 401;
+  if (message.includes('permisos')) return 403;
+  return 500;
+}
+
+export async function GET(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    assertCanReadLicenseWarning(user?.rol);
+
+    const license = await getDragonPyramidLicense();
+    const warning = buildDragonPyramidGraceWarning(license);
+
+    return NextResponse.json(
+      {
+        data: warning,
+        summary: license
+          ? {
+              client_name: license.client_name,
+              license_status: license.license_status,
+              payment_status: license.payment_status,
+              next_due_at: license.next_due_at,
+              grace_until: license.grace_until,
+              expires_at: license.expires_at,
+            }
+          : null,
+      },
+      {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store' },
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: resolveStatus(message) });
+  }
+}

--- a/src/app/dashboard/masteradmin/license/page.tsx
+++ b/src/app/dashboard/masteradmin/license/page.tsx
@@ -32,6 +32,7 @@ import type {
   DragonPyramidLicenseControl,
   DragonPyramidLicenseStatus,
 } from '@/interfaces/dragonPyramidLicense.interface';
+import { buildDragonPyramidGraceWarning } from '@/utils/dragonPyramidLicenseWarning';
 
 const statusOptions: Array<{ value: DragonPyramidLicenseStatus; label: string; helper: string }> = [
   { value: 'active', label: 'Activa', helper: 'Cliente habilitado normalmente.' },
@@ -184,6 +185,8 @@ export default function MasterAdminLicensePage() {
     return `Vence en ${daysUntilPayment} día(s)`;
   }, [daysUntilPayment]);
 
+  const graceWarning = useMemo(() => buildDragonPyramidGraceWarning(license), [license]);
+
   const summaryCards = useMemo(
     () => [
       { label: 'Producto', value: 'Gym Master', icon: Activity },
@@ -301,6 +304,40 @@ export default function MasterAdminLicensePage() {
               </div>
             </div>
           </div>
+
+          {graceWarning.visible && (
+            <Card
+              className={`min-w-0 border shadow-xl ${
+                graceWarning.severity === 'critical'
+                  ? 'border-red-400/40 bg-red-950/30 text-red-50'
+                  : 'border-amber-400/40 bg-amber-950/30 text-amber-50'
+              }`}
+            >
+              <CardContent className='flex flex-col gap-4 p-5 md:flex-row md:items-start md:justify-between'>
+                <div className='flex min-w-0 gap-3'>
+                  <AlertTriangle className='mt-1 h-5 w-5 shrink-0' />
+                  <div className='min-w-0'>
+                    <p className='text-xs font-semibold uppercase tracking-[0.22em] opacity-80'>
+                      Advertencia previa a suspensión
+                    </p>
+                    <h3 className='mt-1 text-lg font-black'>{graceWarning.title}</h3>
+                    <p className='mt-1 text-sm leading-6'>{graceWarning.message}</p>
+                    <ul className='mt-3 list-disc space-y-1 pl-4 text-sm leading-6'>
+                      {graceWarning.details.map((detail) => (
+                        <li key={detail}>{detail}</li>
+                      ))}
+                    </ul>
+                    <p className='mt-3 text-xs opacity-80'>
+                      Esta feature solo informa al cliente. El bloqueo real se implementará en la feature de suspensión por falta de pago.
+                    </p>
+                  </div>
+                </div>
+                <div className='rounded-2xl border border-current/20 px-4 py-3 text-sm font-bold'>
+                  {graceWarning.clientName ?? form.client_name ?? 'Gym Master Cliente'}
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           <div className='grid w-full min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6'>
             {summaryCards.map((item) => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,6 +37,7 @@ import {
   getEstadoActualEquipamiento,
   getSegmentacionPagos,
   getHistogramaPagos,
+  getDragonPyramidLicenseWarning,
 } from '@/services/apiClient';
 
 import { Equipamento } from '@/interfaces/equipamiento.interface';
@@ -50,6 +51,7 @@ import { getResolvedGimnasioBranding } from '@/utils/gimnasioBrandingClient';
 
 // ⬇️ IMPORTA EL TIPO QUE EMITE LA TABLA
 import type { AsistenciaReciente as AsistenciaRecienteApi } from '@/services/qrService';
+import type { DragonPyramidGraceWarning } from '@/utils/dragonPyramidLicenseWarning';
 
 type AdminAccessEventPayload = {
   event_id?: string;
@@ -160,6 +162,9 @@ export default function DashboardPage() {
     completa: boolean;
     faltantes: string[];
   } | null>(null);
+  const [dragonPyramidLicenseWarning, setDragonPyramidLicenseWarning] =
+    useState<DragonPyramidGraceWarning | null>(null);
+  const [loadingDragonPyramidWarning, setLoadingDragonPyramidWarning] = useState(false);
 
   // Overlay de bienvenida
   const [showWelcome, setShowWelcome] = useState(false);
@@ -341,6 +346,40 @@ export default function DashboardPage() {
 
     return () => {
       cancelled = true;
+    };
+  }, [user?.rol]);
+
+
+  useEffect(() => {
+    if (user?.rol !== 'admin') {
+      setDragonPyramidLicenseWarning(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchDragonPyramidLicenseWarning() {
+      try {
+        setLoadingDragonPyramidWarning(true);
+        const response = await getDragonPyramidLicenseWarning();
+        if (!cancelled) {
+          setDragonPyramidLicenseWarning(response.ok ? response.data ?? null : null);
+        }
+      } catch (error) {
+        console.error('Error cargando aviso de licencia Dragon Pyramid:', error);
+        if (!cancelled) setDragonPyramidLicenseWarning(null);
+      } finally {
+        if (!cancelled) setLoadingDragonPyramidWarning(false);
+      }
+    }
+
+    fetchDragonPyramidLicenseWarning();
+
+    const interval = window.setInterval(fetchDragonPyramidLicenseWarning, 300000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
     };
   }, [user?.rol]);
 
@@ -542,6 +581,45 @@ export default function DashboardPage() {
 
             {userType === 'admin' && (
               <>
+                {dragonPyramidLicenseWarning?.visible && (
+                  <Card
+                    className={`border shadow-sm ${
+                      dragonPyramidLicenseWarning.severity === 'critical'
+                        ? 'border-red-300 bg-red-50 text-red-950 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-50'
+                        : 'border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-50'
+                    }`}
+                  >
+                    <CardContent className='flex flex-col gap-4 p-4 sm:p-5 md:flex-row md:items-start md:justify-between'>
+                      <div className='flex min-w-0 gap-3'>
+                        <AlertTriangle className='mt-1 h-5 w-5 shrink-0' />
+                        <div className='min-w-0'>
+                          <p className='text-xs font-semibold uppercase tracking-[0.22em] opacity-80'>
+                            Aviso comercial Dragon Pyramid
+                          </p>
+                          <h2 className='mt-1 text-base font-black sm:text-lg'>
+                            {dragonPyramidLicenseWarning.title}
+                          </h2>
+                          <p className='mt-1 text-sm leading-6'>
+                            {dragonPyramidLicenseWarning.message}
+                          </p>
+                          <ul className='mt-2 list-disc space-y-1 pl-4 text-xs leading-5 sm:text-sm'>
+                            {dragonPyramidLicenseWarning.details.slice(0, 4).map((detail) => (
+                              <li key={detail}>{detail}</li>
+                            ))}
+                          </ul>
+                          <p className='mt-2 text-xs opacity-80'>
+                            Este aviso no bloquea el sistema. La suspensión real queda reservada para la feature posterior de bloqueo por falta de pago.
+                          </p>
+                        </div>
+                      </div>
+                      <div className='rounded-xl border border-current/20 px-3 py-2 text-xs font-semibold md:max-w-[240px]'>
+                        Cliente: {dragonPyramidLicenseWarning.clientName ?? 'Gym Master Cliente'}
+                        {loadingDragonPyramidWarning ? ' · actualizando...' : ''}
+                      </div>
+                    </CardContent>
+                  </Card>
+                )}
+
                 {gimnasioParametrizacionStatus && !gimnasioParametrizacionStatus.completa && (
                   <Card className='border-amber-300 bg-amber-50 text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/30 dark:text-amber-50'>
                     <CardContent className='flex flex-col gap-4 p-4 sm:p-5 md:flex-row md:items-center md:justify-between'>

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -33,6 +33,22 @@ const endpointDefinitions: EndpointDefinition[] = [
     source: "src/app/api/dragon-pyramid/license/route.ts",
     internal: true,
   },
+
+  {
+    path: "/api/dragon-pyramid/license/warning",
+    methods: ["GET"],
+    tag: "Dragon Pyramid",
+    summary: "Aviso de vencimiento y gracia Dragon Pyramid",
+    description:
+      "Devuelve un resumen seguro para administradores del gimnasio con advertencias de licencia, pago vencido, próximo vencimiento o período de gracia. No bloquea el sistema; solo informa antes de la futura suspensión por falta de pago.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/dragon-pyramid/license/warning/route.ts",
+    internal: true,
+  },
   {
     path: "/api/internal/dragon-pyramid/license-sync",
     methods: ["POST"],

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1192,3 +1192,14 @@ export async function updateDragonPyramidLicenseControl(payload: unknown) {
   const data = await res.json();
   return { ok: res.ok, ...data };
 }
+
+export async function getDragonPyramidLicenseWarning() {
+  const token = getToken();
+  const res = await fetch('/api/dragon-pyramid/license/warning', {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    cache: 'no-store',
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}

--- a/src/utils/dragonPyramidLicenseWarning.ts
+++ b/src/utils/dragonPyramidLicenseWarning.ts
@@ -1,0 +1,199 @@
+import type {
+  DragonPyramidClientPaymentStatus,
+  DragonPyramidLicenseControl,
+  DragonPyramidLicenseStatus,
+} from '@/interfaces/dragonPyramidLicense.interface';
+
+export type DragonPyramidGraceWarningSeverity = 'info' | 'warning' | 'critical';
+
+export type DragonPyramidGraceWarning = {
+  visible: boolean;
+  severity: DragonPyramidGraceWarningSeverity;
+  title: string;
+  message: string;
+  details: string[];
+  licenseStatus: DragonPyramidLicenseStatus | null;
+  paymentStatus: DragonPyramidClientPaymentStatus | null;
+  daysUntilLicenseExpiration: number | null;
+  daysUntilPaymentDue: number | null;
+  daysUntilGraceEnd: number | null;
+  clientName: string | null;
+  nextDueAt: string | null;
+  graceUntil: string | null;
+};
+
+const NEAR_DUE_DAYS = 7;
+
+const licenseStatusLabel: Record<DragonPyramidLicenseStatus, string> = {
+  active: 'activa',
+  trial: 'trial',
+  grace: 'en gracia',
+  suspended: 'suspendida',
+  cancelled: 'cancelada',
+};
+
+const paymentStatusLabel: Record<DragonPyramidClientPaymentStatus, string> = {
+  paid: 'al día',
+  pending: 'pendiente',
+  overdue: 'vencido',
+  grace: 'en gracia',
+  suspended_candidate: 'candidato a suspensión',
+  unknown: 'sin dato',
+};
+
+function daysUntil(value?: string | null) {
+  if (!value) return null;
+  const target = new Date(value);
+  if (Number.isNaN(target.getTime())) return null;
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const targetDay = new Date(target.getFullYear(), target.getMonth(), target.getDate()).getTime();
+  return Math.ceil((targetDay - startOfToday) / (1000 * 60 * 60 * 24));
+}
+
+function formatRelative(days: number | null, futureLabel: string, todayLabel: string, pastLabel: string) {
+  if (days === null) return null;
+  if (days < 0) return `${pastLabel} hace ${Math.abs(days)} día(s)`;
+  if (days === 0) return todayLabel;
+  return `${futureLabel} en ${days} día(s)`;
+}
+
+function maxSeverity(
+  current: DragonPyramidGraceWarningSeverity,
+  next: DragonPyramidGraceWarningSeverity,
+): DragonPyramidGraceWarningSeverity {
+  const rank: Record<DragonPyramidGraceWarningSeverity, number> = {
+    info: 1,
+    warning: 2,
+    critical: 3,
+  };
+  return rank[next] > rank[current] ? next : current;
+}
+
+export function buildDragonPyramidGraceWarning(
+  license?: DragonPyramidLicenseControl | null,
+): DragonPyramidGraceWarning {
+  const licenseStatus = license?.license_status ?? null;
+  const paymentStatus = license?.payment_status ?? null;
+  const daysUntilLicenseExpiration = daysUntil(license?.expires_at);
+  const daysUntilPaymentDue = daysUntil(license?.next_due_at);
+  const daysUntilGraceEnd = daysUntil(license?.grace_until);
+  const details: string[] = [];
+  let severity: DragonPyramidGraceWarningSeverity = 'info';
+
+  if (!license) {
+    return {
+      visible: false,
+      severity: 'info',
+      title: 'Sin estado de licencia configurado',
+      message: 'Todavía no hay datos comerciales sincronizados para esta instancia.',
+      details: [],
+      licenseStatus,
+      paymentStatus,
+      daysUntilLicenseExpiration,
+      daysUntilPaymentDue,
+      daysUntilGraceEnd,
+      clientName: null,
+      nextDueAt: null,
+      graceUntil: null,
+    };
+  }
+
+  if (paymentStatus === 'pending') {
+    severity = maxSeverity(severity, 'warning');
+    details.push('El pago del cliente figura como pendiente de confirmación.');
+  }
+
+  if (paymentStatus === 'overdue') {
+    severity = maxSeverity(severity, 'critical');
+    details.push('El pago del cliente figura como vencido.');
+  }
+
+  if (paymentStatus === 'grace') {
+    severity = maxSeverity(severity, 'warning');
+    details.push('El cliente está dentro del período de gracia comercial.');
+  }
+
+  if (paymentStatus === 'suspended_candidate') {
+    severity = maxSeverity(severity, 'critical');
+    details.push('El cliente está marcado como candidato a suspensión futura.');
+  }
+
+  if (licenseStatus === 'grace') {
+    severity = maxSeverity(severity, 'warning');
+    details.push('La licencia está marcada en período de gracia.');
+  }
+
+  if (licenseStatus === 'suspended') {
+    severity = maxSeverity(severity, 'critical');
+    details.push('La licencia está marcada como suspendida. En esta etapa solo se informa; el bloqueo real queda para la siguiente feature.');
+  }
+
+  if (licenseStatus === 'cancelled') {
+    severity = maxSeverity(severity, 'critical');
+    details.push('La licencia está marcada como cancelada.');
+  }
+
+  if (daysUntilPaymentDue !== null) {
+    if (daysUntilPaymentDue < 0) {
+      severity = maxSeverity(severity, 'critical');
+      details.push(formatRelative(daysUntilPaymentDue, 'El pago vence', 'El pago vence hoy', 'El pago venció') as string);
+    } else if (daysUntilPaymentDue <= NEAR_DUE_DAYS) {
+      severity = maxSeverity(severity, 'warning');
+      details.push(formatRelative(daysUntilPaymentDue, 'El pago vence', 'El pago vence hoy', 'El pago venció') as string);
+    }
+  }
+
+  if (daysUntilLicenseExpiration !== null) {
+    if (daysUntilLicenseExpiration < 0) {
+      severity = maxSeverity(severity, 'critical');
+      details.push(formatRelative(daysUntilLicenseExpiration, 'La licencia vence', 'La licencia vence hoy', 'La licencia venció') as string);
+    } else if (daysUntilLicenseExpiration <= NEAR_DUE_DAYS) {
+      severity = maxSeverity(severity, 'warning');
+      details.push(formatRelative(daysUntilLicenseExpiration, 'La licencia vence', 'La licencia vence hoy', 'La licencia venció') as string);
+    }
+  }
+
+  if (daysUntilGraceEnd !== null && (paymentStatus === 'grace' || licenseStatus === 'grace')) {
+    if (daysUntilGraceEnd < 0) {
+      severity = maxSeverity(severity, 'critical');
+      details.push(formatRelative(daysUntilGraceEnd, 'El período de gracia termina', 'El período de gracia termina hoy', 'El período de gracia terminó') as string);
+    } else {
+      severity = maxSeverity(severity, daysUntilGraceEnd <= NEAR_DUE_DAYS ? 'critical' : 'warning');
+      details.push(formatRelative(daysUntilGraceEnd, 'El período de gracia termina', 'El período de gracia termina hoy', 'El período de gracia terminó') as string);
+    }
+  }
+
+  const visible = details.length > 0;
+  const title = severity === 'critical'
+    ? 'Atención: licencia o pago en estado crítico'
+    : severity === 'warning'
+    ? 'Aviso de licencia y pago Dragon Pyramid'
+    : 'Estado comercial informativo';
+
+  const message = visible
+    ? 'El sistema seguirá operando normalmente en esta etapa, pero este aviso anticipa una posible suspensión futura si no se regulariza la situación comercial.'
+    : 'La licencia y el estado comercial no requieren advertencias en este momento.';
+
+  if (licenseStatus || paymentStatus) {
+    details.unshift(
+      `Estado actual: licencia ${licenseStatus ? licenseStatusLabel[licenseStatus] : 'sin dato'} · pago ${paymentStatus ? paymentStatusLabel[paymentStatus] : 'sin dato'}.`,
+    );
+  }
+
+  return {
+    visible,
+    severity,
+    title,
+    message,
+    details,
+    licenseStatus,
+    paymentStatus,
+    daysUntilLicenseExpiration,
+    daysUntilPaymentDue,
+    daysUntilGraceEnd,
+    clientName: license.client_name ?? null,
+    nextDueAt: license.next_due_at ?? null,
+    graceUntil: license.grace_until ?? null,
+  };
+}


### PR DESCRIPTION
# PR - Gym Master - Dragon Pyramid Grace Period Warning v1

## Rama

`feature/dragon-pyramid-grace-period-warning-v1`

## Tipo de cambio

- [x] Feature
- [x] UX/UI polish
- [x] Seguridad / control SaaS
- [x] Documentacion tecnica
- [ ] Migracion DB

## Resumen

Esta feature agrega la capa de advertencias comerciales Dragon Pyramid sobre la licencia SaaS de Gym Master. El objetivo es informar al administrador del gimnasio y al Master Admin de Dragon Pyramid cuando la instancia se encuentra proxima a vencimiento, vencida, en periodo de gracia o en estado comercial riesgoso, sin bloquear todavia el acceso al sistema.

La feature se apoya sobre la base ya creada en `dragon-pyramid-license-control-foundation-v1` y `dragon-pyramid-client-payment-status-v1`, reutilizando los campos existentes de licencia y pago. No requiere nueva migracion de base de datos.

## Alcance funcional

- Banner de advertencia comercial en `/dashboard` para rol `admin`.
- Banner detallado en `/dashboard/masteradmin/license` para rol `masteradmin`.
- Nuevo endpoint seguro `GET /api/dragon-pyramid/license/warning`.
- Helper centralizado para calcular condiciones de advertencia:
  - pago pendiente;
  - pago vencido;
  - periodo de gracia;
  - licencia proxima a vencer;
  - licencia vencida;
  - candidato a suspension futura.
- Integracion visual no bloqueante.
- Swagger actualizado.
- Documentacion tecnica agregada.

## Alcance de seguridad

Esta feature no suspende el servicio, no bloquea login, no cierra sesiones y no impide operar. Solo muestra advertencias. El bloqueo real queda reservado para la feature futura:

`feature/dragon-pyramid-app-suspension-by-nonpayment-v1`

Los socios no visualizan avisos comerciales de licencia/pago, ya que corresponde a una relacion contractual entre Dragon Pyramid y el gimnasio cliente.

## Archivos modificados

```txt
src/utils/dragonPyramidLicenseWarning.ts
src/app/api/dragon-pyramid/license/warning/route.ts
src/services/apiClient.ts
src/app/dashboard/page.tsx
src/app/dashboard/masteradmin/license/page.tsx
src/lib/swagger/openApiSpec.ts
docs/mobile/dragon-pyramid-grace-period-warning-v1.md
```

## Base de datos

No requiere migracion DB.

Se reutilizan los campos existentes de la licencia/control comercial ya creados y validados en features anteriores.

## Swagger

Actualizado para documentar:

```txt
GET /api/dragon-pyramid/license/warning
```

## QA realizado

- Login y navegacion como `masteradmin`.
- Visualizacion de advertencia en `/dashboard/masteradmin/license`.
- Visualizacion de banner comercial en `/dashboard` para admin.
- Confirmacion de que el socio no ve avisos comerciales.
- Confirmacion de que el sistema no bloquea ni cierra sesion.
- Prueba con estados de pago/licencia riesgosos.
- Validacion responsive mobile/desktop.
- Build local exitoso.

## Comando de build

```bash
npm run build
```

## Resultado esperado

La aplicacion queda preparada para advertir a administradores sobre vencimientos, periodo de gracia o riesgo comercial, manteniendo el sistema operativo hasta que se implemente el enforcement real de suspension.

## Titulo sugerido del PR

`feat: add Dragon Pyramid grace period warnings`
