### PR TITLE
feat: add Dragon Pyramid app suspension by nonpayment

### DIFF
--- a/docs/mobile/dragon-pyramid-app-suspension-by-nonpayment-v1.md
+++ b/docs/mobile/dragon-pyramid-app-suspension-by-nonpayment-v1.md
@@ -1,0 +1,71 @@
+# Dragon Pyramid app suspension by nonpayment v1
+
+## Objetivo
+
+Implementar la primera capa real de suspensión operativa de Gym Master controlada por la licencia local Dragon Pyramid.
+
+Esta feature usa la base creada en las features previas:
+
+- `dragon-pyramid-license-control-foundation-v1`
+- `dragon-pyramid-client-payment-status-v1`
+- `dragon-pyramid-grace-period-warning-v1`
+
+## Alcance
+
+Cuando la licencia local queda en estado:
+
+- `suspended`
+- `cancelled`
+
+el shell protegido de `/dashboard` bloquea el acceso operativo de:
+
+- `admin`
+- `usuario`
+- `socio`
+
+El acceso reservado de Dragon Pyramid permanece disponible para regularizar, reactivar o sincronizar la licencia.
+
+## Rutas que permanecen disponibles
+
+- `/auth/login`
+- `/auth/login/masteradmin`
+- `/dashboard/masteradmin/license`
+- `/api/dragon-pyramid/license`
+- `/api/dragon-pyramid/license/suspension-status`
+- `/api/internal/dragon-pyramid/license-sync`
+
+## Implementación
+
+Se agregó un estado seguro de suspensión:
+
+- `src/utils/dragonPyramidSuspension.ts`
+- `src/app/api/dragon-pyramid/license/suspension-status/route.ts`
+
+El `DashboardRouteGuard` consulta este estado para usuarios operativos y muestra una pantalla de suspensión antes de renderizar módulos del dashboard.
+
+## Criterio de seguridad
+
+- `suspended_candidate` no bloquea todavía; sigue siendo advertencia comercial.
+- `suspended` y `cancelled` bloquean operación.
+- `masteradmin` queda excluido del bloqueo para poder reactivar.
+- El endpoint de sincronización interna sigue funcionando para futura Dragon Pyramid Platform.
+- Si el endpoint de suspensión falla temporalmente, el guard aplica fail-open para evitar bloqueo accidental por error técnico.
+
+## Pruebas sugeridas
+
+1. Ingresar como `masteradmin` a `/dashboard/masteradmin/license`.
+2. Cambiar licencia a `suspended`.
+3. Entrar como `admin` a `/dashboard` y confirmar pantalla de suspensión.
+4. Entrar como `usuario` y confirmar bloqueo.
+5. Entrar como `socio` y confirmar bloqueo genérico sin detalles comerciales.
+6. Confirmar que `/auth/login/masteradmin` sigue disponible.
+7. Confirmar que `/dashboard/masteradmin/license` sigue disponible para `masteradmin`.
+8. Reactivar licencia como `active`.
+9. Confirmar que admin/socio vuelven a operar.
+10. Probar `cancelled` y repetir bloqueo.
+11. Probar `suspended_candidate` y confirmar que no bloquea.
+12. Ejecutar `npm run build`.
+
+## DB
+
+No requiere migración. Reutiliza la tabla de licencia existente.

