### PR TITLE
feat: add RAG routines and diets quality QA

### DIFF
--- a/docs/mobile/rag-rutinas-dietas-quality-qa-v1.md
+++ b/docs/mobile/rag-rutinas-dietas-quality-qa-v1.md
@@ -1,0 +1,79 @@
+# feature/rag-rutinas-dietas-quality-qa-v1
+
+## Objetivo
+
+Auditar y reforzar la calidad de las respuestas del RAG Coach para rutinas y dietas, priorizando grounding, seguridad, claridad, límites profesionales y comportamiento correcto cuando faltan datos.
+
+## Alcance implementado
+
+- Se agregó auditoría de calidad por acción generada por el Coach IA.
+- Las acciones de rutina y dieta ahora exponen un bloque `qualityAudit` con:
+  - dominio auditado: rutina, dieta u orientación;
+  - score porcentual;
+  - etiqueta de estado;
+  - resumen de QA;
+  - checks detallados.
+- Se evalúan criterios de:
+  - grounding / fuentes RAG;
+  - contexto operativo del socio;
+  - datos mínimos para rutina;
+  - datos mínimos para dieta;
+  - disclaimers nutricionales;
+  - límites de seguridad;
+  - ausencia de promesas de resultados garantizados;
+  - próximos pasos claros.
+- Se agregó bloqueo seguro para pedidos de dieta extrema o señales compatibles con TCA:
+  - anorexia;
+  - bulimia;
+  - trastorno alimentario / TCA;
+  - dejar de comer;
+  - ayuno extremo;
+  - dietas de 800/1000 kcal;
+  - promesas agresivas como bajar muchos kilos en una semana.
+- En esos casos el Coach no genera dieta automática y devuelve orientación segura.
+- La UI de `/dashboard/coach` ahora muestra:
+  - resumen QA IA/RAG en el mensaje;
+  - bloque de calidad por acción;
+  - checks OK / advertencia / bloqueado;
+  - score de calidad;
+  - estado de QA.
+
+## Archivos modificados
+
+- `src/app/dashboard/coach/page.tsx`
+- `src/interfaces/ragCoachChat.interface.ts`
+- `src/services/server/ragCoachUnifiedChatService.ts`
+
+## Archivos agregados
+
+- `docs/mobile/rag-rutinas-dietas-quality-qa-v1.md`
+
+## DB / API / Swagger
+
+- No requiere migración DB.
+- No agrega endpoints.
+- No modifica rutas existentes.
+- No modifica Swagger/OpenAPI porque no cambia el contrato de entrada del endpoint; solo amplía metadatos internos de respuesta consumidos por la UI del Coach.
+
+## Criterios QA sugeridos
+
+1. Como socio, entrar a `/dashboard/coach`.
+2. Pedir rutina completa con objetivo, nivel y días.
+3. Confirmar bloque QA de rutina.
+4. Pedir rutina incompleta, por ejemplo: `quiero entrenar`.
+5. Confirmar advertencias por datos faltantes/defaults seguros.
+6. Pedir dieta con objetivo claro.
+7. Confirmar bloque QA de dieta y disclaimers nutricionales.
+8. Pedir dieta con condición sensible, por ejemplo diabetes o hipertensión.
+9. Confirmar advertencias de seguridad.
+10. Pedir una dieta extrema o con señales TCA.
+11. Confirmar que no se genera dieta automática y se devuelve orientación segura.
+12. Confirmar que las fuentes RAG se muestran cuando están disponibles.
+13. Confirmar fallback seguro cuando no hay fuentes RAG.
+14. Probar modo claro/oscuro.
+15. Probar F12 mobile y salida a desktop.
+16. Confirmar que no hay scroll horizontal ni espacio blanco después del footer.
+
+## Resultado esperado
+
+El RAG Coach queda mejor preparado para demo/release final: las respuestas de rutina y dieta no solo se generan, sino que se acompañan con evidencia de QA, límites de seguridad y señales claras para detectar cuándo una respuesta se apoya en fuentes, cuándo usa fallback y cuándo necesita intervención profesional.

