### PR TITLE
feat: add contextual memory to RAG Coach

### DIFF
--- a/docs/mobile/rag-coach-contextual-memory-build-fix-v1.md
+++ b/docs/mobile/rag-coach-contextual-memory-build-fix-v1.md
@@ -1,0 +1,33 @@
+# RAG Coach contextual memory build fix v1
+
+## Rama
+
+`feature/rag-coach-contextual-memory-v1`
+
+## Objetivo
+
+Corregir un error de tipado detectado durante `npm run build` en el servicio unificado del RAG Coach.
+
+## Corrección
+
+La función `buildContextAwareGuidance` fue extendida para aceptar opcionalmente la memoria conversacional (`RagCoachConversationMemory`). El patch previo ya enviaba esa memoria al construir la respuesta de orientación, pero la firma de la función seguía aceptando únicamente `name`, `message` y `context`.
+
+## Archivo modificado
+
+- `src/services/server/ragCoachUnifiedChatService.ts`
+
+## Alcance
+
+- No toca DB.
+- No agrega endpoints.
+- No modifica Swagger/OpenAPI.
+- No cambia contratos públicos.
+- Mantiene el objetivo de memoria contextual de la sesión.
+
+## Validación
+
+Ejecutar:
+
+```bash
+npm run build
+```

--- a/docs/mobile/rag-coach-contextual-memory-v1.md
+++ b/docs/mobile/rag-coach-contextual-memory-v1.md
@@ -1,0 +1,114 @@
+# feature/rag-coach-contextual-memory-v1
+
+## Objetivo
+
+Mejorar la continuidad contextual del RAG Coach para que sus respuestas no se comporten como mensajes aislados, sino como una asistencia más personalizada basada en:
+
+- contexto operativo real del socio;
+- últimas rutinas/dietas/evolución disponibles;
+- asistencia reciente;
+- ficha médica y restricciones preventivas;
+- mensajes recientes de la conversación actual;
+- intención anterior, sugerencias pendientes y próximos pasos.
+
+## Alcance implementado
+
+### Frontend
+
+Archivo principal:
+
+- `src/app/dashboard/coach/page.tsx`
+
+Cambios principales:
+
+- Se envía `conversationContext` al endpoint del Coach con los últimos mensajes de la sesión.
+- Se conserva intención anterior, acciones generadas, sugerencias y parámetros pendientes.
+- Se agrega bloque visual de **Memoria contextual** dentro de cada respuesta del Coach.
+- Se agrega card lateral de memoria con:
+  - confianza contextual;
+  - objetivo inferido/cargado;
+  - nivel;
+  - cantidad de rutinas;
+  - cantidad de dietas;
+  - registros de evolución;
+  - score contextual.
+- Se muestra trazabilidad contextual desplegable para QA.
+- Se mantienen responsive mobile/desktop, modo claro/oscuro y shell vertical para evitar espacio blanco después del footer.
+
+### Contrato de datos
+
+Archivo:
+
+- `src/interfaces/ragCoachChat.interface.ts`
+
+Se agregan tipos para:
+
+- `RagCoachConversationMemory`;
+- `RagCoachConversationMemoryMessage`;
+- `RagCoachContextSnapshot`;
+- `memoryHighlights`;
+- `memoryTrace`;
+- `contextConfidence`.
+
+### Servicio de contexto del socio
+
+Archivo:
+
+- `src/services/server/ragCoachSocioContextService.ts`
+
+Se extiende el contexto del socio con:
+
+- snapshot resumido;
+- score de disponibilidad contextual;
+- etiqueta de readiness;
+- highlights de memoria;
+- foco recomendado.
+
+### Servicio unificado del Coach
+
+Archivo:
+
+- `src/services/server/ragCoachUnifiedChatService.ts`
+
+Se agrega:
+
+- sanitización de memoria conversacional recibida desde el frontend;
+- reinterpretación de follow-ups cortos como “sí”, “dale”, “seguimos”, “qué hago hoy”;
+- resolución de intención usando memoria previa;
+- trazabilidad contextual;
+- contexto de confianza;
+- prefijo de memoria en respuestas;
+- propagación de snapshot, highlights y trace hacia el frontend.
+
+## Qué no toca
+
+- No agrega migración DB.
+- No modifica tablas.
+- No modifica endpoints.
+- No modifica Swagger/OpenAPI porque no se crean rutas nuevas ni se cambia la URL del contrato externo.
+- No toca generación base de rutinas/dietas/evolución más allá de enriquecer contexto e intención.
+- No toca PWA/service worker.
+
+## QA sugerido
+
+1. Entrar como socio a `/dashboard/coach`.
+2. Enviar: `No sé por dónde empezar`.
+3. Confirmar que devuelve orientación y muestra datos faltantes.
+4. Enviar luego: `dale` o `sí`.
+5. Confirmar que el Coach usa memoria de la conversación para continuar en vez de responder genérico.
+6. Enviar: `Qué hago hoy`.
+7. Confirmar que intenta apoyarse en rutina/contexto previo.
+8. Enviar: `Quiero una dieta que acompañe la rutina`.
+9. Confirmar que detecta intención dieta usando memoria de la rutina previa.
+10. Revisar que aparezca la card lateral de memoria contextual.
+11. Revisar que aparezca el bloque `Memoria contextual` dentro de las respuestas.
+12. Revisar `Trazabilidad contextual` en QA.
+13. Probar modo claro y oscuro.
+14. Probar F12 mobile y salida a desktop.
+15. Confirmar que no hay scroll horizontal ni espacio blanco después del footer.
+
+## Commit sugerido
+
+```bash
+git commit -m "feat: add contextual memory to RAG Coach"
+```