--- a/docs/mobile/dragon-pyramid-suspension-change-user-fix-v1.md
+++ b/docs/mobile/dragon-pyramid-suspension-change-user-fix-v1.md
@@ -1,0 +1,34 @@
+# Dragon Pyramid suspension change user fix v1
+
+## Objetivo
+
+Corregir la acción **Cambiar usuario** en la pantalla de suspensión operativa de Gym Master.
+
+## Problema detectado
+
+Cuando la licencia estaba suspendida, la pantalla de bloqueo ofrecía el botón **Cambiar usuario** como un enlace simple a `/auth/login`. Al existir una sesión activa/cacheada, el login podía quedar atrapado en el mismo estado autenticado y volver al dashboard bloqueado.
+
+## Solución aplicada
+
+- Reemplazo del enlace simple por un botón con acción explícita.
+- Ejecución de `logout()` del store de autenticación antes de redirigir.
+- Limpieza de sesión/cookie/localStorage mediante el flujo existente `logoutSession()`.
+- Redirección controlada a `/auth/login` usando `router.replace()`.
+
+## Alcance
+
+- No modifica DB.
+- No modifica endpoints.
+- No modifica Swagger.
+- No altera el acceso reservado Master Admin.
+- No cambia la lógica de suspensión/reactivación.
+
+## QA sugerido
+
+1. Suspender licencia.
+2. Entrar como admin o socio operativo.
+3. Confirmar pantalla de suspensión.
+4. Presionar **Cambiar usuario**.
+5. Confirmar que vuelve a `/auth/login` sin sesión previa activa.
+6. Iniciar sesión con otro usuario.
+7. Confirmar que no queda trabado por credenciales cacheadas.

--- a/src/app/api/dragon-pyramid/license/suspension-status/route.ts
+++ b/src/app/api/dragon-pyramid/license/suspension-status/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import { getDragonPyramidLicense } from '@/services/server/dragonPyramidLicenseService';
+import { buildDragonPyramidSuspensionStatus } from '@/utils/dragonPyramidSuspension';
+
+export const dynamic = 'force-dynamic';
+
+function resolveStatus(message: string) {
+  if (message.includes('Token')) return 401;
+  return 500;
+}
+
+export async function GET(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    const license = await getDragonPyramidLicense();
+    const status = buildDragonPyramidSuspensionStatus(license);
+
+    const safeStatus = user.rol === 'socio'
+      ? {
+          ...status,
+          title: status.isSuspended ? 'Servicio temporalmente no disponible' : status.title,
+          message: status.isSuspended
+            ? 'El servicio del gimnasio se encuentra temporalmente no disponible. Comunicate con la administración del gimnasio para más información.'
+            : status.message,
+          details: status.isSuspended ? [] : status.details,
+          clientName: null,
+        }
+      : status;
+
+    return NextResponse.json(
+      { data: safeStatus },
+      {
+        status: 200,
+        headers: { 'Cache-Control': 'no-store' },
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: resolveStatus(message) });
+  }
+}

