### PR TITLE
feat: add Dragon Pyramid reactivation after payment

### DIFF
--- a/docs/mobile/dragon-pyramid-reactivation-after-payment-v1.md
+++ b/docs/mobile/dragon-pyramid-reactivation-after-payment-v1.md
@@ -1,0 +1,43 @@
+# Dragon Pyramid Reactivation After Payment v1
+
+## Rama
+
+`feature/dragon-pyramid-reactivation-after-payment-v1`
+
+## Objetivo
+
+Cerrar el ciclo comercial de licencia Dragon Pyramid para Gym Master: después de que un cliente regulariza el pago, Master Admin puede levantar la suspensión operativa sin tocar la base manualmente.
+
+## Alcance
+
+- Se agrega endpoint protegido `POST /api/dragon-pyramid/license/reactivate` para rol `masteradmin`.
+- Se agrega acción visible en `/dashboard/masteradmin/license` cuando el cliente está suspendido, cancelado, vencido, en gracia o candidato a suspensión.
+- La reactivación deja `license_status = active` y `payment_status = paid`.
+- Registra `reactivated_at` y `last_payment_at`.
+- Limpia `suspended_at` y `suspension_reason`.
+- Mantiene `next_due_at`, monto, moneda y plan comercial si se cargan desde el formulario.
+- El endpoint interno `license-sync` puede ejecutar la misma reactivación cuando Dragon Pyramid Platform envíe `reactivate: true` o `status: active` + `paymentStatus: paid`.
+
+## Seguridad
+
+- Solo `masteradmin` puede ejecutar la reactivación manual.
+- La sincronización externa sigue protegida con `DRAGON_PYRAMID_LICENSE_SYNC_SECRET`.
+- No se abren rutas para admin común, usuario ni socio.
+
+## No incluye
+
+- No crea la plataforma madre Dragon Pyramid.
+- No integra pasarela de pagos real Dragon Pyramid.
+- No agrega migración DB: reutiliza campos existentes de licencia y pago.
+- No versiona SQL privado.
+
+## QA sugerido
+
+1. Poner licencia en `suspended` desde Master Admin.
+2. Confirmar que admin/socio quedan bloqueados.
+3. Entrar como `masteradmin` a `/dashboard/masteradmin/license`.
+4. Presionar `Reactivar servicio`.
+5. Confirmar que licencia queda `active` y pago `paid`.
+6. Confirmar que desaparece la pantalla de suspensión para admin/socio.
+7. Probar sync interno con `reactivate: true` y secret correcto.
+8. Probar que secret incorrecto sigue devolviendo `401`.

--- a/src/app/api/dragon-pyramid/license/reactivate/route.ts
+++ b/src/app/api/dragon-pyramid/license/reactivate/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  assertMasterAdmin,
+  reactivateDragonPyramidLicenseAfterPayment,
+} from '@/services/server/dragonPyramidLicenseService';
+
+export const dynamic = 'force-dynamic';
+
+function resolveStatus(message: string) {
+  if (message.includes('permisos')) return 403;
+  if (message.includes('válid')) return 400;
+  return 500;
+}
+
+export async function POST(req: Request) {
+  try {
+    const { user } = await authMiddleware(req);
+    assertMasterAdmin(user);
+
+    const body = await req.json().catch(() => ({}));
+    const data = await reactivateDragonPyramidLicenseAfterPayment({
+      client_code: body?.client_code,
+      client_name: body?.client_name,
+      last_payment_at: body?.last_payment_at,
+      next_due_at: body?.next_due_at,
+      expected_amount: body?.expected_amount,
+      currency: body?.currency,
+      billing_plan: body?.billing_plan,
+      payment_notes: body?.payment_notes,
+      expires_at: body?.expires_at,
+      grace_until: body?.grace_until,
+      reason: body?.reason,
+      sync_source: 'manual_masteradmin_reactivation',
+      metadata: {
+        ...(body?.metadata && typeof body.metadata === 'object' ? body.metadata : {}),
+        updated_by: user.email ?? user.id,
+        updated_from: 'gym-master-masteradmin-reactivation',
+      },
+    });
+
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: resolveStatus(message) });
+  }
+}

--- a/src/app/api/internal/dragon-pyramid/license-sync/route.ts
+++ b/src/app/api/internal/dragon-pyramid/license-sync/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { upsertDragonPyramidLicense } from '@/services/server/dragonPyramidLicenseService';
+import {
+  reactivateDragonPyramidLicenseAfterPayment,
+  upsertDragonPyramidLicense,
+} from '@/services/server/dragonPyramidLicenseService';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,7 +30,11 @@ export async function POST(req: Request) {
     }
 
     const body = await req.json();