--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -13,12 +13,14 @@ import {
   Brain,
   CheckCircle2,
   Dumbbell,
+  History,
   Info,
   Loader2,
   MessageSquareText,
   RefreshCcw,
   SearchCheck,
   Send,
+  Target,
   ShieldCheck,
   Sparkles,
   UserRound,
@@ -34,6 +36,8 @@ import type {
   RagCoachChatActionResult,
   RagCoachChatIntent,
   RagCoachChatSource,
+  RagCoachContextSnapshot,
+  RagCoachConversationMemory,
 } from '@/interfaces/ragCoachChat.interface';
 import { enviarMensajeCoachIa } from '@/services/ragCoachChatClient';
 import { useAuthStore } from '@/stores/authStore';
@@ -51,6 +55,10 @@ type ChatMessage = {
   safetySummary?: string;
   intent?: RagCoachChatIntent;
   missingParams?: string[];
+  contextSnapshot?: RagCoachContextSnapshot;
+  memoryHighlights?: string[];
+  memoryTrace?: string[];
+  contextConfidence?: 'alta' | 'media' | 'baja';
 };
 
 const quickPrompts = [
@@ -120,6 +128,55 @@ function formatSimilarity(value?: number) {
 
 function hasSources(actions?: RagCoachChatActionResult[]) {
   return actions?.some((action) => (action.sources ?? []).length > 0) ?? false;
+}
+
+function getLatestAssistant(messages: ChatMessage[]) {
+  return [...messages].reverse().find((message) => message.role === 'assistant');
+}
+
+function buildConversationMemory(
+  previousMessages: ChatMessage[],
+  pendingUserMessage: ChatMessage,
+): RagCoachConversationMemory {
+  const messagesForMemory = [...previousMessages, pendingUserMessage];
+  const latestAssistant = getLatestAssistant(previousMessages);
+
+  return {
+    recentMessages: messagesForMemory.slice(-8).map((message) => ({
+      role: message.role,
+      content: message.content.slice(0, 280),
+      intent: message.intent,
+    })),
+    lastAssistantIntent: latestAssistant?.intent,
+    lastActionTypes: latestAssistant?.actions?.map((action) => action.type) ?? [],
+    lastSuggestedReplies: latestAssistant?.suggestedReplies?.slice(0, 4) ?? [],
+    pendingMissingParams: latestAssistant?.missingParams?.slice(0, 6) ?? [],
+    lastNextBestStep: latestAssistant?.nextBestStep,
+    lastContextSummary: latestAssistant?.contextSummary,
+  };
+}
+
+function getLatestContextMessage(messages: ChatMessage[]) {
+  return [...messages].reverse().find((message) => message.role === 'assistant' && (message.contextSnapshot || message.contextSummary));
+}
+
+function contextConfidenceLabel(value?: 'alta' | 'media' | 'baja') {
+  if (value === 'alta') return 'Alta';
+  if (value === 'media') return 'Media';
+  if (value === 'baja') return 'Baja';
+  return 'Pendiente';
+}
+
+function contextConfidenceClass(value?: 'alta' | 'media' | 'baja') {
+  if (value === 'alta') return 'border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100';
+  if (value === 'media') return 'border-cyan-200 bg-cyan-50 text-cyan-800 dark:border-cyan-500/30 dark:bg-cyan-500/10 dark:text-cyan-100';
+  if (value === 'baja') return 'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100';
+  return 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-200';
+}
+
+function formatContextValue(value?: string | number | null) {
+  if (value === null || value === undefined || value === '') return '—';
+  return String(value);
 }
 
 function renderSources(sources: RagCoachChatSource[]) {
@@ -230,6 +287,8 @@ export default function CoachIaPage() {
   const totalAssistantMessages = messages.filter((message) => message.role === 'assistant').length;
   const totalActionMessages = messages.reduce((total, message) => total + (message.actions?.filter((action) => action.ok).length ?? 0), 0);
   const hasRagSources = messages.some((message) => hasSources(message.actions));
+  const latestContextMessage = useMemo(() => getLatestContextMessage(messages), [messages]);
+  const latestContextSnapshot = latestContextMessage?.contextSnapshot;
 
   useEffect(() => {
     initializeAuth();
@@ -288,7 +347,11 @@ export default function CoachIaPage() {
     setMessages((current) => [...current, userMessage]);
 
     try {
-      const res = await enviarMensajeCoachIa({ message, socio_id: user?.id_socio || 'me' });
+      const res = await enviarMensajeCoachIa({
+        message,
+        socio_id: user?.id_socio || 'me',
+        conversationContext: buildConversationMemory(messages, userMessage),
+      });
 
       if (!res.ok || !res.data) {
         throw new Error(res.error || 'No se pudo obtener respuesta del Coach IA.');
@@ -307,6 +370,10 @@ export default function CoachIaPage() {
         safetySummary: res.data.safetySummary,
         intent: res.data.intent,
         missingParams: res.data.missingParams,
+        contextSnapshot: res.data.contextSnapshot,
+        memoryHighlights: res.data.memoryHighlights,
+        memoryTrace: res.data.memoryTrace,
+        contextConfidence: res.data.contextConfidence,
       };
 
       setMessages((current) => [...current, assistantMessage]);
@@ -358,13 +425,13 @@ export default function CoachIaPage() {
                   <div className="max-w-3xl">
                     <div className="inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold text-cyan-100">
                       <Brain className="h-3.5 w-3.5" />
-                      RAG Coach final polish
+                      RAG Coach contextual memory
                     </div>
                     <h1 className="mt-4 text-2xl font-black tracking-tight sm:text-4xl">
-                      Coach IA con contexto, fuentes y fallback seguro
+                      Coach IA con memoria contextual del socio
                     </h1>
                     <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-300 sm:text-base">
-                      Consultá rutinas, dietas y evolución física con una experiencia más clara, trazable y lista para demo comercial.
+                      Consultá rutinas, dietas y evolución física con continuidad conversacional, contexto operativo y recomendaciones más personalizadas.
                     </p>
                   </div>
 
@@ -461,6 +528,25 @@ export default function CoachIaPage() {
                                 </div>
                               )}
 
+                              {message.contextSnapshot && message.role === 'assistant' && (
+                                <div className="mt-3 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2 text-xs text-emerald-950 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+                                  <div className="mb-2 flex items-center gap-1.5 font-semibold">
+                                    <Target className="h-3.5 w-3.5" />
+                                    Memoria contextual
+                                  </div>
+                                  <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+                                    <span>Objetivo: {formatContextValue(message.contextSnapshot.objetivoLabel)}</span>
+                                    <span>Nivel: {formatContextValue(message.contextSnapshot.nivelLabel)}</span>
+                                    <span>Rutinas: {message.contextSnapshot.rutinasTotal}</span>
+                                    <span>Dietas: {message.contextSnapshot.dietasTotal}</span>
+                                    <span>Evolución: {message.contextSnapshot.evolucionTotal}</span>
+                                    <span>Asistencia 7d: {message.contextSnapshot.asistencia7Dias}</span>
+                                    <span>Score: {message.contextSnapshot.readinessScore}%</span>
+                                    <span>{message.contextSnapshot.readinessLabel}</span>
+                                  </div>
+                                </div>
+                              )}
+
                               {message.safetySummary && message.role === 'assistant' && (
                                 <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
                                   <strong>Seguridad:</strong> {message.safetySummary}
@@ -480,6 +566,24 @@ export default function CoachIaPage() {
                                     {message.contextHints?.slice(0, 3).map((hint) => <li key={hint}>{hint}</li>)}
                                   </ul>
                                 </div>
+                              )}
+
+                              {(message.memoryHighlights?.length ?? 0) > 0 && message.role === 'assistant' && (
+                                <div className="mt-3 rounded-xl border border-violet-100 bg-violet-50 px-3 py-2 text-xs text-violet-950 dark:border-violet-500/30 dark:bg-violet-500/10 dark:text-violet-100">
+                                  <div className="mb-1 font-semibold">Memoria recordada</div>
+                                  <ul className="list-disc space-y-1 pl-4">
+                                    {message.memoryHighlights?.slice(0, 3).map((item) => <li key={item}>{item}</li>)}
+                                  </ul>
+                                </div>
+                              )}
+
+                              {(message.memoryTrace?.length ?? 0) > 0 && message.role === 'assistant' && (
+                                <details className="mt-3 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-950/60 dark:text-slate-300">
+                                  <summary className="cursor-pointer font-semibold">Trazabilidad contextual</summary>
+                                  <ul className="mt-2 list-disc space-y-1 pl-4">
+                                    {message.memoryTrace?.slice(0, 5).map((item) => <li key={item}>{item}</li>)}
+                                  </ul>
+                                </details>
                               )}
 
                               {(message.missingParams?.length ?? 0) > 0 && message.role === 'assistant' && (
@@ -580,14 +684,75 @@ export default function CoachIaPage() {
                   <Card className="rounded-3xl border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
                     <CardHeader className="pb-2">
                       <div className="flex items-center gap-2">
+                        <History className="h-5 w-5 text-[#02a8e1]" />
+                        <h2 className="text-base font-bold text-slate-950 dark:text-white">Memoria contextual</h2>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="space-y-3 text-sm text-slate-600 dark:text-slate-300">
+                      <div className={`rounded-2xl border px-3 py-2 text-xs font-semibold ${contextConfidenceClass(latestContextMessage?.contextConfidence)}`}>
+                        Confianza: {contextConfidenceLabel(latestContextMessage?.contextConfidence)}
+                      </div>
+                      {latestContextSnapshot ? (
+                        <div className="space-y-2 rounded-2xl bg-slate-50 p-3 text-xs dark:bg-slate-950/60">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-slate-500 dark:text-slate-400">Objetivo</span>
+                            <strong className="text-right text-slate-900 dark:text-white">{formatContextValue(latestContextSnapshot.objetivoLabel)}</strong>
+                          </div>
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="text-slate-500 dark:text-slate-400">Nivel</span>
+                            <strong className="text-right text-slate-900 dark:text-white">{formatContextValue(latestContextSnapshot.nivelLabel)}</strong>
+                          </div>
+                          <div className="grid grid-cols-3 gap-2 pt-2 text-center">
+                            <div className="rounded-xl bg-white p-2 dark:bg-slate-900">
+                              <div className="font-black text-slate-950 dark:text-white">{latestContextSnapshot.rutinasTotal}</div>
+                              <div className="text-[10px]">rutinas</div>
+                            </div>
+                            <div className="rounded-xl bg-white p-2 dark:bg-slate-900">
+                              <div className="font-black text-slate-950 dark:text-white">{latestContextSnapshot.dietasTotal}</div>
+                              <div className="text-[10px]">dietas</div>
+                            </div>
+                            <div className="rounded-xl bg-white p-2 dark:bg-slate-900">
+                              <div className="font-black text-slate-950 dark:text-white">{latestContextSnapshot.evolucionTotal}</div>
+                              <div className="text-[10px]">evolución</div>
+                            </div>
+                          </div>
+                          <div className="rounded-xl border border-slate-200 bg-white p-2 dark:border-slate-800 dark:bg-slate-900">
+                            <div className="mb-1 flex items-center justify-between text-[11px]">
+                              <span>Score contextual</span>
+                              <strong>{latestContextSnapshot.readinessScore}%</strong>
+                            </div>
+                            <div className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+                              <div className="h-full rounded-full bg-[#02a8e1]" style={{ width: `${latestContextSnapshot.readinessScore}%` }} />
+                            </div>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="rounded-2xl bg-slate-50 p-3 text-xs dark:bg-slate-950/60">
+                          Todavía no hay memoria contextual calculada. Enviá una consulta para que el Coach lea el contexto del socio.
+                        </p>
+                      )}
+                      {(latestContextMessage?.memoryHighlights?.length ?? 0) > 0 && (
+                        <div className="space-y-1 rounded-2xl border border-slate-200 p-3 text-xs dark:border-slate-700">
+                          <div className="font-semibold text-slate-950 dark:text-white">Recordado</div>
+                          {latestContextMessage?.memoryHighlights?.slice(0, 3).map((item) => (
+                            <p key={item}>• {item}</p>
+                          ))}
+                        </div>
+                      )}
+                    </CardContent>
+                  </Card>
+
+                  <Card className="rounded-3xl border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                    <CardHeader className="pb-2">
+                      <div className="flex items-center gap-2">
                         <CheckCircle2 className="h-5 w-5 text-emerald-500" />
                         <h2 className="text-base font-bold text-slate-950 dark:text-white">Checklist de calidad</h2>
                       </div>
                     </CardHeader>
                     <CardContent className="space-y-2 text-sm text-slate-600 dark:text-slate-300">
                       {[
-                        'Contexto del socio visible.',
-                        'Fuentes RAG cuando existan.',
+                        'Memoria conversacional visible.',
+                        'Contexto operativo del socio resumido.',
                         'Fallback seguro para señales sensibles.',
                         'Acciones claras para ver rutina, dieta o evolución.',
                         'Diseño responsive sin scroll horizontal.',

--- a/src/interfaces/ragCoachChat.interface.ts
+++ b/src/interfaces/ragCoachChat.interface.ts
@@ -12,10 +12,26 @@ export type RagCoachChatActionType =
   | 'evolution_analyzed'
   | 'guidance_only';
 
+export interface RagCoachConversationMemoryMessage {
+  role: 'assistant' | 'user';
+  content: string;
+  intent?: RagCoachChatIntent;
+}
+
+export interface RagCoachConversationMemory {
+  recentMessages?: RagCoachConversationMemoryMessage[];
+  lastAssistantIntent?: RagCoachChatIntent;
+  lastActionTypes?: RagCoachChatActionType[];
+  lastSuggestedReplies?: string[];
+  pendingMissingParams?: string[];
+  lastNextBestStep?: string;
+  lastContextSummary?: string;
+}
+
 export interface RagCoachChatRequest {
   message: string;
   socio_id?: string;
-  conversationContext?: Record<string, unknown>;
+  conversationContext?: RagCoachConversationMemory;
 }
 
 export interface RagCoachChatSource {
@@ -24,6 +40,28 @@ export interface RagCoachChatSource {
   sourceTable?: string;
   similarity?: number;
   contentPreview?: string;
+}
+
+export interface RagCoachContextSnapshot {
+  socioName?: string | null;
+  nivelLabel?: string;
+  objetivoLabel?: string;
+  diasPorSemana?: number | null;
+  rutinasTotal: number;
+  ultimaRutina?: string | null;
+  dietasTotal: number;
+  ultimaDietaObjetivo?: string | null;
+  evolucionTotal: number;
+  ultimaEvolucionFecha?: string | null;
+  ultimoPeso?: number | null;
+  ultimaCintura?: number | null;
+  asistencia7Dias: number;
+  asistencia30Dias: number;
+  fichaMedicaExiste: boolean;
+  restriccionesMedicas: number;
+  aprobacionMedica?: boolean | null;
+  readinessScore: number;
+  readinessLabel: string;
 }
 
 export interface RagCoachChatActionResult {
@@ -52,6 +90,10 @@ export interface RagCoachChatResponseData {
   contextHints?: string[];
   nextBestStep?: string;
   safetySummary?: string;
+  contextSnapshot?: RagCoachContextSnapshot;
+  memoryHighlights?: string[];
+  memoryTrace?: string[];
+  contextConfidence?: 'alta' | 'media' | 'baja';
 }
 
 export interface RagCoachChatApiResponse {

--- a/src/services/server/ragCoachSocioContextService.ts
+++ b/src/services/server/ragCoachSocioContextService.ts
@@ -1,4 +1,5 @@
 import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import type { RagCoachContextSnapshot } from '@/interfaces/ragCoachChat.interface';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 
 export type RagCoachSocioContext = {
@@ -57,6 +58,9 @@ export type RagCoachSocioContext = {
   };
   resumenHumano: string;
   hints: string[];
+  contextSnapshot: RagCoachContextSnapshot;
+  memoryHighlights: string[];
+  recommendedFocus: string[];
 };
 
 function toIsoDate(value: Date) {
@@ -117,7 +121,7 @@ function buildSafeMedicalRestrictions(row: Record<string, unknown> | null) {
   return restrictions;
 }
 
-function buildHumanSummary(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints'>) {
+function buildHumanSummary(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'>) {
   const parts = [
     `${context.rutinas.total} rutina${context.rutinas.total === 1 ? '' : 's'}`,
     `${context.dietas.total} dieta${context.dietas.total === 1 ? '' : 's'}`,
@@ -129,7 +133,7 @@ function buildHumanSummary(context: Omit<RagCoachSocioContext, 'resumenHumano' |
   return `Usé tu contexto del sistema: ${parts.join(', ')}.`;
 }
 
-function buildHints(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints'>) {
+function buildHints(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'>) {
   const hints: string[] = [];
 
   if (context.rutinas.total === 0) {
@@ -156,7 +160,109 @@ function buildHints(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints
     hints.push('Tiene observaciones preventivas de ficha médica: priorizar recomendaciones prudentes.');
   }
 
+
   return hints;
+}
+
+function levelLabel(value?: number | null) {
+  if (value === 1) return 'Inicial';
+  if (value === 2) return 'Intermedio';
+  if (value === 3) return 'Avanzado';
+  return 'No definido';
+}
+
+function objectiveLabel(value?: number | null) {
+  const labels: Record<number, string> = {
+    1: 'Ganar masa muscular',
+    2: 'Definición / bajar grasa',
+    3: 'Bajar de peso',
+    4: 'Fuerza',
+    5: 'Resistencia',
+    6: 'Rehabilitación / cuidado físico',
+    7: 'Salud y bienestar',
+    10: 'Estrés / bienestar emocional',
+  };
+
+  return value && labels[value] ? labels[value] : 'No definido';
+}
+
+function buildReadinessScore(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'>) {
+  let score = 0;
+  if (context.socio) score += 15;
+  if (context.socio?.objetivo) score += 15;
+  if (context.socio?.nivel) score += 10;
+  if (context.rutinas.total > 0) score += 15;
+  if (context.dietas.total > 0) score += 15;
+  if (context.evolucion.total > 0) score += 15;
+  if (context.asistencia.ultimos30Dias > 0) score += 10;
+  if (context.fichaMedica.existe) score += 5;
+  return Math.max(0, Math.min(100, score));
+}
+
+function readinessLabel(score: number) {
+  if (score >= 75) return 'Contexto alto';
+  if (score >= 45) return 'Contexto medio';
+  return 'Contexto inicial';
+}
+
+function buildContextSnapshot(
+  context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'>,
+): RagCoachContextSnapshot {
+  const readinessScore = buildReadinessScore(context);
+  return {
+    socioName: context.socio?.nombre,
+    nivelLabel: levelLabel(context.socio?.nivel),
+    objetivoLabel: objectiveLabel(context.socio?.objetivo),
+    diasPorSemana: context.socio?.diasPorSemana ?? null,
+    rutinasTotal: context.rutinas.total,
+    ultimaRutina: context.rutinas.recientes[0]?.nombre ?? null,
+    dietasTotal: context.dietas.total,
+    ultimaDietaObjetivo: context.dietas.recientes[0]?.objetivo ?? context.dietas.recientes[0]?.nombrePlan ?? null,
+    evolucionTotal: context.evolucion.total,
+    ultimaEvolucionFecha: context.evolucion.ultimaFecha ?? null,
+    ultimoPeso: context.evolucion.ultimoPeso ?? context.fichaMedica.peso ?? null,
+    ultimaCintura: context.evolucion.ultimaCintura ?? null,
+    asistencia7Dias: context.asistencia.ultimos7Dias,
+    asistencia30Dias: context.asistencia.ultimos30Dias,
+    fichaMedicaExiste: context.fichaMedica.existe,
+    restriccionesMedicas: context.fichaMedica.restriccionesSeguras.length,
+    aprobacionMedica: context.fichaMedica.aprobacionMedica ?? null,
+    readinessScore,
+    readinessLabel: readinessLabel(readinessScore),
+  };
+}
+
+function buildMemoryHighlights(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'>) {
+  const highlights: string[] = [];
+  const latestRoutine = context.rutinas.recientes[0]?.nombre;
+  const latestDiet = context.dietas.recientes[0]?.objetivo ?? context.dietas.recientes[0]?.nombrePlan;
+
+  if (latestRoutine) highlights.push(`Última rutina detectada: ${latestRoutine}.`);
+  if (latestDiet) highlights.push(`Última dieta/objetivo nutricional detectado: ${latestDiet}.`);
+  if (context.evolucion.ultimaFecha) {
+    const metrics = [
+      context.evolucion.ultimoPeso ? `${context.evolucion.ultimoPeso} kg` : '',
+      context.evolucion.ultimaCintura ? `cintura ${context.evolucion.ultimaCintura} cm` : '',
+    ].filter(Boolean).join(' · ');
+    highlights.push(`Última evolución: ${context.evolucion.ultimaFecha}${metrics ? ` (${metrics})` : ''}.`);
+  }
+  if (context.asistencia.ultimos7Dias > 0) highlights.push(`Asistencia reciente: ${context.asistencia.ultimos7Dias} registro(s) en 7 días.`);
+  if (context.fichaMedica.restriccionesSeguras.length > 0) highlights.push('Ficha médica con restricciones preventivas activas.');
+
+  return highlights;
+}
+
+function buildRecommendedFocus(context: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'>) {
+  const focus: string[] = [];
+
+  if (context.rutinas.total === 0) focus.push('crear rutina base inicial');
+  if (context.dietas.total === 0) focus.push('acompañar con orientación nutricional');
+  if (context.evolucion.total === 0) focus.push('cargar evolución física inicial');
+  if (context.asistencia.ultimos7Dias === 0) focus.push('retomar asistencia de forma progresiva');
+  if (context.fichaMedica.restriccionesSeguras.length > 0) focus.push('mantener recomendaciones conservadoras');
+  if (!focus.length) focus.push('ajustar rutina/dieta según progreso mensual');
+
+  return focus;
 }
 
 export async function buildRagCoachSocioContext(
@@ -231,7 +337,7 @@ export async function buildRagCoachSocioContext(
   const latestEvolution = evolucionRows[0] ?? null;
   const asistencia7 = asistenciaRows.filter((row) => typeof row.fecha === 'string' && row.fecha >= start7).length;
 
-  const baseContext: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints'> = {
+  const baseContext: Omit<RagCoachSocioContext, 'resumenHumano' | 'hints' | 'contextSnapshot' | 'memoryHighlights' | 'recommendedFocus'> = {
     socioId,
     socio: socioRow
       ? {
@@ -293,5 +399,8 @@ export async function buildRagCoachSocioContext(
     ...baseContext,
     resumenHumano: buildHumanSummary(baseContext),
     hints: buildHints(baseContext),
+    contextSnapshot: buildContextSnapshot(baseContext),
+    memoryHighlights: buildMemoryHighlights(baseContext),
+    recommendedFocus: buildRecommendedFocus(baseContext),
   };
 }

--- a/src/services/server/ragCoachUnifiedChatService.ts
+++ b/src/services/server/ragCoachUnifiedChatService.ts
@@ -2,6 +2,7 @@ import type { JwtUser } from '@/interfaces/jwtUser.interface';
 import type {
   RagCoachChatActionResult,
   RagCoachChatIntent,
+  RagCoachConversationMemory,
   RagCoachChatRequest,
   RagCoachChatResponseData,
   RagCoachChatSource,
@@ -16,6 +17,10 @@ import { buildRagCoachSocioContext, type RagCoachSocioContext } from './ragCoach
 
 const MAX_MESSAGE_LENGTH = 1600;
 const MAX_SOURCES_PER_ACTION = 4;
+const MAX_MEMORY_MESSAGES = 8;
+
+const AFFIRMATIVE_FOLLOW_UP_RE = /^(si|sí|dale|ok|perfecto|hacelo|hazlo|quiero eso|generala|generalo|armala|armalo|preparala|preparalo|tambien|también)$/;
+
 
 function normalize(value: string) {
   return value
@@ -48,6 +53,92 @@ function getDisplayName(user: JwtUser) {
 
 function uniqueValues(values: string[]) {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function safeArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? value as T[] : [];
+}
+
+function sanitizeMemoryText(value: unknown, maxLength = 280) {
+  return cleanText(value, maxLength);
+}
+
+function sanitizeConversationMemory(value: unknown): RagCoachConversationMemory {
+  if (!value || typeof value !== 'object') return {};
+  const raw = value as Record<string, unknown>;
+  const recentMessages = safeArray<Record<string, unknown>>(raw.recentMessages)
+    .slice(-MAX_MEMORY_MESSAGES)
+    .map((item) => ({
+      role: item.role === 'assistant' ? 'assistant' as const : 'user' as const,
+      content: sanitizeMemoryText(item.content),
+      intent: typeof item.intent === 'string' ? item.intent as RagCoachChatIntent : undefined,
+    }))
+    .filter((item) => item.content.length > 0);
+
+  return {
+    recentMessages,
+    lastAssistantIntent: typeof raw.lastAssistantIntent === 'string' ? raw.lastAssistantIntent as RagCoachChatIntent : undefined,
+    lastActionTypes: safeArray<string>(raw.lastActionTypes)
+      .filter((item): item is RagCoachChatActionResult['type'] => ['routine_generated', 'diet_generated', 'evolution_analyzed', 'guidance_only'].includes(item)),
+    lastSuggestedReplies: safeArray<string>(raw.lastSuggestedReplies).map((item) => sanitizeMemoryText(item, 120)).filter(Boolean).slice(0, 4),
+    pendingMissingParams: safeArray<string>(raw.pendingMissingParams).map((item) => sanitizeMemoryText(item, 60)).filter(Boolean).slice(0, 6),
+    lastNextBestStep: sanitizeMemoryText(raw.lastNextBestStep, 180) || undefined,
+    lastContextSummary: sanitizeMemoryText(raw.lastContextSummary, 220) || undefined,
+  };
+}
+
+function hasPriorAction(memory: RagCoachConversationMemory, actionType: RagCoachChatActionResult['type']) {
+  return (memory.lastActionTypes ?? []).includes(actionType);
+}
+
+function resolveIntentWithMemory(message: string, detectedIntent: RagCoachChatIntent, memory: RagCoachConversationMemory): RagCoachChatIntent {
+  const text = normalize(message);
+
+  if (detectedIntent !== 'general_guidance' && detectedIntent !== 'unknown') return detectedIntent;
+
+  if (/\b(que hago hoy|hoy que hago|que me toca hoy|plan de hoy|seguimos|continuemos)\b/.test(text)) {
+    if (hasPriorAction(memory, 'routine_generated')) return 'routine_request';
+    if (memory.lastAssistantIntent === 'routine_request') return 'routine_request';
+  }
+
+  if (AFFIRMATIVE_FOLLOW_UP_RE.test(text)) {
+    if (memory.lastSuggestedReplies?.some((reply) => normalize(reply).includes('dieta'))) return 'diet_request';
+    if (hasPriorAction(memory, 'routine_generated') && !hasPriorAction(memory, 'diet_generated')) return 'diet_request';
+    if (memory.lastAssistantIntent === 'general_guidance' || memory.lastAssistantIntent === 'unknown') return 'routine_request';
+  }
+
+  if (/\b(esa dieta|la dieta|alimentacion complementaria|acompañar la rutina|acompanar la rutina)\b/.test(text)) return 'diet_request';
+  if (/\b(esa rutina|mi rutina|la rutina|entrenamiento de hoy)\b/.test(text)) return 'routine_request';
+  if (/\b(mi progreso|como voy|sigo igual|estoy igual|avance)\b/.test(text)) return 'evolution_analysis_request';
+
+  return detectedIntent;
+}
+
+function buildMemoryTrace(memory: RagCoachConversationMemory, intent: RagCoachChatIntent, context?: RagCoachSocioContext | null) {
+  const trace: string[] = [];
+
+  if ((memory.recentMessages ?? []).length > 0) {
+    trace.push(`Se usaron ${memory.recentMessages?.length ?? 0} mensaje(s) recientes de esta conversación.`);
+  }
+  if (memory.lastAssistantIntent) trace.push(`Última intención recordada: ${memory.lastAssistantIntent}.`);
+  if ((memory.pendingMissingParams ?? []).length > 0) trace.push(`Parámetros pendientes recordados: ${memory.pendingMissingParams?.join(', ')}.`);
+  if (context?.contextSnapshot) trace.push(`${context.contextSnapshot.readinessLabel}: ${context.contextSnapshot.readinessScore}% de contexto operativo disponible.`);
+  if ((context?.recommendedFocus ?? []).length > 0) trace.push(`Foco sugerido: ${context?.recommendedFocus.slice(0, 3).join(', ')}.`);
+  trace.push(`Intención final aplicada: ${intent}.`);
+
+  return uniqueValues(trace).slice(0, 6);
+}
+
+function buildContextConfidence(context?: RagCoachSocioContext | null): 'alta' | 'media' | 'baja' {
+  const score = context?.contextSnapshot?.readinessScore ?? 0;
+  if (score >= 75) return 'alta';
+  if (score >= 45) return 'media';
+  return 'baja';
+}
+
+function buildContextualReplyPrefix(context?: RagCoachSocioContext | null) {
+  if (!context?.memoryHighlights.length) return '';
+  return `Tomé como memoria del socio: ${context.memoryHighlights.slice(0, 3).join(' ')}`;
 }
 
 function detectIntent(message: string): RagCoachChatIntent {
@@ -167,11 +258,23 @@ function shouldBlockAutomationForSafety(message: string) {
   return /\b(dolor de pecho|desmayo|desmayos|falta de aire|mareo fuerte|taquicardia)\b/.test(text);
 }
 
-function buildContextAwareGuidance(name: string, message: string, context?: RagCoachSocioContext | null) {
+function buildContextAwareGuidance(
+  name: string,
+  message: string,
+  context?: RagCoachSocioContext | null,
+  memory?: RagCoachConversationMemory,
+) {
   const base = buildGuidanceReply(name, message, context);
   const contextLine = getContextCoachLine(context);
-  if (!contextLine) return base;
-  return `${base}\n\n${contextLine}`;
+  const memoryLines = [
+    memory?.lastNextBestStep ? `Continuidad previa: ${memory.lastNextBestStep}` : '',
+    (memory?.pendingMissingParams ?? []).length > 0
+      ? `Datos pendientes ya detectados: ${(memory?.pendingMissingParams ?? []).join(', ')}.`
+      : '',
+    memory?.lastContextSummary ? `Contexto recordado: ${memory.lastContextSummary}` : '',
+  ].filter(Boolean);
+
+  return [base, contextLine, ...memoryLines].filter(Boolean).join('\n\n');
 }
 
 function todayIso() {
@@ -417,7 +520,10 @@ export async function handleUnifiedRagCoachChat(
     return null;
   });
 
-  const intent = detectIntent(message);
+  const conversationMemory = sanitizeConversationMemory(payload.conversationContext);
+  const detectedIntent = detectIntent(message);
+  const intent = resolveIntentWithMemory(message, detectedIntent, conversationMemory);
+  const memoryTrace = buildMemoryTrace(conversationMemory, intent, socioContext);
   const safetyNotes = buildSafetyNotes(message, intent, socioContext);
   const evolutionSuggestion = await getEvolutionSuggestion(user, effectiveSocioId, socioContext);
   const contextLine = getContextCoachLine(socioContext);
@@ -425,7 +531,9 @@ export async function handleUnifiedRagCoachChat(
   const suggestedReplies: string[] = [];
 
   if (contextLine) coachNotes.push(contextLine);
+  coachNotes.push(...(socioContext?.memoryHighlights ?? []));
   coachNotes.push(...(socioContext?.hints ?? []));
+  if (conversationMemory.lastNextBestStep) coachNotes.push(`Continuidad previa: ${conversationMemory.lastNextBestStep}`);
 
   if (shouldBlockAutomationForSafety(message)) {
     const reply = [
@@ -457,6 +565,10 @@ export async function handleUnifiedRagCoachChat(
       contextHints: socioContext?.hints,
       nextBestStep: 'Derivar a evaluación profesional antes de ajustar entrenamiento o dieta.',
       safetySummary: safetyNotes.join(' '),
+      contextSnapshot: socioContext?.contextSnapshot,
+      memoryHighlights: socioContext?.memoryHighlights,
+      memoryTrace,
+      contextConfidence: buildContextConfidence(socioContext),
     };
   }
 
@@ -495,7 +607,7 @@ export async function handleUnifiedRagCoachChat(
     return {
       greeting,
       intent,
-      reply: `${buildContextAwareGuidance(name, message, socioContext)}\n\n${evolutionSuggestion}`,
+      reply: `${buildContextAwareGuidance(name, message, socioContext, conversationMemory)}\n\n${evolutionSuggestion}`,
       actions: [
         {
           type: 'guidance_only',
@@ -512,6 +624,10 @@ export async function handleUnifiedRagCoachChat(
       contextHints: socioContext?.hints,
       nextBestStep: 'Pedir objetivo, disponibilidad semanal y restricciones.',
       safetySummary: safetyNotes.join(' '),
+      contextSnapshot: socioContext?.contextSnapshot,
+      memoryHighlights: socioContext?.memoryHighlights,
+      memoryTrace,
+      contextConfidence: buildContextConfidence(socioContext),
     };
   }
 
@@ -522,11 +638,13 @@ export async function handleUnifiedRagCoachChat(
     : '';
   const safetySuffix = safetyNotes.length ? `\n\nNota de seguridad: ${safetyNotes[0]}` : '';
   const contextSuffix = contextLine ? `\n\n${contextLine}` : '';
+  const memoryPrefix = buildContextualReplyPrefix(socioContext);
+  const memorySuffix = memoryPrefix ? `\n\n${memoryPrefix}` : '';
 
   return {
     greeting,
     intent,
-    reply: `${actionMessages}${offerDiet}\n\n${evolutionSuggestion}${contextSuffix}${safetySuffix}`,
+    reply: `${actionMessages}${offerDiet}\n\n${evolutionSuggestion}${memorySuffix}${contextSuffix}${safetySuffix}`,
     actions,
     suggestedReplies: uniqueValues(suggestedReplies),
     missingParams: [],
@@ -537,5 +655,9 @@ export async function handleUnifiedRagCoachChat(
       ? 'Ofrecer dieta complementaria y seguimiento de evolución física.'
       : 'Sugerir seguimiento mensual de evolución física si el socio está comprometido.',
     safetySummary: safetyNotes.join(' '),
+    contextSnapshot: socioContext?.contextSnapshot,
+    memoryHighlights: socioContext?.memoryHighlights,
+    memoryTrace,
+    contextConfidence: buildContextConfidence(socioContext),
   };
 }


### PR DESCRIPTION
# PR: RAG Coach contextual memory v1

## Rama

`feature/rag-coach-contextual-memory-v1`

## Título sugerido

`feat: add contextual memory to RAG Coach`

## Resumen

Esta feature mejora la continuidad contextual del RAG Coach de Gym Master. El asistente deja de responder como un chat aislado y comienza a reutilizar memoria conversacional de la sesión actual junto con el contexto operativo del socio, como rutina, dieta, evolución física, asistencia, ficha médica y señales de preparación contextual.

Incluye también el fix de build aplicado luego del primer patch, extendiendo correctamente la firma de `buildContextAwareGuidance(...)` para aceptar memoria conversacional sin romper el tipado de TypeScript.

## Objetivo

Mejorar la experiencia del socio en `/dashboard/coach`, permitiendo que el Coach entienda mejor preguntas de continuidad como:

- `dale`
- `sí`
- `seguimos`
- `qué hago hoy`
- `quiero esa dieta`
- `cómo voy con mi progreso`

## Cambios principales

- Se agrega memoria conversacional de la sesión actual enviada desde el frontend al backend.
- Se almacenan y reutilizan señales recientes:
  - últimos mensajes;
  - última intención detectada;
  - últimas acciones generadas;
  - sugerencias pendientes;
  - parámetros faltantes;
  - próximo paso recomendado.
- Se extiende el contexto del socio con:
  - snapshot contextual;
  - score de preparación contextual;
  - foco recomendado;
  - highlights de memoria;
  - trazabilidad contextual para QA.
- Se mejora la UI del Coach con:
  - card lateral de memoria contextual;
  - bloque de memoria dentro de cada respuesta;
  - indicador de confianza contextual;
  - trazabilidad desplegable.
- Se corrige el build TypeScript extendiendo `buildContextAwareGuidance(...)` para recibir `conversationMemory`.

## Archivos modificados

```text
src/app/dashboard/coach/page.tsx
src/interfaces/ragCoachChat.interface.ts
src/services/server/ragCoachSocioContextService.ts
src/services/server/ragCoachUnifiedChatService.ts
docs/mobile/rag-coach-contextual-memory-v1.md
docs/mobile/rag-coach-contextual-memory-build-fix-v1.md
```

## Base de datos

No requiere migración DB.

## Endpoints y Swagger/OpenAPI

No agrega endpoints nuevos y no modifica contratos públicos. Por ese motivo no requiere cambios en Swagger/OpenAPI.

## Validación realizada

- `npm run build` exitoso luego del fix de build.
- QA funcional exitoso en `/dashboard/coach`.
- Pruebas de continuidad conversacional aprobadas.
- Pruebas con mensajes cortos aprobadas.
- Validación de modo claro/oscuro aprobada.
- Validación responsive mobile/desktop aprobada.
- Sin scroll horizontal.
- Sin espacio blanco después del footer.
- Sin cambios DB ni archivos sensibles para commitear.

## QA sugerido para revisión del PR

1. Entrar como socio a `/dashboard/coach`.
2. Enviar `No sé por dónde empezar`.
3. Confirmar parámetros faltantes, memoria contextual y score.
4. Enviar `dale` y confirmar continuidad.
5. Enviar `Qué hago hoy` y confirmar uso de contexto del socio.
6. Enviar `Quiero una dieta que acompañe la rutina`.
7. Enviar `Cómo voy con mi progreso`.
8. Probar modo claro y oscuro.
9. Probar F12 mobile y volver a desktop.
10. Confirmar que no hay scroll horizontal ni espacio blanco después del footer.

## Checklist

- [x] Build exitoso.
- [x] QA funcional aprobado.
- [x] Fix de build incluido.
- [x] Sin migraciones DB.
- [x] Sin endpoints nuevos.
- [x] Sin cambios Swagger requeridos.
- [x] Sin SQL, dumps, backups, `.env` ni config sensible para commitear.
- [x] Documentación técnica agregada.

## Comando de commit sugerido

```bash
git commit -m "feat: add contextual memory to RAG Coach"
```