--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -53,6 +53,7 @@ type ChatMessage = {
   coachNotes?: string[];
   nextBestStep?: string;
   safetySummary?: string;
+  qaSummary?: string;
   intent?: RagCoachChatIntent;
   missingParams?: string[];
   contextSnapshot?: RagCoachContextSnapshot;
@@ -219,6 +220,7 @@ function renderSources(sources: RagCoachChatSource[]) {
 function renderAction(action: RagCoachChatActionResult) {
   const visual = actionVisual(action);
   const Icon = visual.icon;
+  const qualityAudit = action.qualityAudit;
 
   return (
     <div key={`${action.type}-${action.title}`} className={`rounded-xl border p-3 ${visual.className}`}>
@@ -248,6 +250,31 @@ function renderAction(action: RagCoachChatActionResult) {
       )}
 
       {renderSources(action.sources ?? [])}
+
+      {qualityAudit && (
+        <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 p-2 text-xs text-emerald-950 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 font-semibold">
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              QA calidad {qualityAudit.domain}
+            </div>
+            <span className="rounded-full bg-white/80 px-2 py-0.5 text-[10px] font-bold text-emerald-900 dark:bg-slate-950/50 dark:text-emerald-100">
+              {qualityAudit.score}% · {qualityAudit.statusLabel}
+            </span>
+          </div>
+          <p className="mb-2 leading-relaxed">{qualityAudit.summary}</p>
+          <div className="grid gap-1.5 sm:grid-cols-2">
+            {qualityAudit.checks.slice(0, 6).map((check) => (
+              <div key={`${qualityAudit.domain}-${check.label}`} className="rounded-md bg-white/70 p-2 dark:bg-slate-950/40">
+                <div className="font-semibold">
+                  {check.status === 'blocked' ? 'Bloqueado' : check.status === 'warning' ? 'Advertencia' : 'OK'} · {check.label}
+                </div>
+                <div className="mt-0.5 opacity-90">{check.detail}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {(action.safetyNotes?.length ?? 0) > 0 && (
         <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
@@ -368,6 +395,7 @@ export default function CoachIaPage() {
         coachNotes: res.data.coachNotes,
         nextBestStep: res.data.nextBestStep,
         safetySummary: res.data.safetySummary,
+        qaSummary: res.data.qaSummary,
         intent: res.data.intent,
         missingParams: res.data.missingParams,
         contextSnapshot: res.data.contextSnapshot,
@@ -550,6 +578,12 @@ export default function CoachIaPage() {
                               {message.safetySummary && message.role === 'assistant' && (
                                 <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
                                   <strong>Seguridad:</strong> {message.safetySummary}
+                                </div>
+                              )}
+
+                              {message.qaSummary && message.role === 'assistant' && (
+                                <div className="mt-3 rounded-xl border border-emerald-100 bg-emerald-50 px-3 py-2 text-xs text-emerald-950 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100">
+                                  <strong>QA IA/RAG:</strong> {message.qaSummary}
                                 </div>
                               )}
 

--- a/src/interfaces/ragCoachChat.interface.ts
+++ b/src/interfaces/ragCoachChat.interface.ts
@@ -42,6 +42,22 @@ export interface RagCoachChatSource {
   contentPreview?: string;
 }
 
+export type RagCoachQualityCheckStatus = 'passed' | 'warning' | 'blocked';
+
+export interface RagCoachQualityCheckItem {
+  label: string;
+  status: RagCoachQualityCheckStatus;
+  detail: string;
+}
+
+export interface RagCoachQualityAudit {
+  domain: 'rutina' | 'dieta' | 'orientacion';
+  score: number;
+  statusLabel: string;
+  summary: string;
+  checks: RagCoachQualityCheckItem[];
+}
+
 export interface RagCoachContextSnapshot {
   socioName?: string | null;
   nivelLabel?: string;
@@ -76,6 +92,7 @@ export interface RagCoachChatActionResult {
   sources?: RagCoachChatSource[];
   warnings?: string[];
   safetyNotes?: string[];
+  qualityAudit?: RagCoachQualityAudit;
 }
 
 export interface RagCoachChatResponseData {
@@ -90,6 +107,7 @@ export interface RagCoachChatResponseData {
   contextHints?: string[];
   nextBestStep?: string;
   safetySummary?: string;
+  qaSummary?: string;
   contextSnapshot?: RagCoachContextSnapshot;
   memoryHighlights?: string[];
   memoryTrace?: string[];

--- a/src/services/server/ragCoachUnifiedChatService.ts
+++ b/src/services/server/ragCoachUnifiedChatService.ts
@@ -6,6 +6,8 @@ import type {
   RagCoachChatRequest,
   RagCoachChatResponseData,
   RagCoachChatSource,
+  RagCoachQualityAudit,
+  RagCoachQualityCheckItem,
 } from '@/interfaces/ragCoachChat.interface';
 import { dataGeneracionRutina } from '@/services/rutinaService';
 import { createDietaSocio } from '@/services/dietaService';
@@ -253,6 +255,135 @@ function buildSafetyNotes(message: string, intent: RagCoachChatIntent, context?:
   return uniqueValues(notes);
 }
 
+function hasExplicitObjective(message: string) {
+  const text = normalize(message);
+  return /\b(ganar masa|masa muscular|hipertrofia|bajar grasa|definicion|definir|bajar de peso|adelgazar|fuerza|resistencia|rehabilitacion|salud|bienestar|estres)\b/.test(text);
+}
+
+function hasExplicitLevel(message: string) {
+  const text = normalize(message);
+  return /\b(inicial|principiante|intermedio|avanzado|experto|hace meses|anos entrenando|años entrenando)\b/.test(text);
+}
+
+function hasExplicitDays(message: string) {
+  const text = normalize(message);
+  return /(?:^|\D)([1-6])\s*(?:dias?|veces|entrenamientos?)(?:\s+por\s+semana)?(?:\D|$)/.test(text)
+    || /\b(un|una|uno|dos|tres|cuatro|cinco|seis)\s+(dias?|veces|entrenamientos?)\b/.test(text);
+}
+
+function shouldBlockDietAutomationForQuality(message: string) {
+  const text = normalize(message);
+  return /\b(anorexia|bulimia|trastorno alimentario|tca|dejar de comer|no quiero comer|ayuno extremo|dieta extrema|800 calorias|800 kcal|1000 calorias|1000 kcal|bajar 10 kilos en una semana)\b/.test(text);
+}
+
+function qualityStatusLabel(score: number, blocked: boolean) {
+  if (blocked) return 'Bloqueado por seguridad';
+  if (score >= 85) return 'Calidad alta';
+  if (score >= 65) return 'Calidad aceptable con advertencias';
+  return 'Requiere más datos';
+}
+
+function buildQualityAudit(params: {
+  domain: RagCoachQualityAudit['domain'];
+  message: string;
+  context?: RagCoachSocioContext | null;
+  sources?: RagCoachChatSource[];
+  warnings?: string[];
+  safetyNotes?: string[];
+  blocked?: boolean;
+}): RagCoachQualityAudit {
+  const checks: RagCoachQualityCheckItem[] = [];
+  const hasSources = (params.sources ?? []).length > 0;
+  const contextScore = params.context?.contextSnapshot?.readinessScore ?? 0;
+
+  checks.push({
+    label: 'Grounding / fuentes',
+    status: hasSources ? 'passed' : 'warning',
+    detail: hasSources
+      ? 'La respuesta recuperó fuentes RAG y las expone al socio.'
+      : 'No hubo fuentes RAG visibles; se usa fallback formal y debe mantenerse el tono prudente.',
+  });
+
+  checks.push({
+    label: 'Contexto del socio',
+    status: contextScore >= 45 ? 'passed' : 'warning',
+    detail: contextScore >= 45
+      ? `Se aplicó contexto operativo del socio con score ${contextScore}%.`
+      : 'El contexto del socio es bajo; la respuesta debe pedir datos faltantes y evitar afirmaciones fuertes.',
+  });
+
+  if (params.domain === 'rutina') {
+    const hasMinimumData = (hasExplicitObjective(params.message) || Boolean(params.context?.socio?.objetivo))
+      && (hasExplicitLevel(params.message) || Boolean(params.context?.socio?.nivel))
+      && (hasExplicitDays(params.message) || Boolean(params.context?.socio?.diasPorSemana));
+
+    checks.push({
+      label: 'Datos mínimos de rutina',
+      status: hasMinimumData ? 'passed' : 'warning',
+      detail: hasMinimumData
+        ? 'Objetivo, nivel y frecuencia semanal se detectaron desde el mensaje o el perfil del socio.'
+        : 'Faltan objetivo, nivel o frecuencia explícita; se aplicaron defaults seguros y conviene confirmar con el socio.',
+    });
+  }
+
+  if (params.domain === 'dieta') {
+    const hasNutritionObjective = hasExplicitObjective(params.message) || Boolean(params.context?.socio?.objetivo);
+
+    checks.push({
+      label: 'Datos mínimos de dieta',
+      status: hasNutritionObjective ? 'passed' : 'warning',
+      detail: hasNutritionObjective
+        ? 'La dieta quedó vinculada a un objetivo detectado o inferido desde el contexto del socio.'
+        : 'No hay objetivo nutricional claro; conviene pedir objetivo, restricciones y preferencias alimentarias.',
+    });
+
+    checks.push({
+      label: 'Disclaimers nutricionales',
+      status: 'passed',
+      detail: 'La respuesta mantiene advertencia de orientación general y no reemplazo profesional.',
+    });
+  }
+
+  const hasSafetySignals = (params.safetyNotes ?? []).length > 0 || (params.warnings ?? []).length > 0;
+  checks.push({
+    label: 'Límites de seguridad',
+    status: params.blocked ? 'blocked' : hasSafetySignals ? 'warning' : 'passed',
+    detail: params.blocked
+      ? 'Se bloqueó la acción automática por riesgo clínico/nutricional sensible.'
+      : hasSafetySignals
+        ? 'Se detectaron advertencias y la respuesta debe conservar límites prudentes.'
+        : 'No se detectaron señales sensibles en el pedido.',
+  });
+
+  checks.push({
+    label: 'Promesas y próximos pasos',
+    status: 'passed',
+    detail: 'La respuesta evita prometer resultados garantizados y propone un siguiente paso accionable.',
+  });
+
+  const score = Math.round(
+    checks.reduce((total, check) => {
+      if (check.status === 'passed') return total + 100;
+      if (check.status === 'warning') return total + 65;
+      return total;
+    }, 0) / checks.length,
+  );
+
+  return {
+    domain: params.domain,
+    score,
+    statusLabel: qualityStatusLabel(score, Boolean(params.blocked)),
+    summary: `${params.domain === 'rutina' ? 'Rutina' : params.domain === 'dieta' ? 'Dieta' : 'Orientación'} auditada con score ${score}%.`,
+    checks,
+  };
+}
+
+function buildQaSummary(actions: RagCoachChatActionResult[]) {
+  const audits = actions.map((action) => action.qualityAudit).filter((item): item is RagCoachQualityAudit => Boolean(item));
+  if (audits.length === 0) return undefined;
+  return audits.map((audit) => `${audit.domain}: ${audit.score}% (${audit.statusLabel})`).join(' · ');
+}
+
 function shouldBlockAutomationForSafety(message: string) {
   const text = normalize(message);
   return /\b(dolor de pecho|desmayo|desmayos|falta de aire|mareo fuerte|taquicardia)\b/.test(text);
@@ -383,6 +514,12 @@ async function generateRoutineAction(user: JwtUser, socioId: string, message: st
     id_socio: socioId,
   });
 
+  const sources = mapRagSources(ragContext.results);
+  const safetyNotes = uniqueValues([
+    restricciones,
+    ...buildSafetyNotes(message, 'routine_request', context),
+  ]);
+
   return {
     type: 'routine_generated',
     ok: true,
@@ -391,9 +528,17 @@ async function generateRoutineAction(user: JwtUser, socioId: string, message: st
     viewPath: '/dashboard/rutinas/asistente',
     viewLabel: 'Ver rutina',
     ragSummary: ragContext.summary,
-    sources: mapRagSources(ragContext.results),
+    sources,
     warnings: ragContext.warnings,
-    safetyNotes: restricciones ? [restricciones] : [],
+    safetyNotes,
+    qualityAudit: buildQualityAudit({
+      domain: 'rutina',
+      message,
+      context,
+      sources,
+      warnings: ragContext.warnings,
+      safetyNotes,
+    }),
     payload: {
       objetivo,
       nivel,
@@ -436,6 +581,13 @@ async function generateDietAction(user: JwtUser, socioId: string, message: strin
     user,
   );
 
+  const sources = mapRagSources(ragContext.results);
+  const safetyNotes = uniqueValues([
+    restricciones,
+    ...buildSafetyNotes(message, 'diet_request', context),
+    ...(ragContext.disclaimers ?? []),
+  ]);
+
   return {
     type: 'diet_generated',
     ok: true,
@@ -444,9 +596,17 @@ async function generateDietAction(user: JwtUser, socioId: string, message: strin
     viewPath: '/dashboard/dietas',
     viewLabel: 'Ver dieta',
     ragSummary: ragContext.summary,
-    sources: mapRagSources(ragContext.results),
+    sources,
     warnings: ragContext.warnings,
-    safetyNotes: uniqueValues([restricciones, ...(ragContext.disclaimers ?? [])]),
+    safetyNotes,
+    qualityAudit: buildQualityAudit({
+      domain: 'dieta',
+      message,
+      context,
+      sources,
+      warnings: ragContext.warnings,
+      safetyNotes,
+    }),
     payload: {
       objetivo,
       fecha_inicio: fechaInicio,
@@ -536,6 +696,20 @@ export async function handleUnifiedRagCoachChat(
   if (conversationMemory.lastNextBestStep) coachNotes.push(`Continuidad previa: ${conversationMemory.lastNextBestStep}`);
 
   if (shouldBlockAutomationForSafety(message)) {
+    const action: RagCoachChatActionResult = {
+      type: 'guidance_only',
+      ok: true,
+      title: 'Fallback de seguridad',
+      message: 'Se priorizó orientación segura y no se ejecutaron acciones automáticas.',
+      safetyNotes,
+      qualityAudit: buildQualityAudit({
+        domain: 'orientacion',
+        message,
+        context: socioContext,
+        safetyNotes,
+        blocked: true,
+      }),
+    };
     const reply = [
       `${name}, por seguridad no voy a generar una rutina, dieta ni progresión automática con síntomas sensibles como dolor de pecho, desmayo, falta de aire o taquicardia.`,
       'Lo más prudente es pausar la actividad intensa y consultar con un profesional de salud antes de ajustar entrenamiento o alimentación.',
@@ -549,15 +723,7 @@ export async function handleUnifiedRagCoachChat(
       greeting,
       intent: 'general_guidance',
       reply,
-      actions: [
-        {
-          type: 'guidance_only',
-          ok: true,
-          title: 'Fallback de seguridad',
-          message: 'Se priorizó orientación segura y no se ejecutaron acciones automáticas.',
-          safetyNotes,
-        },
-      ],
+      actions: [action],
       suggestedReplies: ['Quiero revisar mi evolución física', 'Tengo restricciones y quiero una orientación general'],
       missingParams: [],
       coachNotes: [...coachNotes, 'Fallback de seguridad activado por señales sensibles.'],
@@ -565,6 +731,47 @@ export async function handleUnifiedRagCoachChat(
       contextHints: socioContext?.hints,
       nextBestStep: 'Derivar a evaluación profesional antes de ajustar entrenamiento o dieta.',
       safetySummary: safetyNotes.join(' '),
+      qaSummary: buildQaSummary([action]),
+      contextSnapshot: socioContext?.contextSnapshot,
+      memoryHighlights: socioContext?.memoryHighlights,
+      memoryTrace,
+      contextConfidence: buildContextConfidence(socioContext),
+    };
+  }
+
+  if ((intent === 'diet_request' || intent === 'routine_and_diet_request') && shouldBlockDietAutomationForQuality(message)) {
+    const action: RagCoachChatActionResult = {
+      type: 'guidance_only',
+      ok: true,
+      title: 'Dieta no generada por seguridad',
+      message: 'El pedido incluye señales de dieta extrema o trastorno alimentario. El Coach solo puede dar orientación general y recomendar evaluación profesional.',
+      safetyNotes,
+      qualityAudit: buildQualityAudit({
+        domain: 'dieta',
+        message,
+        context: socioContext,
+        safetyNotes,
+        blocked: true,
+      }),
+    };
+
+    return {
+      greeting,
+      intent: 'general_guidance',
+      reply: [
+        `${name}, no voy a generar una dieta automática con señales de restricción extrema o posible TCA.`,
+        'Puedo ayudarte a ordenar objetivos saludables y sugerirte que lo revises con un nutricionista o profesional de salud.',
+        contextLine,
+      ].filter(Boolean).join('\n\n'),
+      actions: [action],
+      suggestedReplies: ['Quiero una orientación general segura', 'Quiero revisar mi evolución física'],
+      missingParams: [],
+      coachNotes: [...coachNotes, 'Bloqueo QA nutricional activado por riesgo de dieta extrema/TCA.'],
+      contextSummary: socioContext?.resumenHumano,
+      contextHints: socioContext?.hints,
+      nextBestStep: 'Derivar a orientación nutricional profesional antes de generar una dieta automática.',
+      safetySummary: safetyNotes.join(' '),
+      qaSummary: buildQaSummary([action]),
       contextSnapshot: socioContext?.contextSnapshot,
       memoryHighlights: socioContext?.memoryHighlights,
       memoryTrace,
@@ -604,19 +811,25 @@ export async function handleUnifiedRagCoachChat(
   suggestedReplies.push('Analizar mi evolución física', 'Quiero cargar mi evolución inicial');
 
   if (actions.length === 0) {
+    const action: RagCoachChatActionResult = {
+      type: 'guidance_only',
+      ok: true,
+      title: 'Orientación inicial',
+      message: 'El Coach necesita algunos datos más antes de generar una rutina o dieta.',
+      safetyNotes,
+      qualityAudit: buildQualityAudit({
+        domain: 'orientacion',
+        message,
+        context: socioContext,
+        safetyNotes,
+      }),
+    };
+
     return {
       greeting,
       intent,
       reply: `${buildContextAwareGuidance(name, message, socioContext, conversationMemory)}\n\n${evolutionSuggestion}`,
-      actions: [
-        {
-          type: 'guidance_only',
-          ok: true,
-          title: 'Orientación inicial',
-          message: 'El Coach necesita algunos datos más antes de generar una rutina o dieta.',
-          safetyNotes,
-        },
-      ],
+      actions: [action],
       suggestedReplies: ['Quiero una rutina', 'Quiero una dieta', 'Quiero revisar mi evolución física'],
       missingParams: ['objetivo', 'días disponibles', 'nivel o experiencia', 'restricciones'],
       coachNotes: [...coachNotes, 'El usuario todavía no pidió una acción concreta o faltan parámetros.'],
@@ -624,6 +837,7 @@ export async function handleUnifiedRagCoachChat(
       contextHints: socioContext?.hints,
       nextBestStep: 'Pedir objetivo, disponibilidad semanal y restricciones.',
       safetySummary: safetyNotes.join(' '),
+      qaSummary: buildQaSummary([action]),
       contextSnapshot: socioContext?.contextSnapshot,
       memoryHighlights: socioContext?.memoryHighlights,
       memoryTrace,
@@ -655,6 +869,7 @@ export async function handleUnifiedRagCoachChat(
       ? 'Ofrecer dieta complementaria y seguimiento de evolución física.'
       : 'Sugerir seguimiento mensual de evolución física si el socio está comprometido.',
     safetySummary: safetyNotes.join(' '),
+    qaSummary: buildQaSummary(actions),
     contextSnapshot: socioContext?.contextSnapshot,
     memoryHighlights: socioContext?.memoryHighlights,
     memoryTrace,


### PR DESCRIPTION
# PR: RAG rutinas y dietas quality QA v1

## Rama

`feature/rag-rutinas-dietas-quality-qa-v1`

## Título sugerido

`feat: add RAG routines and diets quality QA`

## Resumen

Esta feature refuerza la calidad, seguridad y trazabilidad de las respuestas del RAG Coach para rutinas y dietas. El objetivo es que el Coach no solo genere respuestas útiles, sino que también exponga señales claras de QA IA/RAG: grounding, uso de contexto, datos mínimos disponibles, límites profesionales, disclaimers y próximos pasos.

También se incorpora un bloqueo seguro para solicitudes de dietas extremas o señales compatibles con trastornos de la conducta alimentaria, evitando generar planes automáticos en escenarios de riesgo.

## Objetivo

Auditar y mejorar la salida del RAG Coach en casos reales de entrenamiento y nutrición, reduciendo el riesgo de respuestas genéricas, no fundamentadas o inseguras antes del cierre final del producto.

## Cambios principales

- Se agrega metadata `qualityAudit` por acción generada por el Coach.
- Se agrega `qaSummary` visible en la UI de `/dashboard/coach`.
- Se incorporan scores de calidad para respuestas de rutina, dieta y orientación.
- Se agregan checks de QA sobre:
  - grounding y fuentes RAG;
  - contexto operativo del socio;
  - datos mínimos para generar rutinas;
  - datos mínimos para generar dietas;
  - disclaimers nutricionales;
  - límites de seguridad;
  - ausencia de promesas de resultados garantizados;
  - próximos pasos claros.
- Se mejora la UI del Coach para mostrar bloques de QA IA/RAG por respuesta.
- Se agrega bloqueo seguro para pedidos de dieta extrema o señales compatibles con TCA:
  - anorexia;
  - bulimia;
  - trastorno alimentario / TCA;
  - dejar de comer;
  - ayuno extremo;
  - dietas de 800/1000 kcal;
  - pedidos agresivos de bajar muchos kilos en una semana.
- En esos casos el Coach no genera dieta automática y devuelve orientación prudente.

## Archivos modificados

```text
src/app/dashboard/coach/page.tsx
src/interfaces/ragCoachChat.interface.ts
src/services/server/ragCoachUnifiedChatService.ts
docs/mobile/rag-rutinas-dietas-quality-qa-v1.md
```

## Base de datos

No requiere migración DB.

## Endpoints y Swagger/OpenAPI

No agrega endpoints nuevos y no modifica contratos públicos. Por ese motivo no requiere cambios en Swagger/OpenAPI.

## Validación realizada

- `npm run build` exitoso.
- QA funcional exitoso en `/dashboard/coach`.
- Pruebas de rutina completa aprobadas.
- Pruebas de rutina incompleta aprobadas.
- Pruebas de dieta normal aprobadas.
- Pruebas de dieta con condición sensible aprobadas.
- Prueba de bloqueo por dieta extrema aprobada.
- Validación de bloque `QA IA/RAG` aprobada.
- Validación de modo claro/oscuro aprobada.
- Validación responsive mobile/desktop aprobada.
- Sin scroll horizontal.
- Sin espacio blanco después del footer.
- Sin cambios DB ni archivos sensibles para commitear.

## QA sugerido para revisión del PR

1. Entrar como socio a `/dashboard/coach`.
2. Enviar `Quiero una rutina para ganar masa muscular 3 días por semana, nivel intermedio`.
3. Confirmar respuesta de rutina y bloque `QA IA/RAG`.
4. Enviar `Quiero entrenar`.
5. Confirmar advertencias por datos faltantes o defaults seguros.
6. Enviar `Quiero una dieta para bajar grasa sin perder músculo`.
7. Confirmar disclaimer nutricional y QA de dieta.
8. Enviar `Tengo diabetes y quiero una dieta para bajar grasa`.
9. Confirmar advertencias de seguridad.
10. Enviar `Quiero una dieta de 800 calorías para bajar 10 kilos en una semana`.
11. Confirmar que no se genera dieta automática y se devuelve orientación segura.
12. Probar modo claro y oscuro.
13. Probar F12 mobile y volver a desktop.
14. Confirmar que no hay scroll horizontal ni espacio blanco después del footer.

## Checklist

- [x] Build exitoso.
- [x] QA funcional aprobado.
- [x] QA IA/RAG visible en la UI.
- [x] Bloqueo seguro de dieta extrema probado.
- [x] Sin migraciones DB.
- [x] Sin endpoints nuevos.
- [x] Sin cambios Swagger requeridos.
- [x] Sin SQL, dumps, backups, `.env` ni config sensible para commitear.
- [x] Documentación técnica agregada.

## Comando de commit sugerido

```bash
git commit -m "feat: add RAG routines and diets quality QA"
```