-    const data = await upsertDragonPyramidLicense({
+    const wantsReactivation = Boolean(body?.reactivate) ||
+      ((body?.status ?? body?.license_status) === 'active' &&
+        (body?.paymentStatus ?? body?.payment_status) === 'paid');
+
+    const commonPayload = {
       client_code: body?.clientCode ?? body?.client_code,
       client_name: body?.clientName ?? body?.client_name,
       license_status: body?.status ?? body?.license_status,
@@ -45,12 +52,27 @@ export async function POST(req: Request) {
       reactivated_at: body?.reactivatedAt ?? body?.reactivated_at,
       suspension_reason: body?.reason ?? body?.suspension_reason,
       sync_source: 'dragon_pyramid_platform',
+      reason: body?.reason ?? body?.suspension_reason,
       metadata: {
         ...(body?.metadata && typeof body.metadata === 'object' ? body.metadata : {}),
         synced_from: 'dragon_pyramid_platform',
         received_at: new Date().toISOString(),
       },
-    });
+    };
+
+    const data = wantsReactivation
+      ? await reactivateDragonPyramidLicenseAfterPayment({
+          ...commonPayload,
+          sync_source: 'dragon_pyramid_platform_reactivation',
+        })
+      : await upsertDragonPyramidLicense({
+          ...commonPayload,
+          license_status: body?.status ?? body?.license_status,
+          suspended_at: body?.suspendedAt ?? body?.suspended_at,
+          reactivated_at: body?.reactivatedAt ?? body?.reactivated_at,
+          suspension_reason: body?.reason ?? body?.suspension_reason,
+          sync_source: 'dragon_pyramid_platform',
+        });
 
     return NextResponse.json({ data }, { status: 200 });
   } catch (error) {

--- a/src/app/dashboard/masteradmin/license/page.tsx
+++ b/src/app/dashboard/masteradmin/license/page.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCcw,
   Save,
   ShieldCheck,
+  UnlockKeyhole,
 } from 'lucide-react';
 import { AppFooter } from '@/components/footer/AppFooter';
 import { Button } from '@/components/ui/button';