--- a/src/app/dashboard/masteradmin/license/page.tsx
+++ b/src/app/dashboard/masteradmin/license/page.tsx
@@ -38,8 +38,8 @@ const statusOptions: Array<{ value: DragonPyramidLicenseStatus; label: string; h
   { value: 'active', label: 'Activa', helper: 'Cliente habilitado normalmente.' },
   { value: 'trial', label: 'Trial', helper: 'Cliente en período de prueba.' },
   { value: 'grace', label: 'Gracia', helper: 'Vencido, pero con tolerancia operativa.' },
-  { value: 'suspended', label: 'Suspendida', helper: 'Base para bloqueo futuro por falta de pago.' },
-  { value: 'cancelled', label: 'Cancelada', helper: 'Cliente dado de baja.' },
+  { value: 'suspended', label: 'Suspendida', helper: 'Bloquea el acceso operativo de admin, usuarios y socios.' },
+  { value: 'cancelled', label: 'Cancelada', helper: 'Cliente dado de baja; bloquea el acceso operativo.' },
 ];
 
 const paymentStatusOptions: Array<{ value: DragonPyramidClientPaymentStatus; label: string; helper: string }> = [
@@ -290,7 +290,7 @@ export default function MasterAdminLicensePage() {
                   </div>
                   <h2 className='mt-4 text-2xl font-black sm:text-3xl'>Estado de pago del cliente SaaS</h2>
                   <p className='mt-2 text-sm leading-6 text-cyan-50/90 sm:text-base'>
-                    Esta etapa agrega control comercial sobre la licencia local: estado de pago, próximo vencimiento, plan y monto esperado. Todavía no bloquea el servicio; deja la base lista para gracia, suspensión y reactivación futuras.
+                    Esta etapa agrega suspensión operativa controlada: si la licencia pasa a suspendida o cancelada, admin, usuarios y socios quedan bloqueados hasta regularización o reactivación desde Dragon Pyramid.
                   </p>
                 </div>
                 <div className='flex w-full flex-col gap-2 sm:w-auto'>
@@ -577,7 +577,7 @@ export default function MasterAdminLicensePage() {
                   La plataforma madre podrá enviar también paymentStatus, lastPaymentAt, nextDueAt, expectedAmount, currency, billingPlan y paymentNotes.
                 </p>
                 <p className='rounded-2xl border border-amber-300/40 bg-amber-50 p-4 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100'>
-                  En esta feature se registra estado de pago, pero no se bloquea el sistema. El bloqueo real queda para la feature de suspensión por falta de pago.
+                  Con licencia suspendida o cancelada, el acceso operativo queda bloqueado. El acceso Master Admin y la sincronización interna permanecen disponibles para regularizar o reactivar.
                 </p>
               </CardContent>
             </Card>

--- a/src/components/auth/DashboardRouteGuard.tsx
+++ b/src/components/auth/DashboardRouteGuard.tsx
@@ -2,19 +2,108 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { ReactNode, useEffect } from 'react';
-import { ShieldAlert } from 'lucide-react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { LockKeyhole, RefreshCcw, ShieldAlert } from 'lucide-react';
 import { useAuthStore } from '@/stores/authStore';
 import {
   canAccessDashboardPath,
   getDashboardRoutePermission,
 } from '@/lib/permissions/menuPermissions';
+import { getDragonPyramidLicenseSuspensionStatus } from '@/services/apiClient';
+import type { DragonPyramidSuspensionStatus } from '@/utils/dragonPyramidSuspension';
 
 function DashboardRouteLoading() {
   return (
     <div className='flex min-h-screen items-center justify-center bg-background px-4 text-sm text-muted-foreground'>
       Validando acceso...
     </div>
+  );
+}
+
+
+function isSuspensionBypassDashboardPath(pathname?: string | null) {
+  if (!pathname) return false;
+  return pathname === '/dashboard/masteradmin/license' || pathname.startsWith('/dashboard/masteradmin/');
+}
+
+function DashboardRouteSuspended({
+  suspensionStatus,
+}: {
+  suspensionStatus: DragonPyramidSuspensionStatus;
+}) {
+  const router = useRouter();
+  const logout = useAuthStore((state) => state.logout);
+
+  const handleReload = () => {
+    window.location.reload();
+  };
+
+  const handleChangeUser = () => {
+    logout();
+    router.replace('/auth/login');
+  };
+
+  return (
+    <main className='grid h-[100dvh] max-h-[100dvh] min-h-0 overflow-hidden bg-background px-4 py-6'>
+      <section className='m-auto w-full max-w-2xl overflow-hidden rounded-3xl border border-red-300 bg-red-50/95 p-6 text-center shadow-2xl shadow-red-950/10 dark:border-red-900/70 dark:bg-red-950/85'>
+        <div className='mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 text-red-700 dark:bg-red-950/60 dark:text-red-200'>
+          <LockKeyhole className='h-8 w-8' aria-hidden='true' />
+        </div>
+
+        <p className='text-xs font-black uppercase tracking-[0.28em] text-red-700 dark:text-red-200'>
+          Dragon Pyramid · Control de licencia
+        </p>
+        <h1 className='mt-3 text-2xl font-black tracking-tight text-red-800 dark:text-red-100 sm:text-3xl'>
+          {suspensionStatus.title}
+        </h1>
+        <p className='mx-auto mt-3 max-w-xl text-sm leading-6 text-red-950/80 dark:text-red-100/85'>
+          {suspensionStatus.message}
+        </p>
+
+        {suspensionStatus.clientName ? (
+          <div className='mx-auto mt-5 max-w-md rounded-2xl border border-red-200 bg-white/70 p-4 text-left text-sm dark:border-red-900/70 dark:bg-red-950/40'>
+            <p className='text-xs font-bold uppercase tracking-wide text-red-700 dark:text-red-200'>Cliente</p>
+            <p className='mt-1 font-black text-red-950 dark:text-red-50'>{suspensionStatus.clientName}</p>
+          </div>
+        ) : null}
+
+        {suspensionStatus.details.length > 0 ? (
+          <ul className='mx-auto mt-5 max-w-xl space-y-2 rounded-2xl border border-red-200 bg-white/70 p-4 text-left text-sm text-red-950/85 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-100/85'>
+            {suspensionStatus.details.map((detail) => (
+              <li key={detail} className='leading-6'>• {detail}</li>
+            ))}
+          </ul>
+        ) : null}
+
+        <div className='mt-6 grid gap-3 sm:grid-cols-3'>
+          <button
+            type='button'
+            onClick={handleReload}
+            className='inline-flex h-11 items-center justify-center rounded-md border border-red-200 bg-white px-4 py-2 text-sm font-semibold text-red-900 transition-colors hover:bg-red-50 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-100 dark:hover:bg-red-950/50'
+          >
+            <RefreshCcw className='mr-2 h-4 w-4' />
+            Reintentar
+          </button>
+          <Link
+            href='/auth/login/masteradmin'
+            className='inline-flex h-11 items-center justify-center rounded-md bg-red-700 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-800 dark:bg-red-600 dark:hover:bg-red-500'
+          >
+            Acceso Dragon Pyramid
+          </Link>
+          <button
+            type='button'
+            onClick={handleChangeUser}
+            className='inline-flex h-11 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground'
+          >
+            Cambiar usuario
+          </button>
+        </div>
+
+        <p className='mt-5 text-xs leading-5 text-red-900/70 dark:text-red-100/70'>
+          El bloqueo no afecta el acceso reservado Master Admin ni la sincronización interna de Dragon Pyramid para permitir regularización o reactivación del servicio.
+        </p>
+      </section>
+    </main>
   );
 }
 
@@ -69,6 +158,21 @@ export default function DashboardRouteGuard({
   const router = useRouter();
   const { user, isAuthenticated, isInitialized, initializeAuth } =
     useAuthStore();
+  const [suspensionStatus, setSuspensionStatus] =
+    useState<DragonPyramidSuspensionStatus | null>(null);
+  const [loadingSuspensionStatus, setLoadingSuspensionStatus] = useState(false);
+
+  const shouldCheckSuspension = useMemo(
+    () =>
+      Boolean(
+        isInitialized &&
+          isAuthenticated &&
+          user &&
+          user.rol !== 'masteradmin' &&
+          !isSuspensionBypassDashboardPath(pathname),
+      ),
+    [isAuthenticated, isInitialized, pathname, user],
+  );
 
   useEffect(() => {
     initializeAuth();
@@ -86,6 +190,37 @@ export default function DashboardRouteGuard({
     }
   }, [isAuthenticated, isInitialized, router, user?.must_change_password]);
 
+  useEffect(() => {
+    if (!shouldCheckSuspension) {
+      setSuspensionStatus(null);
+      setLoadingSuspensionStatus(false);
+      return;
+    }
+
+    let isMounted = true;
+    setLoadingSuspensionStatus(true);
+
+    getDragonPyramidLicenseSuspensionStatus()
+      .then((response) => {
+        if (!isMounted) return;
+        setSuspensionStatus(response.ok ? response.data ?? null : null);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        // Fail open: si el aviso de licencia no puede consultarse por un error temporal,
+        // no bloqueamos accidentalmente la operación del cliente.
+        setSuspensionStatus(null);
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setLoadingSuspensionStatus(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [shouldCheckSuspension, pathname]);
+
   if (!isInitialized) {
     return <DashboardRouteLoading />;
   }
@@ -96,6 +231,14 @@ export default function DashboardRouteGuard({
 
   if (user.must_change_password) {
     return <DashboardRouteLoading />;
+  }
+
+  if (shouldCheckSuspension && loadingSuspensionStatus) {
+    return <DashboardRouteLoading />;
+  }
+
+  if (shouldCheckSuspension && suspensionStatus?.isSuspended) {
+    return <DashboardRouteSuspended suspensionStatus={suspensionStatus} />;
   }
 
   const canAccess = canAccessDashboardPath(

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -24,7 +24,7 @@ const endpointDefinitions: EndpointDefinition[] = [
     tag: "Dragon Pyramid",
     summary: "Estado local de licencia SaaS",
     description:
-      "Permite al rol masteradmin consultar y actualizar el estado local de licencia y el estado de pago SaaS de esta instancia de Gym Master. Es una foundation comercial para conexión futura con Dragon Pyramid Platform y no bloquea todavía el servicio del cliente.",
+      "Permite al rol masteradmin consultar y actualizar el estado local de licencia y el estado de pago SaaS de esta instancia de Gym Master. Si la licencia queda suspendida o cancelada, el shell operativo bloquea admin, usuarios y socios, manteniendo abierto Master Admin para regularización.",
     auth: true,
     admin: true,
     notImplemented: false,
@@ -47,6 +47,21 @@ const endpointDefinitions: EndpointDefinition[] = [
     statuses: [200, 401, 403, 500],
     queryParams: [],
     source: "src/app/api/dragon-pyramid/license/warning/route.ts",
+    internal: true,
+  },
+  {
+    path: "/api/dragon-pyramid/license/suspension-status",
+    methods: ["GET"],
+    tag: "Dragon Pyramid",
+    summary: "Estado de suspensión operativa Dragon Pyramid",
+    description:
+      "Devuelve un estado seguro de suspensión para el shell del dashboard. Permite bloquear el acceso operativo cuando la licencia local está suspendida o cancelada, sin bloquear el acceso Master Admin ni la sincronización interna de Dragon Pyramid.",
+    auth: true,
+    admin: false,
+    notImplemented: false,
+    statuses: [200, 401, 500],
+    queryParams: [],
+    source: "src/app/api/dragon-pyramid/license/suspension-status/route.ts",
     internal: true,
   },
   {

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1203,3 +1203,14 @@ export async function getDragonPyramidLicenseWarning() {
   const data = await res.json();
   return { ok: res.ok, ...data };
 }
+
+export async function getDragonPyramidLicenseSuspensionStatus() {
+  const token = getToken();
+  const res = await fetch('/api/dragon-pyramid/license/suspension-status', {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    cache: 'no-store',
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}

--- a/src/utils/dragonPyramidSuspension.ts
+++ b/src/utils/dragonPyramidSuspension.ts
@@ -1,0 +1,136 @@
+import type {
+  DragonPyramidClientPaymentStatus,
+  DragonPyramidLicenseControl,
+  DragonPyramidLicenseStatus,
+} from '@/interfaces/dragonPyramidLicense.interface';
+
+export type DragonPyramidSuspensionReason =
+  | 'license_suspended'
+  | 'license_cancelled'
+  | null;
+
+export type DragonPyramidSuspensionStatus = {
+  isSuspended: boolean;
+  reason: DragonPyramidSuspensionReason;
+  title: string;
+  message: string;
+  details: string[];
+  clientName: string | null;
+  licenseStatus: DragonPyramidLicenseStatus | null;
+  paymentStatus: DragonPyramidClientPaymentStatus | null;
+  suspendedAt: string | null;
+  graceUntil: string | null;
+  nextDueAt: string | null;
+  canUseMasterAdminRecovery: boolean;
+};
+
+const licenseStatusLabel: Record<DragonPyramidLicenseStatus, string> = {
+  active: 'activa',
+  trial: 'trial',
+  grace: 'en gracia',
+  suspended: 'suspendida',
+  cancelled: 'cancelada',
+};
+
+const paymentStatusLabel: Record<DragonPyramidClientPaymentStatus, string> = {
+  paid: 'al día',
+  pending: 'pendiente',
+  overdue: 'vencido',
+  grace: 'en gracia',
+  suspended_candidate: 'candidato a suspensión',
+  unknown: 'sin dato',
+};
+
+function formatDate(value?: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return new Intl.DateTimeFormat('es-AR', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date);
+}
+
+export function buildDragonPyramidSuspensionStatus(
+  license?: DragonPyramidLicenseControl | null,
+): DragonPyramidSuspensionStatus {
+  const licenseStatus = license?.license_status ?? null;
+  const paymentStatus = license?.payment_status ?? null;
+  const isSuspended = licenseStatus === 'suspended' || licenseStatus === 'cancelled';
+  const reason: DragonPyramidSuspensionReason = licenseStatus === 'suspended'
+    ? 'license_suspended'
+    : licenseStatus === 'cancelled'
+    ? 'license_cancelled'
+    : null;
+
+  const details: string[] = [];
+
+  if (licenseStatus || paymentStatus) {
+    details.push(
+      `Estado actual: licencia ${licenseStatus ? licenseStatusLabel[licenseStatus] : 'sin dato'} · pago ${paymentStatus ? paymentStatusLabel[paymentStatus] : 'sin dato'}.`,
+    );
+  }
+
+  const suspendedAt = formatDate(license?.suspended_at);
+  const graceUntil = formatDate(license?.grace_until);
+  const nextDueAt = formatDate(license?.next_due_at);
+
+  if (suspendedAt) details.push(`Suspensión registrada: ${suspendedAt}.`);
+  if (graceUntil) details.push(`Período de gracia configurado hasta: ${graceUntil}.`);
+  if (nextDueAt) details.push(`Próximo vencimiento comercial: ${nextDueAt}.`);
+  if (license?.suspension_reason) details.push(`Motivo: ${license.suspension_reason}.`);
+
+  if (!license) {
+    return {
+      isSuspended: false,
+      reason: null,
+      title: 'Licencia no configurada',
+      message: 'No existe todavía un estado local de licencia Dragon Pyramid para esta instancia.',
+      details: [],
+      clientName: null,
+      licenseStatus: null,
+      paymentStatus: null,
+      suspendedAt: null,
+      graceUntil: null,
+      nextDueAt: null,
+      canUseMasterAdminRecovery: true,
+    };
+  }
+
+  if (!isSuspended) {
+    return {
+      isSuspended: false,
+      reason: null,
+      title: 'Servicio operativo',
+      message: 'La instancia se encuentra habilitada para operar.',
+      details,
+      clientName: license.client_name ?? null,
+      licenseStatus,
+      paymentStatus,
+      suspendedAt: license.suspended_at ?? null,
+      graceUntil: license.grace_until ?? null,
+      nextDueAt: license.next_due_at ?? null,
+      canUseMasterAdminRecovery: true,
+    };
+  }
+
+  return {
+    isSuspended: true,
+    reason,
+    title: reason === 'license_cancelled'
+      ? 'Servicio cancelado por Dragon Pyramid'
+      : 'Servicio suspendido temporalmente',
+    message: reason === 'license_cancelled'
+      ? 'Esta instancia de Gym Master fue dada de baja. Para revisar o reactivar el servicio, ingresá con el acceso reservado de Dragon Pyramid.'
+      : 'Esta instancia de Gym Master se encuentra suspendida. El acceso operativo queda pausado hasta regularizar o reactivar la licencia desde Dragon Pyramid.',
+    details,
+    clientName: license.client_name ?? null,
+    licenseStatus,
+    paymentStatus,
+    suspendedAt: license.suspended_at ?? null,
+    graceUntil: license.grace_until ?? null,
+    nextDueAt: license.next_due_at ?? null,
+    canUseMasterAdminRecovery: true,
+  };
+}


### PR DESCRIPTION
# feat: add Dragon Pyramid app suspension by nonpayment

## Rama

`feature/dragon-pyramid-app-suspension-by-nonpayment-v1`

## Resumen

Se implementa el primer bloqueo operativo real de Gym Master por estado de licencia Dragon Pyramid. La aplicación bloquea el acceso operativo de roles `admin`, `usuario` y `socio` cuando la licencia local queda en estado `suspended` o `cancelled`, manteniendo siempre abierta la puerta reservada de Dragon Pyramid para auditoría, sincronización y reactivación.

Esta feature no agrega nuevas tablas ni requiere migración. Reutiliza la estructura de licencia y estado comercial creada en las features previas.

## Alcance funcional

- Bloqueo operativo para `/dashboard` y rutas protegidas cuando la licencia está suspendida o cancelada.
- Pantalla de suspensión con estado, cliente, vencimiento, gracia y motivo.
- Acceso reservado Dragon Pyramid sin bloqueo:
  - `/auth/login/masteradmin`
  - `/dashboard/masteradmin/license`
  - `/api/dragon-pyramid/license`
  - `/api/dragon-pyramid/license/suspension-status`
  - `/api/internal/dragon-pyramid/license-sync`
- Reintento de acceso operativo luego de reactivación.
- Botón **Cambiar usuario** corregido para cerrar sesión real y redirigir a `/auth/login`, evitando quedar trabado con credenciales cacheadas.
- Endpoint de estado de suspensión para consulta segura del frontend.
- Swagger actualizado.
- Documentación técnica agregada.

## Estados que bloquean

```txt
license_status = suspended
license_status = cancelled
```

## Estados que no bloquean

```txt
payment_status = overdue
payment_status = grace
payment_status = suspended_candidate
license_status = grace
```

Estos estados siguen funcionando como advertencias comerciales, no como suspensión total.

## Archivos modificados

```txt
src/components/auth/DashboardRouteGuard.tsx
src/utils/dragonPyramidSuspension.ts
src/app/api/dragon-pyramid/license/suspension-status/route.ts
src/services/apiClient.ts
src/app/dashboard/masteradmin/license/page.tsx
src/lib/swagger/openApiSpec.ts
docs/mobile/dragon-pyramid-app-suspension-by-nonpayment-v1.md
docs/mobile/dragon-pyramid-suspension-change-user-fix-v1.md
```

## Seguridad

El bloqueo no afecta el acceso `masteradmin` ni la sincronización interna. Esto evita que Dragon Pyramid quede fuera de la instancia y permite reactivar el servicio aun cuando el cliente se encuentre suspendido.

No se versionan SQL, dumps, backups ni archivos privados. Esta feature no requiere migración de base de datos.

## Validación realizada

- Login `masteradmin` disponible.
- Panel `/dashboard/masteradmin/license` disponible durante suspensión.
- Cambio de licencia a `suspended` bloquea acceso operativo de admin/socio.
- Cambio de licencia a `active` reactiva acceso operativo.
- Estado `cancelled` bloquea acceso operativo.
- Estado `suspended_candidate` no bloquea, solo advierte.
- Endpoint de sync interno sigue disponible.
- Botón **Cambiar usuario** cierra sesión y vuelve a `/auth/login` sin quedar cacheado.
- Responsive validado.
- Footer validado sin espacio blanco posterior.
- `npm run build` validado localmente.

## Pruebas sugeridas para review

1. Entrar como `masteradmin` a `/dashboard/masteradmin/license`.
2. Cambiar `license_status` a `suspended`.
3. Entrar como `admin` común a `/dashboard`.
4. Confirmar pantalla de suspensión.
5. Presionar **Cambiar usuario** y confirmar redirección limpia a `/auth/login`.
6. Entrar como `masteradmin` y reactivar licencia a `active`.
7. Confirmar que admin/socio vuelven a operar.
8. Confirmar que `payment_status = suspended_candidate` no bloquea.