@@ -25,6 +26,7 @@ import { Label } from '@/components/ui/label';
 import { useAuthStore } from '@/stores/authStore';
 import {
   getDragonPyramidLicenseControl,
+  reactivateDragonPyramidLicenseControl,
   updateDragonPyramidLicenseControl,
 } from '@/services/apiClient';
 import type {
@@ -144,6 +146,7 @@ export default function MasterAdminLicensePage() {
   const [form, setForm] = useState(buildInitialForm(null));
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [reactivating, setReactivating] = useState(false);
 
   useEffect(() => {
     initializeAuth();
@@ -186,6 +189,13 @@ export default function MasterAdminLicensePage() {
   }, [daysUntilPayment]);
 
   const graceWarning = useMemo(() => buildDragonPyramidGraceWarning(license), [license]);
+
+  const canShowReactivationAction =
+    currentStatus === 'suspended' ||
+    currentStatus === 'cancelled' ||
+    currentPaymentStatus === 'overdue' ||
+    currentPaymentStatus === 'grace' ||
+    currentPaymentStatus === 'suspended_candidate';
 
   const summaryCards = useMemo(
     () => [
@@ -233,6 +243,35 @@ export default function MasterAdminLicensePage() {
       toast.error(error instanceof Error ? error.message : 'Error al actualizar licencia');
     } finally {
       setSaving(false);
+    }
+  };
+
+
+  const handleReactivateAfterPayment = async () => {
+    setReactivating(true);
+    try {
+      const response = await reactivateDragonPyramidLicenseControl({
+        client_code: form.client_code,
+        client_name: form.client_name,
+        billing_plan: form.billing_plan,
+        expected_amount: form.expected_amount ? Number(form.expected_amount) : null,
+        currency: form.currency,
+        last_payment_at: form.last_payment_at ? new Date(form.last_payment_at).toISOString() : new Date().toISOString(),
+        next_due_at: form.next_due_at ? new Date(form.next_due_at).toISOString() : null,
+        expires_at: form.expires_at ? new Date(form.expires_at).toISOString() : null,
+        payment_notes: form.payment_notes || 'Pago regularizado y servicio reactivado desde Master Admin.',
+        reason: form.suspension_reason || 'Reactivación manual por pago regularizado.',
+      });
+
+      if (!response.ok) throw new Error(response.error || 'No se pudo reactivar el servicio');
+      const data = response.data as DragonPyramidLicenseControl;
+      setLicense(data);
+      setForm(buildInitialForm(data));
+      toast.success('Servicio reactivado y pago marcado al día');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Error al reactivar servicio');
+    } finally {
+      setReactivating(false);
     }
   };
 
@@ -288,9 +327,9 @@ export default function MasterAdminLicensePage() {
                     <LockKeyhole className='h-3.5 w-3.5' />
                     Puerta reservada /auth/login/masteradmin
                   </div>
-                  <h2 className='mt-4 text-2xl font-black sm:text-3xl'>Estado de pago del cliente SaaS</h2>
+                  <h2 className='mt-4 text-2xl font-black sm:text-3xl'>Reactivación comercial del cliente SaaS</h2>
                   <p className='mt-2 text-sm leading-6 text-cyan-50/90 sm:text-base'>
-                    Esta etapa agrega suspensión operativa controlada: si la licencia pasa a suspendida o cancelada, admin, usuarios y socios quedan bloqueados hasta regularización o reactivación desde Dragon Pyramid.
+                    Esta etapa agrega reactivación controlada después de regularizar el pago: Dragon Pyramid puede levantar la suspensión operativa desde este panel o desde la futura plataforma madre.
                   </p>
                 </div>
                 <div className='flex w-full flex-col gap-2 sm:w-auto'>
@@ -335,6 +374,33 @@ export default function MasterAdminLicensePage() {
                 <div className='rounded-2xl border border-current/20 px-4 py-3 text-sm font-bold'>
                   {graceWarning.clientName ?? form.client_name ?? 'Gym Master Cliente'}
                 </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {canShowReactivationAction && (
+            <Card className='min-w-0 border-emerald-400/40 bg-emerald-950/25 text-emerald-50 shadow-xl'>
+              <CardContent className='flex flex-col gap-4 p-5 lg:flex-row lg:items-center lg:justify-between'>
+                <div className='flex min-w-0 gap-3'>
+                  <UnlockKeyhole className='mt-1 h-5 w-5 shrink-0 text-emerald-200' />
+                  <div className='min-w-0'>
+                    <p className='text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200/90'>
+                      Reactivación después de pago
+                    </p>
+                    <h3 className='mt-1 text-lg font-black'>Pago regularizado / levantar suspensión</h3>
+                    <p className='mt-1 text-sm leading-6 text-emerald-50/85'>
+                      Esta acción marca la licencia como activa, el pago como al día, registra la fecha de reactivación y limpia el motivo de suspensión para que admin, usuarios y socios vuelvan a operar.
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  className='w-full bg-emerald-500 text-emerald-950 hover:bg-emerald-400 lg:w-auto'
+                  onClick={handleReactivateAfterPayment}
+                  disabled={loading || saving || reactivating}
+                >
+                  <UnlockKeyhole className='mr-2 h-4 w-4' />
+                  {reactivating ? 'Reactivando...' : 'Reactivar servicio'}
+                </Button>
               </CardContent>
             </Card>
           )}
@@ -577,7 +643,7 @@ export default function MasterAdminLicensePage() {
                   La plataforma madre podrá enviar también paymentStatus, lastPaymentAt, nextDueAt, expectedAmount, currency, billingPlan y paymentNotes.
                 </p>
                 <p className='rounded-2xl border border-amber-300/40 bg-amber-50 p-4 text-amber-900 dark:bg-amber-950/30 dark:text-amber-100'>
-                  Con licencia suspendida o cancelada, el acceso operativo queda bloqueado. El acceso Master Admin y la sincronización interna permanecen disponibles para regularizar o reactivar.
+                  Con licencia suspendida o cancelada, el acceso operativo queda bloqueado. La reactivación vuelve a dejar licencia activa, pago al día y acceso operativo habilitado.
                 </p>
               </CardContent>
             </Card>

--- a/src/interfaces/dragonPyramidLicense.interface.ts
+++ b/src/interfaces/dragonPyramidLicense.interface.ts
@@ -60,3 +60,20 @@ export type DragonPyramidLicenseUpdateInput = {
   sync_source?: string | null;
   metadata?: Record<string, unknown>;
 };
+
+
+export type DragonPyramidLicenseReactivationInput = {
+  client_code?: string;
+  client_name?: string;
+  last_payment_at?: string | null;
+  next_due_at?: string | null;
+  expected_amount?: number | string | null;
+  currency?: string | null;
+  billing_plan?: string | null;
+  payment_notes?: string | null;
+  expires_at?: string | null;
+  grace_until?: string | null;
+  reason?: string | null;
+  sync_source?: string | null;
+  metadata?: Record<string, unknown>;
+};

--- a/src/lib/swagger/openApiSpec.ts
+++ b/src/lib/swagger/openApiSpec.ts
@@ -34,6 +34,23 @@ const endpointDefinitions: EndpointDefinition[] = [
     internal: true,
   },
 
+
+  {
+    path: "/api/dragon-pyramid/license/reactivate",
+    methods: ["POST"],
+    tag: "Dragon Pyramid",
+    summary: "Reactivar servicio después de pago",
+    description:
+      "Permite al rol masteradmin reactivar la instancia después de regularizar el pago: deja licencia activa, pago al día, registra reactivated_at y limpia la causa de suspensión para liberar el acceso operativo.",
+    auth: true,
+    admin: true,
+    notImplemented: false,
+    statuses: [200, 400, 401, 403, 500],
+    queryParams: [],
+    source: "src/app/api/dragon-pyramid/license/reactivate/route.ts",
+    internal: true,
+  },
+
   {
     path: "/api/dragon-pyramid/license/warning",
     methods: ["GET"],

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1193,6 +1193,21 @@ export async function updateDragonPyramidLicenseControl(payload: unknown) {
   return { ok: res.ok, ...data };
 }
 
+
+export async function reactivateDragonPyramidLicenseControl(payload: unknown) {
+  const token = getToken();
+  const res = await fetch('/api/dragon-pyramid/license/reactivate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(payload ?? {}),
+  });
+  const data = await res.json();
+  return { ok: res.ok, ...data };
+}
+
 export async function getDragonPyramidLicenseWarning() {
   const token = getToken();
   const res = await fetch('/api/dragon-pyramid/license/warning', {

--- a/src/services/server/dragonPyramidLicenseService.ts
+++ b/src/services/server/dragonPyramidLicenseService.ts
@@ -5,6 +5,7 @@ import type {
   DragonPyramidClientPaymentStatus,
   DragonPyramidLicenseControl,
   DragonPyramidLicenseStatus,
+  DragonPyramidLicenseReactivationInput,
   DragonPyramidLicenseUpdateInput,
 } from '@/interfaces/dragonPyramidLicense.interface';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
@@ -113,6 +114,14 @@ function buildUpdatePayload(input: DragonPyramidLicenseUpdateInput) {
     payload.reactivated_at = new Date().toISOString();
   }
 
+  if ((status === 'active' || status === 'trial') && input.suspended_at === undefined) {
+    payload.suspended_at = null;
+  }
+
+  if ((status === 'active' || status === 'trial') && input.suspension_reason === undefined) {
+    payload.suspension_reason = null;
+  }
+
   return payload;
 }
 
@@ -154,4 +163,41 @@ export async function upsertDragonPyramidLicense(
   }
 
   return data as DragonPyramidLicenseControl;
+}
+
+
+export async function reactivateDragonPyramidLicenseAfterPayment(
+  input: DragonPyramidLicenseReactivationInput = {},
+): Promise<DragonPyramidLicenseControl> {
+  const now = new Date().toISOString();
+  const cleanReason = emptyToNull(input.reason);
+  const cleanPaymentNotes = emptyToNull(input.payment_notes);
+
+  return upsertDragonPyramidLicense({
+    client_code: input.client_code,
+    client_name: input.client_name,
+    license_status: 'active',
+    payment_status: 'paid',
+    last_payment_at: input.last_payment_at ?? now,
+    next_due_at: input.next_due_at,
+    expected_amount: input.expected_amount,
+    currency: input.currency,
+    billing_plan: input.billing_plan,
+    payment_notes:
+      cleanPaymentNotes ??
+      cleanReason ??
+      'Pago regularizado y servicio reactivado desde Dragon Pyramid.',
+    expires_at: input.expires_at,
+    grace_until: input.grace_until ?? null,
+    suspended_at: null,
+    reactivated_at: now,
+    suspension_reason: null,
+    sync_source: input.sync_source ?? 'manual_masteradmin_reactivation',
+    metadata: {
+      ...(input.metadata && typeof input.metadata === 'object' ? input.metadata : {}),
+      reactivated_from: input.sync_source ?? 'manual_masteradmin_reactivation',
+      reactivated_at: now,
+      previous_reason: cleanReason ?? null,
+    },
+  });
 }


### PR DESCRIPTION
# feat: add Dragon Pyramid reactivation after payment

## Rama

`feature/dragon-pyramid-reactivation-after-payment-v1`

## Resumen

Se implementa el flujo de reactivación controlada de Gym Master luego de regularizar pago/licencia Dragon Pyramid. La feature completa el ciclo operativo iniciado en las features anteriores: advertencia, suspensión y reactivación.

La reactivación permite volver de `suspended` a `active`, actualizar el estado comercial a `paid`, limpiar los datos de suspensión y devolver el acceso operativo a administradores, usuarios y socios sin intervención manual sobre la base de datos.

## Alcance funcional

- Nuevo endpoint protegido para Master Admin:
  - `POST /api/dragon-pyramid/license/reactivate`
- Nueva acción en `/dashboard/masteradmin/license`:
  - **Reactivar servicio**
- Reactivación desde la futura plataforma madre Dragon Pyramid mediante:
  - `POST /api/internal/dragon-pyramid/license-sync`
- Soporte para payloads con:
  - `reactivate: true`
  - `status: active`
  - `paymentStatus: paid`
- Limpieza de estado de suspensión:
  - `suspended_at = null`
  - `suspension_reason = null`
- Registro de trazabilidad:
  - `reactivated_at`
  - `sync_source = dragon_pyramid_platform_reactivation`
- Actualización de datos comerciales:
  - `payment_status = paid`
  - `last_payment_at`
  - `next_due_at`
  - `expected_amount`
  - `currency`
  - `billing_plan`
  - `payment_notes`
- Swagger actualizado.
- Documentación técnica agregada.

## Archivos modificados

```txt
src/app/dashboard/masteradmin/license/page.tsx
src/app/api/dragon-pyramid/license/reactivate/route.ts
src/app/api/internal/dragon-pyramid/license-sync/route.ts
src/interfaces/dragonPyramidLicense.interface.ts
src/services/server/dragonPyramidLicenseService.ts
src/services/apiClient.ts
src/lib/swagger/openApiSpec.ts
docs/mobile/dragon-pyramid-reactivation-after-payment-v1.md
```

## Seguridad

La reactivación manual queda restringida al rol `masteradmin`. La reactivación por sincronización interna requiere el header `x-dragon-pyramid-sync-key` y debe coincidir con `DRAGON_PYRAMID_LICENSE_SYNC_SECRET`.

El endpoint interno rechazó correctamente una clave inválida con `401 Unauthorized`, evitando que terceros puedan reactivar o modificar el estado de licencia.

## Base de datos

Esta feature no requiere nueva migración. Reutiliza los campos de licencia, pago y trazabilidad creados en las features anteriores del bloque Dragon Pyramid.

No se versionan SQL, dumps, backups ni archivos privados porque el repositorio es público y no se expone estructura interna de base de datos.

## Validación realizada

- Login `masteradmin` operativo.
- Panel `/dashboard/masteradmin/license` operativo.
- Suspensión previa validada.
- Botón **Reactivar servicio** probado.
- Reactivación deja `license_status = active`.
- Reactivación deja `payment_status = paid`.
- Reactivación limpia `suspended_at` y `suspension_reason`.
- Admin/socio recuperan acceso operativo luego de reactivar.
- Sync interno con secret correcto responde `200 OK`.
- Sync interno con `reactivate: true` actualiza licencia, pago y trazabilidad.
- Sync interno con secret incorrecto responde `401 Unauthorized`.
- Responsive y footer de `/dashboard/masteradmin/license` preservados.
- `npm run build` validado localmente.

## Evidencia de QA de sync

### Secret correcto

```txt
HTTP/1.1 200 OK
license_status: active
payment_status: paid
suspended_at: null
suspension_reason: null
sync_source: dragon_pyramid_platform_reactivation
```

### Secret incorrecto

```txt
HTTP/1.1 401 Unauthorized
{"error":"Sincronización no autorizada"}
```

## Pruebas sugeridas para review

1. Entrar como `masteradmin` a `/dashboard/masteradmin/license`.
2. Suspender el servicio.
3. Confirmar que admin/socio quedan bloqueados.
4. Volver como `masteradmin`.
5. Presionar **Reactivar servicio**.
6. Confirmar que el estado vuelve a `active` y `paid`.
7. Confirmar que admin/socio recuperan acceso.
8. Probar sync interno con `reactivate: true` y secret correcto.
9. Probar sync interno con secret incorrecto y confirmar `401 Unauthorized`.
10. Ejecutar `npm run build`.
