### PR TITLE
fix: complete dashboard navigation i18n sweep

### DIFF
--- a/docs/mobile/i18n-navigation-menus-final-sweep-v1.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v1.md
@@ -1,0 +1,64 @@
+# i18n navigation menus final sweep v1
+
+## Objetivo
+
+Auditar y reforzar traducciones ES/EN en navegación, menús y títulos de pantalla.
+
+## Ajustes incluidos
+
+### Helper centralizado de navegación
+
+Se agrega `src/i18n/navigationLabels.ts` para centralizar traducciones de:
+
+- grupos del sidebar;
+- items del sidebar;
+- títulos recibidos por `AppHeader`;
+- variantes con mayúsculas/minúsculas o acentos.
+
+### Sidebar
+
+`SidebarSection` deja de tener mapas locales duplicados y usa el helper centralizado:
+
+- `translateNavigationGroup`
+- `translateNavigationItem`
+
+Esto reduce la posibilidad de que nuevos menús queden en Español cuando el idioma activo es Inglés.
+
+### Header / títulos de pantalla
+
+`AppHeader` ahora traduce el `title` que recibe antes de renderizarlo.
+
+Esto cubre títulos que todavía llegaban como literal Español desde páginas antiguas, por ejemplo:
+
+- `Mis actividades`
+- `Ficha médica`
+- `Evolución física`
+- `Gestor de Rutinas`
+- `Gestor de Dietas`
+- `Detalles de Venta`
+- `Detalle de Rutina`
+- `Detalle de Dieta`
+- `Detalle de Evolución Física`
+- `Ranking y bonificación mensual`
+- `Códigos y etiquetas comerciales`
+- `Alertas de stock comercial`
+
+### Permisos de menú
+
+El bloque de permisos de menú dentro de `UserForm` ahora traduce:
+
+- título del bloque;
+- descripción;
+- aviso de rol administrador;
+- aviso para usuario interno;
+- grupos;
+- items/módulos.
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica permisos ni reglas de acceso.
+- No cambia rutas existentes.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v10-routine-example-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v10-routine-example-fix.md
@@ -1,0 +1,27 @@
+# i18n navigation menus final sweep v10 - routine assistant example fix
+
+## Objetivo
+
+Corregir el ejemplo del hero de `/dashboard/rutinas/asistente` que seguía visible en Español cuando el idioma activo era Inglés.
+
+## Caso corregido
+
+- `“Quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia.”`
+- `"Quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia."`
+- `Quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia.`
+
+## Traducción
+
+`“I want to gain muscle mass, train 6 days, prioritize back and shoulders. I am intermediate and I have lower back pain.”`
+
+## Motivo
+
+La frase se renderiza como ejemplo con comillas y mayúscula inicial, por lo que no coincidía con la variante previa ya existente en el sweep.
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica lógica funcional del asistente de rutinas.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v11-diet-management-badge-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v11-diet-management-badge-fix.md
@@ -1,0 +1,25 @@
+# i18n navigation menus final sweep v11 - diet management badge fix
+
+## Objetivo
+
+Corregir el badge `Gestión de dietas` visible en `/dashboard/dietas` cuando el idioma activo es Inglés.
+
+## Ajuste
+
+Se agregan variantes puntuales al `DashboardInlineI18nSweep`:
+
+- `Gestión de dietas` → `Diet management`
+- `gestión de dietas` → `diet management`
+- `GESTION DE DIETAS` → `DIET MANAGEMENT`
+
+## Motivo
+
+La pantalla puede renderizar el texto como title case y luego aplicar mayúsculas por CSS, por lo que no siempre coincidía con la clave uppercase previa.
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica lógica funcional de Dietas.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v12-diet-form-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v12-diet-form-fix.md
@@ -1,0 +1,41 @@
+# i18n navigation menus final sweep v12 - diet form fix
+
+## Objetivo
+
+Corregir textos residuales en inglés/español mezclado dentro del formulario **Diet -> New Diet** cuando el idioma activo es Inglés.
+
+## Ajuste
+
+Se agregan traducciones puntuales al `DashboardInlineI18nSweep` para:
+
+- badge / labels del formulario de dietas;
+- placeholders de ejemplo;
+- CTA `Generar dieta` / `Generando...` / `Cerrar`;
+- variantes mezcladas (`Goal nutricional`, `Date inicio`, `Date fin`);
+- opciones de catálogo de objetivos más frecuentes (`Volumen`, `Definición`, `Bajar de peso`, `Aumentar fuerza`, `Mejorar resistencia`, etc.).
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios funcionales en la lógica del formulario.
+
+## QA sugerido
+
+Ruta: `/dashboard/dietas`
+
+Validar en Inglés:
+
+- `Nutritional goal`
+- `Select goal`
+- `Start date`
+- `End date`
+- `Member request or goal`
+- `Restrictions or precautions`
+- `Food preferences`
+- placeholders de ejemplo en inglés
+- `Generate diet`
+- `Close`
+- opciones del combo traducidas cuando coincidan con los catálogos contemplados.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v13-medical-record-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v13-medical-record-labels-fix.md
@@ -1,0 +1,26 @@
+# i18n navigation menus final sweep v13 - medical record labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de ES/EN en `/dashboard/ficha-medica` cuando el idioma activo es Inglés.
+
+## Ajuste
+
+Se agregan traducciones puntuales al `DashboardInlineI18nSweep`:
+
+- `Review médica operativa` → `Operational medical review`
+- `REVIEW MÉDICA OPERATIVA` → `OPERATIONAL MEDICAL REVIEW`
+- `Vista de revisión admin` → `Admin review view`
+- `Panel de revisión admin` → `Admin review panel`
+- `APTO MÉDICO` → `MEDICAL CLEARANCE`
+- `Apto médico` → `Medical clearance`
+- `Documentos` → `Documents`
+- `Archivos adjuntos` → `Attachments`
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios funcionales en ficha médica.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v14-members-loading-badge-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v14-members-loading-badge-fix.md
@@ -1,0 +1,24 @@
+# i18n navigation menus final sweep v14 - Members loading and badge fix
+
+## Objetivo
+
+Corregir dos remanentes puntuales en `/dashboard/socios` cuando el idioma activo es Inglés.
+
+## Ajuste
+
+Se agregan traducciones puntuales al `DashboardInlineI18nSweep`:
+
+- `Cargando datos socios...` → `Loading member data...`
+- `Cargando datos de socios...` → `Loading member data...`
+- `Members · vista administrativa` → `Members · administrative view`
+- `vista administrativa` → `administrative view`
+- `Vista administrativa` → `Administrative view`
+- `VISTA ADMINISTRATIVA` → `ADMINISTRATIVE VIEW`
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios funcionales en Members.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v15-members-total-label-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v15-members-total-label-fix.md
@@ -1,0 +1,21 @@
+# i18n navigation menus final sweep v15 - Members total label fix
+
+## Objetivo
+
+Corregir un remanente puntual en la tabla de `/dashboard/socios` cuando el idioma activo es Inglés.
+
+## Ajuste
+
+Se agregan traducciones puntuales al `DashboardInlineI18nSweep`:
+
+- `Total de socios` → `Total members`
+- `total de socios` → `total members`
+- `TOTAL DE SOCIOS` → `TOTAL MEMBERS`
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios funcionales en Members.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v16-socio360-medium-evolution-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v16-socio360-medium-evolution-fix.md
@@ -1,0 +1,22 @@
+# i18n navigation menus final sweep v16 - Socio 360 medium/evolution fix
+
+## Objetivo
+
+Corregir dos remanentes puntuales en el modal 360 de `/dashboard/socios` cuando el idioma activo es Inglés.
+
+## Ajuste
+
+- `medio` → `Medium`
+- `Evolution demo mensual para BI y recorrido del socio.` → `Monthly evolution demo for BI and member journey.`
+
+## Nota técnica
+
+`medio` se maneja como traducción exacta solamente para evitar reemplazos peligrosos dentro de palabras como `intermedio`.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios funcionales en Members / Socio 360.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v17-dashboard-loading-guard-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v17-dashboard-loading-guard-fix.md
@@ -1,0 +1,39 @@
+# i18n navigation menus final sweep v17 - dashboard loading guard fix
+
+## Objetivo
+
+Evitar que `/dashboard` quede bloqueado indefinidamente en `Cargando dashboard...` si una métrica o consulta inicial falla o tarda demasiado.
+
+## Problema
+
+La carga inicial del dashboard admin esperaba varias fuentes:
+
+- equipamientos;
+- mantenimientos;
+- métricas de rutinas;
+- concurrencia;
+- fallos;
+- estado de equipamiento;
+- segmentación e histograma de pagos.
+
+Si alguna llamada fallaba o quedaba colgada, `loadingDatos` podía quedar en `true`.
+
+## Ajuste
+
+Se modifica solo `src/app/dashboard/page.tsx`:
+
+- se agrega guard por `isInitialized` / `isAuthenticated`;
+- se agrega `cancelled` para evitar setState después de desmontar;
+- se envuelven las cargas iniciales en `Promise.allSettled`;
+- se agrega timeout de 10s por llamada inicial;
+- ante error/timeout, el dashboard abre con arrays vacíos en vez de quedar bloqueado;
+- `loadingDatos` se libera siempre en `finally`.
+
+## Alcance
+
+- Solo frontend/dashboard loading guard.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios visuales ni de layout.
+- Sin cambios en la lógica de negocio de métricas: solo fail-open para no bloquear la pantalla.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v18-dashboard-non-blocking-data-load-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v18-dashboard-non-blocking-data-load-fix.md
@@ -1,0 +1,48 @@
+# i18n navigation menus final sweep v18 - dashboard non-blocking data load fix
+
+## Objetivo
+
+Evitar que `/dashboard` quede bloqueado en `Cargando dashboard...` por cargas auxiliares de métricas o datos operativos.
+
+## Diagnóstico
+
+El dashboard principal seguía bloqueando el render completo cuando `loadingDatos` era `true`:
+
+```tsx
+if (loadingDatos || !isInitialized) {
+  return ...
+}
+```
+
+Aunque las cargas ya tenían fail-open y timeout, ese estado seguía siendo un punto único de bloqueo visual.
+
+## Ajuste quirúrgico
+
+Se modifica solo la condición de bloqueo inicial:
+
+```tsx
+if (!isInitialized) {
+  return ...
+}
+```
+
+Esto significa:
+
+- el dashboard solo espera a que la autenticación esté inicializada;
+- las métricas/datos auxiliares cargan en segundo plano;
+- si una métrica tarda o falla, la pantalla abre igual con estados iniciales seguros;
+- no se modifica la lógica de negocio;
+- no se modifica ningún endpoint;
+- no se modifica DB;
+- no se modifica Swagger/OpenAPI.
+
+## Archivo modificado
+
+- `src/app/dashboard/page.tsx`
+
+## QA sugerido
+
+1. Abrir `/dashboard`.
+2. Confirmar que ya no queda bloqueado en `Cargando dashboard...`.
+3. Validar que las cards carguen con valores iniciales o datos reales.
+4. Revisar consola por errores reales de endpoints, sin bloqueo visual de la pantalla.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v19-inline-sweep-es-exact-only-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v19-inline-sweep-es-exact-only-fix.md
@@ -1,0 +1,56 @@
+# i18n navigation menus final sweep v19 - inline sweep ES exact-only fix
+
+## Objetivo
+
+Corregir el bloqueo del dashboard al alternar EN → ES y volver a abrir el modal 360 de socios.
+
+## Diagnóstico
+
+El bloqueo no viene de los endpoints: los logs muestran respuestas 200 para las APIs del modal 360. El síntoma `La página no responde` apunta al hilo principal del navegador.
+
+La causa probable estaba en `DashboardInlineI18nSweep`: desde el fix bidireccional, el modo ES hacía reemplazos parciales EN → ES sobre el valor actual del DOM. Algunas traducciones no eran idempotentes. Ejemplos:
+
+- `Contact` → `Contacto` y luego `Contacto` todavía contiene `Contact`, generando `Contactoo`.
+- `Edit` → `Editar` y luego `Editar` todavía contiene `Edit`, generando `Editarar`.
+- `Sex` → `Sexo` y luego `Sexoo`.
+
+Como el `MutationObserver` escucha `characterData`, esas mutaciones podían dispararse en bucle y congelar la página, especialmente después de cambiar idioma y abrir el modal 360.
+
+## Ajuste quirúrgico
+
+Se mantiene el comportamiento ES → EN con reemplazos parciales para cubrir textos heredados.
+
+Para el camino EN → ES se cambia a modo seguro:
+
+- exact-only translations;
+- no partial replacements en Español;
+- mantiene reversión de frases exactas ya registradas;
+- evita bucles como `Contactoo`, `Editarar`, `Sexoo`.
+
+## Archivo modificado
+
+- `src/components/i18n/DashboardInlineI18nSweep.tsx`
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica funcional del modal 360.
+- No toca el layout.
+
+## QA recomendado
+
+Repro exacta:
+
+1. Entrar en Español al dashboard admin.
+2. Cambiar idioma a Inglés.
+3. Ir a Members.
+4. Abrir modal 360 de un socio.
+5. Cerrar modal.
+6. Cambiar idioma a Español.
+7. Volver al listado de socios.
+8. Abrir modal 360 nuevamente.
+
+Resultado esperado: la página no debe congelarse y el menú lateral debe seguir respondiendo.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v2-inline-dashboard-ui.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v2-inline-dashboard-ui.md
@@ -1,0 +1,50 @@
+# i18n navigation menus final sweep v2 - inline dashboard UI
+
+## Objetivo
+
+Cubrir textos heredados visibles en Español dentro del dashboard cuando el idioma activo es Inglés.
+
+## Contexto
+
+Luego del primer barrido de navegación, todavía quedaban literals internos en pantallas y modales:
+
+- `/dashboard/coach`
+- `/dashboard/dietas`
+- `/dashboard/ficha-medica`
+- `/dashboard/socios`
+- `/dashboard/actividades`
+- modal Socio 360
+- modal Editar Socio
+- tablas y formularios de Actividades
+
+## Ajuste
+
+Se agrega `DashboardInlineI18nSweep`, un componente cliente montado en `src/app/dashboard/layout.tsx`.
+
+El componente:
+
+- actúa solo dentro del dashboard;
+- se activa cuando el locale es `en`;
+- traduce textos heredados conocidos mediante un diccionario ES → EN;
+- observa contenido dinámico con `MutationObserver`, por lo que también cubre modales;
+- traduce text nodes y atributos `placeholder`, `title` y `aria-label`;
+- conserva valores originales para poder volver a ES si el usuario cambia idioma;
+- evita `script`, `style`, `svg`, `canvas` y nodos marcados con `data-i18n-sweep="off"`.
+
+## Alcance de traducciones agregadas
+
+- Coach IA contextual.
+- Gestión de dietas.
+- Ficha médica admin/socio.
+- Socios 360 y modales asociados.
+- Actividades, turnos, cupos, inscripciones y catálogo.
+- Etiquetas de tabla, botones, placeholders y mensajes auxiliares.
+
+## Alcance técnico
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica rutas ni permisos.
+- No modifica lógica funcional.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v20-activities-select-light-mode-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v20-activities-select-light-mode-fix.md
@@ -1,0 +1,64 @@
+# i18n navigation menus final sweep v20 - Activities select light-mode fix
+
+## Objetivo
+
+Corregir dos hallazgos puntuales en `/dashboard/actividades` durante QA en modo claro e idioma Inglés.
+
+## Ajustes
+
+### 1. Contraste de selects/combos en modo claro
+
+Se corrigen los controles que quedaban con fondo oscuro en modo claro:
+
+- Activity
+- Day
+- Status
+- Instructor
+- Location
+- Shift
+- Member search list
+- Quick selector
+
+El cambio mantiene el estilo oscuro para dark mode mediante clases `dark:*`.
+
+### 2. Textos puntuales del modal New Activity
+
+Se agregan traducciones exactas en `DashboardInlineI18nSweep` para evitar mezclas como:
+
+- `Name de Activity` → `Activity name`
+- `Crear Activity` → `Create activity`
+- `Cancelar` → `Cancel`
+- `Ingrese nombre de la actividad` → `Enter activity name`
+
+## Alcance
+
+- Solo frontend.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de turnos, inscripciones o actividades.
+- Sin cambios de estructura visual fuera de los controles afectados.
+
+## QA sugerido
+
+Ruta: `/dashboard/actividades`
+
+Validar en modo claro + EN:
+
+1. Combos de Crear/editar turno:
+   - Activity
+   - Day
+   - Status
+   - Instructor
+   - Location
+
+2. Bloque Enroll member:
+   - Shift
+   - Member search list
+   - Quick selector
+
+3. Modal New Activity:
+   - `Activity name`
+   - `Enter activity name`
+   - `Create activity`
+   - `Cancel`

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v21-activities-remaining-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v21-activities-remaining-labels-fix.md
@@ -1,0 +1,31 @@
+# i18n navigation menus final sweep v21 - Activities remaining labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN en `/dashboard/actividades`.
+
+## Ajustes puntuales
+
+Se agregan traducciones exactas al `DashboardInlineI18nSweep`:
+
+- `Enrolleds por actividad` → `Enrolled by activity`
+- `Inscritos por actividad` → `Enrolled by activity`
+- `Cancelar edición` → `Cancel editing`
+- `Refresh turno` → `Refresh shift`
+- `Name de Activity` → `Activity name`
+- `Creado en` → `Created on`
+- `Currentizado en` → `Updated on`
+- `Actualizado en` → `Updated on`
+- `Total de actividades` → `Total activities`
+
+## Nota técnica
+
+Las traducciones se incorporan como exact-only para no afectar textos parciales ni generar reemplazos peligrosos en el sweep bidireccional.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de turnos, inscripciones o actividades.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v22-employees-remaining-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v22-employees-remaining-labels-fix.md
@@ -1,0 +1,44 @@
+# i18n navigation menus final sweep v22 - Employees remaining labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN en `/dashboard/empleados`.
+
+## Ajustes puntuales
+
+Se agregan traducciones exactas al `DashboardInlineI18nSweep` para:
+
+- `Total empleados` → `Total employees`
+- `Administrativos` → `Administrative`
+- `Nómina estimada` → `Estimated payroll`
+- `Listado de Empleados` / `Readydo de Empleados` → `Employee roster`
+- `Gestión integral de empleados, responsabilidades y base para sueldos/RBAC.` → `Comprehensive employee management, responsibilities and payroll/RBAC base.`
+- `Todos los tipos` / `All los tipos` → `All types`
+- `Añadir Empleado` → `Add employee`
+- `Empleado` → `Employee`
+- `Tipo` → `Type`
+- `Área / puesto` → `Area / position`
+- `Alta` → `Hire date`
+- `Sueldo ref.` → `Reference salary`
+- `Listado de empleados registrados.` / `Readydo de empleados registrados.` → `Registered employee list.`
+
+También se cubren opciones visibles del combo/tipos de empleado:
+
+- `Administrativo` → `Administrative`
+- `Entrenador` → `Trainer`
+- `Mantenimiento` → `Maintenance`
+- `Limpieza` → `Cleaning`
+- `Recepción` → `Reception`
+- `Administración` → `Administration`
+
+## Nota técnica
+
+Las traducciones se incorporan como exact-only para evitar reemplazos parciales peligrosos y mantener estable el sweep bidireccional.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de empleados.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v23-employees-loading-locale-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v23-employees-loading-locale-fix.md
@@ -1,0 +1,34 @@
+# i18n navigation menus final sweep v23 - Employees loading locale fix
+
+## Objetivo
+
+Corregir el loading temprano de `/dashboard/empleados` cuando el idioma activo es Inglés.
+
+## Problema
+
+El texto `Cargando empleados...` se renderiza en un return temprano:
+
+```tsx
+if (loading || !isInitialized) {
+  return <div> Cargando empleados... </div>;
+}
+```
+
+Ese return ocurre antes de que el contenido completo de la pantalla esté disponible, por lo que no conviene depender del `DashboardInlineI18nSweep`.
+
+## Ajuste quirúrgico
+
+Se incorpora `useI18n()` directamente en `src/app/dashboard/empleados/page.tsx` y el loading queda condicionado por idioma:
+
+- EN: `Loading employees...`
+- ES: `Cargando empleados...`
+
+## Alcance
+
+- Solo frontend.
+- Solo `/dashboard/empleados/page.tsx`.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de empleados.
+- Sin cambios en layout.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v24-employee-detail-modal-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v24-employee-detail-modal-labels-fix.md
@@ -1,0 +1,34 @@
+# i18n navigation menus final sweep v24 - Employee detail modal labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN en el modal de detalle de empleado dentro de `/dashboard/empleados`.
+
+## Ajustes puntuales
+
+Se agregan traducciones exactas al `DashboardInlineI18nSweep` para:
+
+- `Detalle de empleado` → `Employee detail`
+- `Puesto` → `Position`
+- `Área` → `Area`
+- `Date de inicio laboral` → `Employment start date`
+- `Date de baja laboral` → `Employment end date`
+- `Tipo de contratación` → `Employment type`
+- `Sueldo base` → `Base salary`
+- `Horarios / disponibilidad` → `Schedule / availability`
+- `mensual` → `Monthly`
+- `Tarde` → `Afternoon`
+- `Administración y caja` → `Administration and cash desk`
+- `Monday a viernes de 15:00 a 18:00` → `Monday to Friday from 15:00 to 18:00`
+
+## Nota técnica
+
+Las traducciones se incorporan como exact-only para evitar reemplazos parciales peligrosos y mantener estable el sweep bidireccional.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de empleados.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v25-employee-edit-modal-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v25-employee-edit-modal-labels-fix.md
@@ -1,0 +1,30 @@
+# i18n navigation menus final sweep v25 - Employee edit modal labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN en el modal de edición de empleado dentro de `/dashboard/empleados`.
+
+## Ajustes puntuales
+
+Se agregan traducciones exactas al `DashboardInlineI18nSweep` para:
+
+- `Edit empleado` → `Edit employee`
+- `Editar empleado` → `Edit employee`
+- `Tipo de empleado` → `Employee type`
+- `Puesto / responsabilidad` → `Position / responsibility`
+- `Sueldo base de referencia` → `Reference base salary`
+- `Notes internas` → `Internal notes`
+- `Notas internas` → `Internal notes`
+
+## Nota técnica
+
+Las traducciones se incorporan como exact-only para evitar reemplazos parciales peligrosos y mantener estable el sweep bidireccional.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de empleados.
+- Sin cambios en datos cargados del empleado.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v26-employee-edit-footer-notes-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v26-employee-edit-footer-notes-fix.md
@@ -1,0 +1,27 @@
+# i18n navigation menus final sweep v26 - Employee edit footer notes fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN al final del modal de edición de empleado dentro de `/dashboard/empleados`.
+
+## Ajustes puntuales
+
+Se agregan traducciones exactas al `DashboardInlineI18nSweep` para:
+
+- `Empleado activo` / `Empleado active` → `Active employee`
+- `Puesto, área y turno se cargan desde combos base para mantener datos homogéneos. Más adelante estos valores podrán moverse a catálogos parametrizables administrados por cada gimnasio.` → `Position, area and shift are loaded from base combos to keep data consistent. Later these values may move to configurable catalogs managed by each gym.`
+- `Este empleado es administrativo. En una próxima feature se desplegarán aquí los permisos de menú/RBAC para definir qué módulos puede ver y utilizar.` → `This employee is administrative. In a future feature, menu/RBAC permissions will be displayed here to define which modules they can view and use.`
+- `Refresh empleado` → `Refresh employee`
+
+## Nota técnica
+
+Las traducciones se incorporan como exact-only para evitar reemplazos parciales peligrosos y mantener estable el sweep bidireccional.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de empleados.
+- Sin cambios en datos cargados del empleado.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v27-employee-salaries-page-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v27-employee-salaries-page-labels-fix.md
@@ -1,0 +1,45 @@
+# i18n navigation menus final sweep v27 - Employee salaries page labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos ES/EN en `/dashboard/empleados-sueldos`.
+
+## Ajuste directo en page
+
+Se actualiza `src/app/dashboard/empleados-sueldos/page.tsx` para usar `useI18n()` en textos propios de la pantalla:
+
+- cards: `Registros`, `Total neto`, `Pagado`, `Pendiente`;
+- título: `Sueldos de empleados`;
+- descripción: `Registro opcional de liquidaciones, pagos y recibos del personal.`;
+- acciones: `Download PDF`, `Export`, `New salary`;
+- filtro de estado;
+- placeholder de búsqueda;
+- loading interno;
+- texto inferior `Showing X of Y records`.
+
+También se agregan `lang` y `aria-label` a los inputs `month` para respetar el idioma activo.
+
+## Ajuste exact-only en sweep
+
+Se agregan traducciones exactas para encabezados/estados de tabla y modales relacionados con sueldos:
+
+- `Empleado` → `Employee`
+- `Período` → `Period`
+- `Bonos` → `Bonuses`
+- `Neto` → `Net`
+- `Pago` → `Payment`
+- `Pendiente` / `pendiente` → `Pending`
+- `Anulado` / `anulado` → `Canceled`
+- `Detalle de sueldo` → `Salary detail`
+- `Editar sueldo` → `Edit salary`
+- `Registrar sueldo` → `Register salary`
+- `Guardar cambios` → `Save changes`
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de sueldos.
+- Sin cambios en PDF/Excel generados; esa traducción queda para futura feature global de reportes/exportaciones multiidioma.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v28-salary-modal-required-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v28-salary-modal-required-labels-fix.md
@@ -1,0 +1,40 @@
+# i18n navigation menus final sweep v28 - Salary modal required labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN en el modal `Edit salary` / `New salary` dentro de `/dashboard/empleados-sueldos`.
+
+## Diagnóstico
+
+El v27 ya cubría etiquetas base como `Empleado`, `Período`, `Bonos` y `Neto`, pero el modal renderiza algunas variantes con símbolos o dos puntos:
+
+- `Empleado *`
+- `Período *`
+- `Empleado:`
+- `Bonos:`
+- `Neto:`
+
+Al estar trabajando con traducciones exact-only para no provocar reemplazos parciales peligrosos, esas variantes deben declararse explícitamente.
+
+## Ajustes puntuales
+
+Se agregan traducciones exactas para:
+
+- `Empleado *` → `Employee *`
+- `Período *` → `Period *`
+- `Concepto` → `Concept`
+- `URL de comprobante` → `Receipt URL`
+- `Empleado:` → `Employee:`
+- `Bonos:` → `Bonuses:`
+- `Neto:` → `Net:`
+- `Sueldo mensual demo` → `Monthly salary demo`
+- `dd/mm/aaaa` → `dd/mm/yyyy`
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de sueldos.
+- Sin cambios en PDF/Excel.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v29-attendances-page-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v29-attendances-page-labels-fix.md
@@ -1,0 +1,54 @@
+# i18n navigation menus final sweep v29 - Attendances page labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos ES/EN en `/dashboard/asistencias`.
+
+## Ajuste directo en page
+
+Se actualiza `src/app/dashboard/asistencias/page.tsx` para usar `useI18n()` en textos propios de la pantalla:
+
+- `Asistencias` → `Attendances`
+- `Dentro ahora` → `Inside now`
+- `Capacidad configurada` → `Configured capacity`
+- `Ocupación` → `Occupancy`
+- `Estado` → `Status`
+- `Listado de Asistencias` → `Attendance roster`
+- `Buscar...` → `Search...`
+- `Todos los períodos` → `All periods`
+- `Salida / Aforo` → `Exit / Capacity`
+- `Modo terminal` → `Terminal mode`
+- `Añadir Asistencia` → `Add attendance`
+- `Actualización automática cada 5s.` → `Automatic refresh every 5s.`
+- `Última actualización` → `Last update`
+- paginación inferior a formato inglés.
+
+También se traduce localmente el mensaje de aforo que llega del servicio:
+
+- `Ocupación normal. Hay disponibilidad operativa.` → `Normal occupancy. Operational capacity is available.`
+
+No se toca el servicio ni el endpoint.
+
+## Ajuste directo en tabla
+
+Se actualiza `src/components/tables/AsistenciaTable.tsx` para traducir encabezados y caption:
+
+- `Nombre de Socio` → `Member name`
+- `Hora Ingreso` → `Check-in time`
+- `Hora Egreso` → `Check-out time`
+- `Ver` → `View`
+- `Total de asistencias` → `Total attendances`
+- `Listado de asistencias registradas.` → `Registered attendance list.`
+
+## Exact-only guard
+
+Se agregan traducciones exactas al `DashboardInlineI18nSweep` como capa defensiva para remanentes visibles relacionados con asistencias.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de asistencias o aforo.
+- Sin cambios en PDF/Excel generados.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v3-inline-dashboard-ui-followup.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v3-inline-dashboard-ui-followup.md
@@ -1,0 +1,29 @@
+# i18n navigation menus final sweep v3 - dashboard follow-up
+
+## Objetivo
+Corregir remanentes detectados en QA luego del v2.
+
+## Ajustes
+
+### 1. Actividades
+- Se elimina el fondo blanco del selector/listado de socios dentro de inscripción.
+- Se mejora el contraste en modo oscuro.
+- Se traducen labels faltantes del bloque de inscripción y el catálogo.
+
+### 2. Rutine assistant
+- Se agregan traducciones ES → EN para el contenido visible de la pantalla `/dashboard/rutinas/asistente`.
+- Cubre hero, ayuda, formulario, resumen interpretado y resultado.
+
+### 3. Members 360
+- Se agregan variantes faltantes como `Con emergencia`, `Riesgo alto`, `Con alertas` y otros remanentes de cards/resúmenes.
+
+### 4. Paginación / contadores
+- Se agrega traducción de `actividades` y `socios` dentro de `commercialUi` para frases dinámicas como `Showing 1 - 8 of 16 activities`.
+- Se agrega traducción base `Ver -> View` para acciones todavía visibles en inglés mixto.
+
+## Alcance técnico
+- Frontend/i18n only.
+- No DB.
+- No endpoints.
+- No Swagger/OpenAPI.
+- Sin cambios de permisos ni lógica de negocio.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v30-attendance-view-modal-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v30-attendance-view-modal-labels-fix.md
@@ -1,0 +1,31 @@
+# i18n navigation menus final sweep v30 - Attendance view modal labels fix
+
+## Objetivo
+
+Corregir remanentes puntuales de textos mixtos ES/EN en el modal de detalle de asistencia dentro de `/dashboard/asistencias`.
+
+## Ajuste directo
+
+Se actualiza `src/components/modal/AsistenciaViewModal.tsx` para usar `useI18n()` directamente en los labels fijos del modal:
+
+- `Detalles de Asistencia` → `Attendance details`
+- `ID Asistencia` → `Attendance ID`
+- `ID Socio` → `Member ID`
+- `Fecha` → `Date`
+- `Hora Ingreso` → `Check-in time`
+- `Hora Egreso` → `Check-out time`
+- `Cerrar` → `Close`
+
+## Nota técnica
+
+Este ajuste se realiza directo en el modal y no mediante `DashboardInlineI18nSweep`, porque son labels fijos y es más seguro controlarlos por idioma desde el componente.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Solo modal de detalle de asistencia.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de asistencias o aforo.
+- Sin cambios en PDF/Excel generados.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v31-attendance-edit-modal-form-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v31-attendance-edit-modal-form-labels-fix.md
@@ -1,0 +1,39 @@
+# i18n navigation menus final sweep v31 - Attendance edit modal/form labels fix
+
+## Objetivo
+
+Corregir textos híbridos ES/EN en el modal de alta/edición de asistencias.
+
+## Ajustes directos
+
+### `AsistenciaModal.tsx`
+
+- `Editar Asistencia` → `Edit attendance`
+- `Nueva Asistencia` → `New attendance`
+
+### `AsistenciaForm.tsx`
+
+- `ID Socio` → `Member ID`
+- `Ingrese ID del socio` → `Enter member ID`
+- `Fecha` → `Date`
+- `Hora Ingreso` → `Check-in time`
+- `Hora Egreso` → `Check-out time`
+- `HH:MM (Opcional)` → `HH:MM (Optional)`
+- `Guardando...` → `Saving...`
+- `Actualizar Asistencia` → `Update attendance`
+- `Registrar Asistencia` → `Register attendance`
+- `Cancelar` → `Cancel`
+- toasts y errores locales del formulario.
+
+## Nota técnica
+
+El ajuste utiliza `useI18n()` directamente en ambos componentes. No depende del sweep global y no modifica datos ni comportamiento del formulario.
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en lógica de asistencia o aforo.
+- Sin cambios en PDF/Excel.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v32-attendance-terminal-labels-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v32-attendance-terminal-labels-fix.md
@@ -1,0 +1,40 @@
+# i18n navigation menus final sweep v32 - Attendance terminal labels fix
+
+## Objetivo
+
+Corregir textos en español/híbridos cuando la pantalla `/dashboard/asistencias/terminal` se visualiza con idioma inglés.
+
+## Archivo actualizado
+
+- `src/components/asistencia/AsistenciaTerminalDisplay.tsx`
+
+## Ajustes puntuales
+
+Se agrega `useI18n()` directamente al componente de Terminal de asistencia y se controlan los textos visibles sin tocar lógica de QR, sesión, polling ni registro:
+
+- `Terminal de asistencia` → `Attendance terminal`
+- `Terminal listo` → `Terminal ready`
+- `Escaneá el QR para registrar asistencia` → `Scan the QR to register attendance`
+- `Abrí la cámara de tu celular...` → `Open your phone camera...`
+- `Ingreso con celular` → `Mobile check-in`
+- `Escaneá este QR` → `Scan this QR`
+- pasos de uso del QR
+- `Monitor externo` → `External monitor`
+- `Actividad reciente` → `Recent activity`
+- `Salida` / `Ingreso` → `Exit` / `Check-in`
+- `Deuda` → `Debt`
+- `Bloqueado` → `Blocked`
+- `Esta pantalla está pensada...` → English explanatory note
+- mensajes de sesión/renovación visibles
+- mensajes de estado/eventos visibles
+
+## Alcance
+
+- Solo frontend/i18n.
+- Sin cambios en DB.
+- Sin cambios en endpoints.
+- Sin cambios en Swagger/OpenAPI.
+- Sin cambios en servicios QR.
+- Sin cambios en polling/realtime.
+- Sin cambios en autenticación o sesión terminal.
+- Sin cambios en PDF/Excel.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v4-build-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v4-build-fix.md
@@ -1,0 +1,33 @@
+# i18n navigation menus final sweep v4 build fix
+
+## Objetivo
+
+Corregir error de compilación en `DashboardInlineI18nSweep.tsx`.
+
+## Error
+
+Next/webpack reportaba:
+
+```text
+Expected ',', got 'string literal (Fin, 'Fin')'
+```
+
+## Causa
+
+En el diccionario `TRANSLATIONS` quedó una entrada sin coma antes de:
+
+```ts
+'Fin': 'End'
+```
+
+## Ajuste
+
+Se agrega la coma faltante y se normaliza la separación entre entradas del objeto.
+
+## Alcance
+
+- Solo build fix frontend.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica funcional.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v5-remaining-members-copy-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v5-remaining-members-copy-fix.md
@@ -1,0 +1,41 @@
+# i18n navigation menus final sweep v5 remaining members copy fix
+
+## Objetivo
+
+Completar la traducción EN pendiente detectada durante el QA manual posterior al build fix v4, principalmente en la vista **Members** y el modal **Members 360**.
+
+## Alcance
+
+- Ajuste de diccionario `DashboardInlineI18nSweep.tsx`.
+- Traducción de copys remanentes en Members, Members 360 y lectura rápida.
+- Traducción de etiquetas remanentes de `Routine assistant`.
+- Normalización de textos mixtos ES/EN reportados por QA.
+
+## Casos cubiertos
+
+- `Registrados`
+- `Vista 360 administrador`
+- `Sin novedades`
+- `Última actualización:`
+- `Abrir módulo`
+- `Evolution física`
+- `Seguimiento corporal`
+- `Sin inscripciones activas`
+- `Señales útiles para atención, retención y seguimiento administrativo.`
+- `Status general`
+- `Risk administrativo`
+- `Seguimiento saludable`
+- `Conviene solicitar o revisar ficha médica vigente.`
+- `Edad`
+- `Date alta`
+- `Alertas de riesgo 360`
+- `Sin estado`
+- `Sin datos`
+- `Última revisión:`
+
+## Impacto
+
+- Sin cambios de DB.
+- Sin cambios de API.
+- Sin cambios de Swagger/OpenAPI.
+- Solo frontend / i18n inline sweep.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v6-socio360-mixed-copy-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v6-socio360-mixed-copy-fix.md
@@ -1,0 +1,25 @@
+# i18n navigation menus final sweep v6 - Socio 360 mixed copy fix
+
+## Objetivo
+
+Corregir textos mixtos ES/EN detectados en el modal 360 de socio cuando el idioma activo es Inglés.
+
+## Casos corregidos
+
+- `Status de cuota` → `Fee status`
+- `Status general` → `Overall status`
+- `Puede operar normalmente como socio active.` → `The member can operate normally as an active member.`
+- `Risk administrativo` → `Administrative risk`
+- `Light follow-up: revisar las alertas 360 antes de cerrar la atención.` → `Light follow-up: review the 360 alerts before closing the case.`
+- `Date alta` → `Registration date`
+- `Contact emergencia` → `Emergency contact`
+- `Phone emergencia` → `Emergency phone`
+- `Descuento active` → `Active discount`
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica lógica del modal 360.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v7-dedupe-build-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v7-dedupe-build-fix.md
@@ -1,0 +1,30 @@
+# i18n navigation menus final sweep v7 - dedupe build fix
+
+## Objetivo
+
+Corregir error de TypeScript por claves duplicadas en `DashboardInlineI18nSweep.tsx`.
+
+## Error
+
+```text
+Type error: An object literal cannot have multiple properties with the same name.
+'STATUS DE CUOTA': 'FEE STATUS'
+```
+
+## Causa
+
+Los fixes incrementales agregaron algunas traducciones ya existentes en el objeto `TRANSLATIONS`.
+
+## Ajuste
+
+- Se deduplican las claves del objeto `TRANSLATIONS`.
+- Se conserva la última definición para que los fixes más recientes tengan prioridad.
+- Se verifica que no queden claves duplicadas.
+
+## Alcance
+
+- Solo frontend/i18n build fix.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica funcional.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v8-bidirectional-inline-sweep-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v8-bidirectional-inline-sweep-fix.md
@@ -1,0 +1,27 @@
+# i18n navigation menus final sweep v8 - bidirectional inline sweep fix
+
+## Objetivo
+
+Corregir el problema donde el dashboard quedaba pegado en Inglés al intentar volver a Español.
+
+## Problema
+
+`DashboardInlineI18nSweep` traducía textos heredados ES → EN mutando nodos del DOM. Al cambiar el idioma de vuelta a ES, algunos textos quedaban en Inglés porque el sweep no hacía la conversión inversa de forma confiable.
+
+## Ajuste
+
+- Se agrega diccionario inverso automático EN → ES.
+- El sweep ahora traduce de forma bidireccional:
+  - `locale === 'en'`: ES → EN.
+  - `locale !== 'en'`: EN → ES.
+- La traducción trabaja sobre el valor actual del nodo/atributo.
+- Se mantiene el comportamiento para contenido dinámico y modales.
+- Se conserva la exclusión de `script`, `style`, `svg`, `canvas` y `data-i18n-sweep="off"`.
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia rutas ni permisos.

--- a/docs/mobile/i18n-navigation-menus-final-sweep-v9-coach-confidence-label-fix.md
+++ b/docs/mobile/i18n-navigation-menus-final-sweep-v9-coach-confidence-label-fix.md
@@ -1,0 +1,25 @@
+# i18n navigation menus final sweep v9 - Coach confidence label fix
+
+## Objetivo
+
+Corregir el remanente `Confianza: Pendiente` visible en `/dashboard/coach` cuando el idioma activo es Inglés.
+
+## Ajuste
+
+Se agregan traducciones puntuales al `DashboardInlineI18nSweep`:
+
+- `Confianza:` → `Confidence:`
+- `Confianza` → `Confidence`
+- `Pendiente` → `Pending`
+
+## Motivo
+
+El texto visible podía renderizarse como partes separadas y no siempre coincidía con la frase completa ya existente.
+
+## Alcance
+
+- Solo frontend/i18n.
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica lógica funcional del Coach IA.

--- a/src/app/dashboard/actividades/page.tsx
+++ b/src/app/dashboard/actividades/page.tsx
@@ -1554,7 +1554,7 @@ export default function ActividadesPage() {
                       <div className="space-y-1.5 md:col-span-2">
                         <Label>Actividad</Label>
                         <select
-                          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                           value={turnoForm.actividad_id}
                           onChange={(event) =>
                             setTurnoForm((prev) => ({
@@ -1589,7 +1589,7 @@ export default function ActividadesPage() {
                       <div className="space-y-1.5">
                         <Label>Día</Label>
                         <select
-                          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                           value={turnoForm.dia_semana}
                           onChange={(event) =>
                             setTurnoForm((prev) => ({
@@ -1608,7 +1608,7 @@ export default function ActividadesPage() {
                       <div className="space-y-1.5">
                         <Label>Estado</Label>
                         <select
-                          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                           value={turnoForm.estado}
                           onChange={(event) =>
                             setTurnoForm((prev) => ({
@@ -1685,7 +1685,7 @@ export default function ActividadesPage() {
                       <div className="space-y-1.5">
                         <Label>Instructor</Label>
                         <select
-                          className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                           value={turnoForm.instructor_id}
                           onChange={(event) =>
                             setTurnoForm((prev) => ({
@@ -1706,7 +1706,7 @@ export default function ActividadesPage() {
                         <Label>Ubicación</Label>
                         {ubicacionesOptions.length ? (
                           <select
-                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                             value={turnoForm.ubicacion}
                             onChange={(event) =>
                               setTurnoForm((prev) => ({
@@ -2214,7 +2214,7 @@ export default function ActividadesPage() {
                     <div className="space-y-1.5">
                       <Label>Turno</Label>
                       <select
-                        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                        className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                         value={inscripcionForm.turno_id}
                         onChange={(event) =>
                           setInscripcionForm((prev) => ({
@@ -2238,7 +2238,7 @@ export default function ActividadesPage() {
                     </div>
                     <div className="space-y-1.5">
                       <Label>Socio</Label>
-                      <div className="rounded-lg border bg-white p-3 shadow-sm">
+                      <div className="rounded-lg border bg-white p-3 shadow-sm dark:border-slate-800 dark:bg-slate-950/70">
                         <div className="relative">
                           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                           <Input
@@ -2280,7 +2280,7 @@ export default function ActividadesPage() {
                           </div>
                         ) : null}
 
-                        <div className="mt-2 max-h-52 overflow-auto rounded-md border">
+                        <div className="mt-2 max-h-52 overflow-auto rounded-md border border-border bg-white dark:bg-slate-950/70">
                           {filteredSociosOptions.length === 0 ? (
                             <div className="px-3 py-4 text-center text-sm text-muted-foreground">
                               No se encontraron socios para esa búsqueda.
@@ -2295,8 +2295,8 @@ export default function ActividadesPage() {
                                   type="button"
                                   className={`flex w-full items-center justify-between border-b px-3 py-2 text-left text-sm transition last:border-b-0 ${
                                     isSelected
-                                      ? "bg-[#e6f7fd] text-slate-950"
-                                      : "bg-white hover:bg-slate-50"
+                                      ? "bg-cyan-50 text-cyan-900 hover:bg-cyan-100 dark:bg-cyan-500/15 dark:text-cyan-50 dark:hover:bg-cyan-500/20"
+                                      : "bg-white text-slate-900 hover:bg-slate-50 dark:bg-slate-950/70 dark:text-slate-100 dark:hover:bg-slate-900"
                                   }`}
                                   onClick={() => {
                                     setInscripcionForm((prev) => ({
@@ -2330,7 +2330,7 @@ export default function ActividadesPage() {
                             Selector rápido
                           </Label>
                           <select
-                            className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            className="h-10 w-full rounded-md border border-input bg-white px-3 text-sm text-slate-950 dark:bg-slate-950/80 dark:text-slate-50"
                             value={inscripcionForm.socio_id}
                             onChange={(event) => {
                               const socio = sociosOptions.find(

--- a/src/app/dashboard/asistencias/page.tsx
+++ b/src/app/dashboard/asistencias/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
+import { useI18n } from "@/i18n/I18nProvider";
 import { AppHeader } from "@/components/header/AppHeader";
 import { AppFooter } from "@/components/footer/AppFooter";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -47,6 +48,47 @@ function getAsistenciaSortValue(asistencia: Asistencia) {
   return `${fecha}T${hora}`;
 }
 
+
+function translateAforoEstado(value: string | undefined, isEnglish: boolean) {
+  if (!value) return "--";
+
+  if (!isEnglish) {
+    return value;
+  }
+
+  const normalized = value.toLowerCase();
+
+  if (normalized === "normal") return "Normal";
+  if (normalized === "moderado") return "Moderate";
+  if (normalized === "alto") return "High";
+  if (normalized === "critico" || normalized === "crítico") return "Critical";
+
+  return value;
+}
+
+function translateAforoMessage(message: string | undefined, isEnglish: boolean) {
+  if (!message) {
+    return isEnglish ? "No capacity data." : "Sin datos de aforo.";
+  }
+
+  if (!isEnglish) {
+    return message;
+  }
+
+  const translations: Record<string, string> = {
+    "Ocupación normal. Hay disponibilidad operativa.":
+      "Normal occupancy. Operational capacity is available.",
+    "Ocupación moderada. El gimnasio opera con margen disponible.":
+      "Moderate occupancy. The gym is operating with available margin.",
+    "Ocupación alta. Recomendado monitorear accesos y horarios pico.":
+      "High occupancy. Monitor access points and peak hours.",
+    "Ocupación crítica. Activar control de aforo y limitar nuevos ingresos.":
+      "Critical occupancy. Activate capacity control and limit new entries.",
+  };
+
+  return translations[message] ?? message;
+}
+
 function sortAsistenciasByIngresoDesc(asistencias: Asistencia[]) {
   return [...asistencias].sort((a, b) =>
     getAsistenciaSortValue(b).localeCompare(getAsistenciaSortValue(a)),
@@ -57,6 +99,9 @@ export default function AsistenciasPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } =
     useAuthStore();
   const router = useRouter();
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const attendanceText = (es: string, en: string) => (isEnglish ? en : es);
   const [asistencias, setAsistencias] = useState<Asistencia[]>([]);
   const [filteredAsistencias, setFilteredAsistencias] = useState<Asistencia[]>(
     [],
@@ -312,7 +357,7 @@ export default function AsistenciasPage() {
   }, [currentPage, totalPages]);
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{attendanceText("Cargando...", "Loading...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -324,7 +369,7 @@ export default function AsistenciasPage() {
       <div className="flex w-full min-h-screen">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Asistencias" />
+          <AppHeader title={attendanceText("Asistencias", "Attendances")} />
           <main className="flex-1 p-6 space-y-6">
             <div className="grid gap-4 md:grid-cols-4">
               <Card className="border-emerald-100 bg-emerald-50/60 dark:border-emerald-900 dark:bg-emerald-950/20">
@@ -332,7 +377,7 @@ export default function AsistenciasPage() {
                   <div className="flex items-center justify-between gap-3">
                     <div>
                       <p className="text-sm font-medium text-muted-foreground">
-                        Dentro ahora
+                        {attendanceText("Dentro ahora", "Inside now")}
                       </p>
                       <p className="text-3xl font-black">
                         {aforo?.aforo_actual ?? "--"}
@@ -345,7 +390,7 @@ export default function AsistenciasPage() {
               <Card>
                 <CardContent className="p-4">
                   <p className="text-sm font-medium text-muted-foreground">
-                    Capacidad configurada
+                    {attendanceText("Capacidad configurada", "Configured capacity")}
                   </p>
                   <p className="text-3xl font-black">
                     {aforo?.capacidad_maxima ?? "--"}
@@ -358,7 +403,7 @@ export default function AsistenciasPage() {
               <Card>
                 <CardContent className="p-4">
                   <p className="text-sm font-medium text-muted-foreground">
-                    Ocupación
+                    {attendanceText("Ocupación", "Occupancy")}
                   </p>
                   <p className="text-3xl font-black">
                     {aforo ? `${aforo.porcentaje_ocupacion}%` : "--"}
@@ -384,14 +429,14 @@ export default function AsistenciasPage() {
                   <div className="flex items-center gap-2">
                     <AlertTriangle className="h-5 w-5 text-amber-500" />
                     <p className="text-sm font-medium text-muted-foreground">
-                      Estado
+                      {attendanceText("Estado", "Status")}
                     </p>
                   </div>
                   <p className="mt-1 text-xl font-black capitalize">
-                    {aforo?.estado ?? "--"}
+                    {translateAforoEstado(aforo?.estado, isEnglish)}
                   </p>
                   <p className="line-clamp-2 text-xs text-muted-foreground">
-                    {aforo?.mensaje_estado ?? "Sin datos de aforo."}
+                    {translateAforoMessage(aforo?.mensaje_estado, isEnglish)}
                   </p>
                 </CardContent>
               </Card>
@@ -399,13 +444,13 @@ export default function AsistenciasPage() {
 
             <Card className="w-full">
               <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
-                <h2 className="text-xl font-bold">Listado de Asistencias</h2>
+                <h2 className="text-xl font-bold">{attendanceText("Listado de Asistencias", "Attendance roster")}</h2>
                 <div className="flex flex-wrap items-center w-full gap-2 md:w-auto">
                   <div className="relative flex-grow md:flex-grow-0">
                     <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
                       type="search"
-                      placeholder="Buscar..."
+                      placeholder={attendanceText("Buscar...", "Search...")}
                       className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
@@ -416,25 +461,25 @@ export default function AsistenciasPage() {
                     onChange={(e) => setPeriodFilter(e.target.value)}
                     className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
                   >
-                    <option value="todos">Todos los períodos</option>
-                    <option value="dia">Hoy</option>
-                    <option value="semana">Últimos 7 días</option>
-                    <option value="mes">Mes actual</option>
-                    <option value="anio">Año actual</option>
+                    <option value="todos">{attendanceText("Todos los períodos", "All periods")}</option>
+                    <option value="dia">{attendanceText("Hoy", "Today")}</option>
+                    <option value="semana">{attendanceText("Últimos 7 días", "Last 7 days")}</option>
+                    <option value="mes">{attendanceText("Mes actual", "Current month")}</option>
+                    <option value="anio">{attendanceText("Año actual", "Current year")}</option>
                   </select>
                   <Input
                     type="date"
                     value={fechaDesde}
                     onChange={(e) => setFechaDesde(e.target.value)}
                     className="w-[150px]"
-                    title="Fecha desde"
+                    title={attendanceText("Fecha desde", "Date from")}
                   />
                   <Input
                     type="date"
                     value={fechaHasta}
                     onChange={(e) => setFechaHasta(e.target.value)}
                     className="w-[150px]"
-                    title="Fecha hasta"
+                    title={attendanceText("Fecha hasta", "Date to")}
                   />
                   <Button
                     onClick={handleDownloadPdf}
@@ -442,7 +487,7 @@ export default function AsistenciasPage() {
                     className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <FileText className="w-4 h-4" />
-                    <span className="hidden sm:inline">Descargar PDF</span>
+                    <span className="hidden sm:inline">{attendanceText("Descargar PDF", "Download PDF")}</span>
                   </Button>
                   <Button
                     variant="outline"
@@ -450,7 +495,7 @@ export default function AsistenciasPage() {
                     className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <FileSpreadsheet className="w-4 h-4" />
-                    <span className="hidden sm:inline">Exportar</span>
+                    <span className="hidden sm:inline">{attendanceText("Exportar", "Export")}</span>
                   </Button>
                   <Button
                     type="button"
@@ -459,8 +504,8 @@ export default function AsistenciasPage() {
                     className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <Users className="w-4 h-4" />
-                    <span className="hidden sm:inline">Salida / Aforo</span>
-                    <span className="sm:hidden">Aforo</span>
+                    <span className="hidden sm:inline">{attendanceText("Salida / Aforo", "Exit / Capacity")}</span>
+                    <span className="sm:hidden">{attendanceText("Aforo", "Capacity")}</span>
                   </Button>
                   <Button
                     type="button"
@@ -475,29 +520,31 @@ export default function AsistenciasPage() {
                     className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <MonitorUp className="w-4 h-4" />
-                    <span className="hidden sm:inline">Modo terminal</span>
+                    <span className="hidden sm:inline">{attendanceText("Modo terminal", "Terminal mode")}</span>
                     <span className="sm:hidden">Terminal</span>
                   </Button>
                   <Button
                     onClick={() => setOpenModal(true)}
                     className="bg-[#02a8e1] hover:bg-[#0288b1]"
                   >
-                    <span className="hidden sm:inline">Añadir Asistencia</span>
-                    <span className="sm:hidden">Añadir</span>
+                    <span className="hidden sm:inline">{attendanceText("Añadir Asistencia", "Add attendance")}</span>
+                    <span className="sm:hidden">{attendanceText("Añadir", "Add")}</span>
                   </Button>
                 </div>
               </CardHeader>
               <CardContent className="p-4 space-y-4">
                 <div className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
                   <span>
-                    Actualización automática cada{" "}
+                    {attendanceText("Actualización automática cada", "Automatic refresh every")}{" "}
                     {ASISTENCIAS_AUTO_REFRESH_MS / 1000}
                     s.
-                    {isAutoRefreshing ? " Sincronizando asistencias..." : ""}
+                    {isAutoRefreshing
+                      ? attendanceText(" Sincronizando asistencias...", " Syncing attendances...")
+                      : ""}
                   </span>
                   {lastUpdatedAt && (
                     <span>
-                      Última actualización: {formatFrontendTime(lastUpdatedAt)}
+                      {attendanceText("Última actualización", "Last update")}: {formatFrontendTime(lastUpdatedAt)}
                     </span>
                   )}
                 </div>
@@ -523,14 +570,15 @@ export default function AsistenciasPage() {
                 {!loading && totalAsistencias > 0 && (
                   <div className="flex flex-col gap-3 border-t pt-4 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
                     <span>
-                      Mostrando{" "}
-                      {(safeCurrentPage - 1) * ASISTENCIAS_PAGE_SIZE + 1} -{" "}
-                      {Math.min(
-                        safeCurrentPage * ASISTENCIAS_PAGE_SIZE,
-                        totalAsistencias,
-                      )}{" "}
-                      de {totalAsistencias} asistencias ordenadas por ingreso
-                      reciente.
+                      {isEnglish
+                        ? `Showing ${(safeCurrentPage - 1) * ASISTENCIAS_PAGE_SIZE + 1} - ${Math.min(
+                            safeCurrentPage * ASISTENCIAS_PAGE_SIZE,
+                            totalAsistencias,
+                          )} of ${totalAsistencias} attendances ordered by recent check-in.`
+                        : `Mostrando ${(safeCurrentPage - 1) * ASISTENCIAS_PAGE_SIZE + 1} - ${Math.min(
+                            safeCurrentPage * ASISTENCIAS_PAGE_SIZE,
+                            totalAsistencias,
+                          )} de ${totalAsistencias} asistencias ordenadas por ingreso reciente.`}
                     </span>
                     <div className="flex items-center gap-2">
                       <Button
@@ -541,11 +589,9 @@ export default function AsistenciasPage() {
                         onClick={() =>
                           setCurrentPage((page) => Math.max(1, page - 1))
                         }
-                      >
-                        Anterior
-                      </Button>
+                      >{attendanceText("Anterior", "Previous")}</Button>
                       <span className="min-w-[92px] text-center font-medium text-foreground">
-                        Página {safeCurrentPage} de {totalPages}
+                        {attendanceText("Página", "Page")} {safeCurrentPage} {attendanceText("de", "of")} {totalPages}
                       </span>
                       <Button
                         type="button"
@@ -557,9 +603,7 @@ export default function AsistenciasPage() {
                             Math.min(totalPages, page + 1),
                           )
                         }
-                      >
-                        Siguiente
-                      </Button>
+                      >{attendanceText("Siguiente", "Next")}</Button>
                     </div>
                   </div>
                 )}

--- a/src/app/dashboard/empleados-sueldos/page.tsx
+++ b/src/app/dashboard/empleados-sueldos/page.tsx
@@ -21,6 +21,7 @@ import { EmpleadoSueldo, EmpleadoSueldoEstado } from "@/interfaces/empleado_suel
 import { formatCurrencyARS } from "@/lib/comercial/productos";
 import { anularEmpleadoSueldo, getEmpleadoSueldos, getEmpleados } from "@/services/apiClient";
 import { useAuthStore } from "@/stores/authStore";
+import { useI18n } from "@/i18n/I18nProvider";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDate } from "@/utils/dateFormat";
@@ -42,6 +43,9 @@ function periodoInRange(periodo: string, desde: string, hasta: string) {
 
 export default function EmpleadosSueldosPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const salaryText = (es: string, en: string) => (isEnglish ? en : es);
   const router = useRouter();
   const [sueldos, setSueldos] = useState<EmpleadoSueldo[]>([]);
   const [empleados, setEmpleados] = useState<Empleado[]>([]);
@@ -256,30 +260,30 @@ export default function EmpleadosSueldosPage() {
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <AppHeader title="Sueldos" />
+        <AppHeader title={salaryText("Sueldos", "Salaries")} />
         <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-5 p-4 md:p-6">
           <div className="grid gap-4 md:grid-cols-4">
             <Card>
               <CardContent className="p-5">
-                <p className="text-sm text-muted-foreground">Registros</p>
+                <p className="text-sm text-muted-foreground">{salaryText("Registros", "Records")}</p>
                 <p className="text-2xl font-bold">{totals.total}</p>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="p-5">
-                <p className="text-sm text-muted-foreground">Total neto</p>
+                <p className="text-sm text-muted-foreground">{salaryText("Total neto", "Total net")}</p>
                 <p className="text-2xl font-bold">{formatCurrencyARS(totals.neto)}</p>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="p-5">
-                <p className="text-sm text-muted-foreground">Pagado</p>
+                <p className="text-sm text-muted-foreground">{salaryText("Pagado", "Paid")}</p>
                 <p className="text-2xl font-bold text-emerald-600">{formatCurrencyARS(totals.pagado)}</p>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="p-5">
-                <p className="text-sm text-muted-foreground">Pendiente</p>
+                <p className="text-sm text-muted-foreground">{salaryText("Pendiente", "Pending")}</p>
                 <p className="text-2xl font-bold text-amber-600">{formatCurrencyARS(totals.pendiente)}</p>
               </CardContent>
             </Card>
@@ -292,20 +296,20 @@ export default function EmpleadosSueldosPage() {
                   <WalletCards className="h-5 w-5" />
                 </div>
                 <div>
-                  <h1 className="text-xl font-semibold">Sueldos de empleados</h1>
+                  <h1 className="text-xl font-semibold">{salaryText("Sueldos de empleados", "Employee salaries")}</h1>
                   <p className="text-sm text-muted-foreground">
-                    Registro opcional de liquidaciones, pagos y recibos del personal.
+                    {salaryText("Registro opcional de liquidaciones, pagos y recibos del personal.", "Optional record of payroll settlements, payments and staff receipts.")}
                   </p>
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
                 <Button type="button" variant="outline" onClick={downloadPdf}>
                   <FileText className="mr-2 h-4 w-4" />
-                  Descargar PDF
+                  {salaryText("Descargar PDF", "Download PDF")}
                 </Button>
                 <Button type="button" variant="outline" onClick={exportExcel}>
                   <FileSpreadsheet className="mr-2 h-4 w-4" />
-                  Exportar
+                  {salaryText("Exportar", "Export")}
                 </Button>
                 <Button
                   type="button"
@@ -315,7 +319,7 @@ export default function EmpleadosSueldosPage() {
                   }}
                 >
                   <Plus className="mr-2 h-4 w-4" />
-                  Nuevo sueldo
+                  {salaryText("Nuevo sueldo", "New salary")}
                 </Button>
               </div>
             </CardHeader>
@@ -326,26 +330,26 @@ export default function EmpleadosSueldosPage() {
                   onChange={(event) => setEstadoFilter(event.target.value as EstadoFilter)}
                   className="rounded-md border bg-background px-3 py-2 text-sm"
                 >
-                  <option value="todos">Todos los estados</option>
-                  <option value="pendiente">Pendientes</option>
-                  <option value="pagado">Pagados</option>
-                  <option value="anulado">Anulados</option>
+                  <option value="todos">{salaryText("Todos los estados", "All statuses")}</option>
+                  <option value="pendiente">{salaryText("Pendientes", "Pending")}</option>
+                  <option value="pagado">{salaryText("Pagados", "Paid")}</option>
+                  <option value="anulado">{salaryText("Anulados", "Canceled")}</option>
                 </select>
-                <Input type="month" value={periodoDesde} onChange={(event) => setPeriodoDesde(event.target.value)} />
-                <Input type="month" value={periodoHasta} onChange={(event) => setPeriodoHasta(event.target.value)} />
+                <Input type="month" lang={isEnglish ? "en" : "es"} aria-label={salaryText("Período desde", "Period from")} value={periodoDesde} onChange={(event) => setPeriodoDesde(event.target.value)} />
+                <Input type="month" lang={isEnglish ? "en" : "es"} aria-label={salaryText("Período hasta", "Period to")} value={periodoHasta} onChange={(event) => setPeriodoHasta(event.target.value)} />
                 <div className="relative md:col-span-2">
                   <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
                   <Input
                     value={searchTerm}
                     onChange={(event) => setSearchTerm(event.target.value)}
-                    placeholder="Buscar empleado, DNI, concepto, medio..."
+                    placeholder={salaryText("Buscar empleado, DNI, concepto, medio...", "Search employee, ID, concept, payment method...")}
                     className="pl-9"
                   />
                 </div>
               </div>
 
               {loading ? (
-                <div className="py-10 text-center text-muted-foreground">Cargando sueldos...</div>
+                <div className="py-10 text-center text-muted-foreground">{salaryText("Cargando sueldos...", "Loading salaries...")}</div>
               ) : (
                 <EmpleadoSueldoTable
                   sueldos={paginatedSueldos}
@@ -369,7 +373,9 @@ export default function EmpleadosSueldosPage() {
                 onPageChange={setCurrentPage}
               />
               <p className="text-sm text-muted-foreground">
-                Mostrando {paginatedSueldos.length} de {filteredSueldos.length} registros.
+                {isEnglish
+                  ? `Showing ${paginatedSueldos.length} of ${filteredSueldos.length} records.`
+                  : `Mostrando ${paginatedSueldos.length} de ${filteredSueldos.length} registros.`}
               </p>
             </CardContent>
           </Card>

--- a/src/app/dashboard/empleados/page.tsx
+++ b/src/app/dashboard/empleados/page.tsx
@@ -24,6 +24,7 @@ import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import ExcelJS from "exceljs";
 import { FileSpreadsheet, FileText, Search, UserCog, UsersRound } from "lucide-react";
 import { toast } from "sonner";
+import { useI18n } from "@/i18n/I18nProvider";
 
 const EMPLEADOS_PAGE_SIZE = 10;
 type EstadoFilter = "todos" | "activos" | "inactivos";
@@ -38,6 +39,7 @@ const fallbackTiposEmpleado: CatalogoParametrizableItem[] = [
 
 export default function EmpleadosPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
   const router = useRouter();
   const [empleados, setEmpleados] = useState<Empleado[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -243,7 +245,11 @@ export default function EmpleadosPage() {
   };
 
   if (loading || !isInitialized) {
-    return <div className="flex h-screen items-center justify-center">Cargando empleados...</div>;
+    return (
+      <div className="flex h-screen items-center justify-center">
+        {locale === "en" ? "Loading employees..." : "Cargando empleados..."}
+      </div>
+    );
   }
 
   if (!isAuthenticated) return null;

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,9 +1,15 @@
 import DashboardRouteGuard from '@/components/auth/DashboardRouteGuard';
+import DashboardInlineI18nSweep from '@/components/i18n/DashboardInlineI18nSweep';
 
 export default function DashboardLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <DashboardRouteGuard>{children}</DashboardRouteGuard>;
+  return (
+    <DashboardRouteGuard>
+      <DashboardInlineI18nSweep />
+      {children}
+    </DashboardRouteGuard>
+  );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -229,55 +229,138 @@ export default function DashboardPage() {
   }, [isAuthenticated, isInitialized, router]);
 
   useEffect(() => {
+    if (!isInitialized) return;
+
+    if (!isAuthenticated) {
+      setLoadingDatos(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    function withDashboardTimeout<T>(
+      promise: Promise<T>,
+      label: string,
+      timeoutMs = 10000,
+    ): Promise<T> {
+      return new Promise<T>((resolve, reject) => {
+        const timeoutId = window.setTimeout(() => {
+          reject(new Error(`Dashboard load timeout: ${label}`));
+        }, timeoutMs);
+
+        promise
+          .then((value) => {
+            window.clearTimeout(timeoutId);
+            resolve(value);
+          })
+          .catch((error) => {
+            window.clearTimeout(timeoutId);
+            reject(error);
+          });
+      });
+    }
+
     async function fetchData() {
       setLoadingDatos(true);
-      const eqs = await getAllEquipamientos();
-      const mants = await getAllMantenimientos();
-      setEquipos(eqs || []);
-      setMantenimientos(mants || []);
 
-      if (user?.rol === 'admin') {
-        const [
-          adherencia,
-          evolucion,
-          concurrencia,
-          fallos,
-          estado,
-          segmentacion,
-          histograma,
-        ] = await Promise.all([
-          getAdherenciaRutinas(),
-          getEvolucionPromedioRutinas(),
-          getConcurrenciaAsistencia('semanal'),
-          getTopFallosEquipamiento(),
-          getEstadoActualEquipamiento(),
-          getSegmentacionPagos(),
-          getHistogramaPagos(),
+      try {
+        const [equiposResult, mantenimientosResult] = await Promise.allSettled([
+          withDashboardTimeout(getAllEquipamientos(), 'equipamientos'),
+          withDashboardTimeout(getAllMantenimientos(), 'mantenimientos'),
         ]);
 
-        setAdherenciaRutinas(
-          adherencia.ok && adherencia.data ? adherencia.data : []
-        );
-        setEvolucionRutinas(
-          evolucion.ok && evolucion.data ? evolucion.data : []
-        );
-        setConcurrenciaSemanal(
-          concurrencia.ok && concurrencia.data ? concurrencia.data : []
-        );
-        setTopFallos(fallos.ok && fallos.data ? fallos.data : []);
-        setEstadoEquipamiento(estado.ok && estado.data ? estado.data : []);
-        setSegmentacionPagos(
-          segmentacion.ok && segmentacion.data ? segmentacion.data : []
-        );
-        setHistogramaPagos(
-          histograma.ok && histograma.data ? histograma.data : []
-        );
-      }
+        if (cancelled) return;
 
-      setLoadingDatos(false);
+        setEquipos(
+          equiposResult.status === 'fulfilled' ? equiposResult.value || [] : [],
+        );
+        setMantenimientos(
+          mantenimientosResult.status === 'fulfilled'
+            ? mantenimientosResult.value || []
+            : [],
+        );
+
+        if (user?.rol === 'admin') {
+          const [
+            adherenciaResult,
+            evolucionResult,
+            concurrenciaResult,
+            fallosResult,
+            estadoResult,
+            segmentacionResult,
+            histogramaResult,
+          ] = await Promise.allSettled([
+            withDashboardTimeout(getAdherenciaRutinas(), 'adherencia rutinas'),
+            withDashboardTimeout(getEvolucionPromedioRutinas(), 'evolución rutinas'),
+            withDashboardTimeout(getConcurrenciaAsistencia('semanal'), 'concurrencia asistencia'),
+            withDashboardTimeout(getTopFallosEquipamiento(), 'top fallos equipamiento'),
+            withDashboardTimeout(getEstadoActualEquipamiento(), 'estado actual equipamiento'),
+            withDashboardTimeout(getSegmentacionPagos(), 'segmentación pagos'),
+            withDashboardTimeout(getHistogramaPagos(), 'histograma pagos'),
+          ]);
+
+          if (cancelled) return;
+
+          const adherencia =
+            adherenciaResult.status === 'fulfilled' ? adherenciaResult.value : null;
+          const evolucion =
+            evolucionResult.status === 'fulfilled' ? evolucionResult.value : null;
+          const concurrencia =
+            concurrenciaResult.status === 'fulfilled' ? concurrenciaResult.value : null;
+          const fallos =
+            fallosResult.status === 'fulfilled' ? fallosResult.value : null;
+          const estado =
+            estadoResult.status === 'fulfilled' ? estadoResult.value : null;
+          const segmentacion =
+            segmentacionResult.status === 'fulfilled' ? segmentacionResult.value : null;
+          const histograma =
+            histogramaResult.status === 'fulfilled' ? histogramaResult.value : null;
+
+          setAdherenciaRutinas(
+            adherencia?.ok && adherencia.data ? adherencia.data : [],
+          );
+          setEvolucionRutinas(
+            evolucion?.ok && evolucion.data ? evolucion.data : [],
+          );
+          setConcurrenciaSemanal(
+            concurrencia?.ok && concurrencia.data ? concurrencia.data : [],
+          );
+          setTopFallos(fallos?.ok && fallos.data ? fallos.data : []);
+          setEstadoEquipamiento(estado?.ok && estado.data ? estado.data : []);
+          setSegmentacionPagos(
+            segmentacion?.ok && segmentacion.data ? segmentacion.data : [],
+          );
+          setHistogramaPagos(
+            histograma?.ok && histograma.data ? histograma.data : [],
+          );
+        }
+      } catch (error) {
+        console.error('Error cargando dashboard:', error);
+
+        if (!cancelled) {
+          setEquipos([]);
+          setMantenimientos([]);
+          setAdherenciaRutinas([]);
+          setEvolucionRutinas([]);
+          setConcurrenciaSemanal([]);
+          setTopFallos([]);
+          setEstadoEquipamiento([]);
+          setSegmentacionPagos([]);
+          setHistogramaPagos([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingDatos(false);
+        }
+      }
     }
+
     fetchData();
-  }, [user?.rol]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, isInitialized, user?.rol]);
 
   useEffect(() => {
     if (user?.rol !== 'admin') {
@@ -554,7 +637,7 @@ export default function DashboardPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.rol]);
 
-  if (loadingDatos || !isInitialized) {
+  if (!isInitialized) {
     return (
       <div className='flex items-center justify-center h-screen'>
         {t('common.loadingDashboard')}

--- a/src/components/asistencia/AsistenciaTerminalDisplay.tsx
+++ b/src/components/asistencia/AsistenciaTerminalDisplay.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/services/qrService";
 import { formatFrontendDate, formatFrontendTime } from "@/utils/dateFormat";
 import { useAuthStore } from "@/stores/authStore";
+import { useI18n } from "@/i18n/I18nProvider";
 import {
   getTerminalToken,
   getToken,
@@ -296,6 +297,78 @@ function getIdleEvent(): TerminalEvent {
   };
 }
 
+
+function translateTerminalText(value: string, isEnglish: boolean) {
+  if (!isEnglish) return value;
+
+  const translations: Record<string, string> = {
+    "Socio": "Member",
+    "Escaneo disponible": "Scan available",
+    "Escaneá el QR para registrar asistencia": "Scan the QR to register attendance",
+    "Abrí la cámara de tu celular, escaneá el código y seguí el flujo de ingreso desde Gym Master.":
+      "Open your phone camera, scan the code and follow the check-in flow from Gym Master.",
+    "Salida registrada": "Exit registered",
+    "Debe regularizar": "Payment required",
+    "Acceso bloqueado": "Access blocked",
+    "No se pudo registrar": "Could not register",
+    "Acceso permitido": "Access allowed",
+    "Egreso registrado correctamente. Aforo actualizado.":
+      "Exit registered successfully. Capacity updated.",
+    "El socio debe dirigirse a administración para regularizar su situación.":
+      "The member must go to administration to regularize their status.",
+    "El socio está desactivado. Debe dirigirse a administración.":
+      "The member is deactivated and must go to administration.",
+    "No se pudo registrar la asistencia.": "Attendance could not be registered.",
+    "Asistencia registrada correctamente. Bienvenido al gimnasio.":
+      "Attendance registered successfully. Welcome to the gym.",
+    "Preparando sesión extendida de Terminal...":
+      "Preparing extended terminal session...",
+    "La sesión de Terminal expiró. Iniciá sesión nuevamente para reactivar la pantalla.":
+      "The terminal session expired. Sign in again to reactivate the screen.",
+    "Sesión de Terminal expirada.": "Terminal session expired.",
+    "No hay sesión activa para la Terminal. Iniciá sesión nuevamente.":
+      "There is no active terminal session. Sign in again.",
+    "Sesión de Terminal activa.": "Terminal session active.",
+    "Renovando sesión segura de Terminal...":
+      "Renewing secure terminal session...",
+    "Sesión de Terminal renovada correctamente.":
+      "Terminal session renewed successfully.",
+    "No se pudieron cargar las asistencias recientes.":
+      "Recent attendances could not be loaded.",
+    "No se pudo cargar el QR diario de asistencia.":
+      "The daily attendance QR could not be loaded.",
+    "No se pudieron cargar avisos de Terminal:":
+      "Terminal notices could not be loaded:",
+  };
+
+  return translations[value] ?? value;
+}
+
+function getTerminalStatusLabel(
+  status: TerminalVariant,
+  tipoMovimiento: "entrada" | "salida" | undefined,
+  isEnglish: boolean,
+) {
+  if (tipoMovimiento === "salida") return isEnglish ? "Exit" : "Salida";
+  if (status === "success") return "OK";
+  if (status === "debt") return isEnglish ? "Debt" : "Deuda";
+  if (status === "inactive") return isEnglish ? "Blocked" : "Bloqueado";
+  return "Info";
+}
+
+function getTerminalMovementLabel(
+  tipoMovimiento: "entrada" | "salida" | undefined,
+  isEnglish: boolean,
+) {
+  return tipoMovimiento === "salida"
+    ? isEnglish
+      ? "Exit"
+      : "Salida"
+    : isEnglish
+      ? "Check-in"
+      : "Ingreso";
+}
+
 function TerminalIcon({ variant }: { variant: TerminalVariant }) {
   if (variant === "success")
     return <CheckCircle2 className="h-20 w-20 md:h-28 md:w-28" />;
@@ -307,6 +380,11 @@ function TerminalIcon({ variant }: { variant: TerminalVariant }) {
 }
 
 export default function AsistenciaTerminalDisplay() {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const terminalText = (es: string, en: string) => (isEnglish ? en : es);
+  const translateText = (value: string) => translateTerminalText(value, isEnglish);
+
   const [event, setEvent] = useState<TerminalEvent>(() => getIdleEvent());
   const [recent, setRecent] = useState<AsistenciaReciente[]>([]);
   const [now, setNow] = useState(() => new Date());
@@ -692,7 +770,7 @@ export default function AsistenciaTerminalDisplay() {
                 Gym Master
               </p>
               <h1 className="text-2xl font-black tracking-tight md:text-3xl 2xl:text-4xl">
-                Terminal de asistencia
+                {terminalText("Terminal de asistencia", "Attendance terminal")}
               </h1>
             </div>
           </div>
@@ -711,7 +789,7 @@ export default function AsistenciaTerminalDisplay() {
               variant="outline"
               onClick={requestFullscreen}
               className="border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white"
-              title="Pantalla completa"
+              title={terminalText("Pantalla completa", "Fullscreen")}
             >
               <Maximize2 className="h-5 w-5" />
             </Button>
@@ -727,7 +805,7 @@ export default function AsistenciaTerminalDisplay() {
             }`}
           >
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <span>{sessionState.message}</span>
+              <span>{translateText(sessionState.message)}</span>
               {sessionState.status === "expired" && (
                 <div className="flex gap-2">
                   <Button
@@ -743,7 +821,7 @@ export default function AsistenciaTerminalDisplay() {
                     }}
                     className="border-white/20 bg-white/10 text-white hover:bg-white/20 hover:text-white"
                   >
-                    Reintentar renovación
+                    {terminalText("Reintentar renovación", "Retry renewal")}
                   </Button>
                   <Button
                     type="button"
@@ -755,7 +833,7 @@ export default function AsistenciaTerminalDisplay() {
                     }}
                     className="bg-white text-slate-950 hover:bg-slate-100"
                   >
-                    Iniciar sesión
+                    {terminalText("Iniciar sesión", "Sign in")}
                   </Button>
                 </div>
               )}
@@ -774,7 +852,7 @@ export default function AsistenciaTerminalDisplay() {
                     {qrDataUrl ? (
                       <Image
                         src={qrDataUrl}
-                        alt="QR diario para registrar asistencia"
+                        alt={terminalText("QR diario para registrar asistencia", "Daily QR to register attendance")}
                         width={410}
                         height={410}
                         priority
@@ -784,18 +862,18 @@ export default function AsistenciaTerminalDisplay() {
                         <QrCode className="h-40 w-40" />
                         <span className="text-sm font-bold">
                           {qrLoading
-                            ? "Cargando QR diario..."
-                            : "QR no disponible"}
+                            ? terminalText("Cargando QR diario...", "Loading daily QR...")
+                            : terminalText("QR no disponible", "QR unavailable")}
                         </span>
                       </div>
                     )}
                   </div>
                   <div className="mt-3 rounded-2xl bg-slate-950 p-3 text-center text-white">
                     <p className="text-xs font-bold uppercase tracking-[0.24em] text-cyan-300">
-                      Ingreso con celular
+                      {terminalText("Ingreso con celular", "Mobile check-in")}
                     </p>
                     <p className="mt-1 text-base font-black 2xl:text-lg">
-                      Escaneá este QR
+                      {terminalText("Escaneá este QR", "Scan this QR")}
                     </p>
                   </div>
                 </div>
@@ -805,17 +883,17 @@ export default function AsistenciaTerminalDisplay() {
                     className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-black uppercase tracking-[0.2em] 2xl:px-4 2xl:py-2 2xl:text-sm ${styles.badge}`}
                   >
                     <Smartphone className="h-4 w-4" />
-                    Terminal listo
+                    {terminalText("Terminal listo", "Terminal ready")}
                   </span>
 
                   <h2
                     className={`mt-4 text-4xl font-black leading-tight tracking-tight md:text-5xl 2xl:text-6xl ${styles.title}`}
                   >
-                    {event.title}
+                    {translateText(event.title)}
                   </h2>
 
                   <p className="mt-4 max-w-4xl text-xl font-semibold leading-relaxed md:text-2xl 2xl:text-3xl">
-                    {event.message}
+                    {translateText(event.message)}
                   </p>
 
                   <div className="mt-5 space-y-2 rounded-3xl border border-cyan-200 bg-white/70 p-4 text-left text-slate-800 dark:border-cyan-700/60 dark:bg-slate-900/70 dark:text-slate-100 2xl:mt-6 2xl:space-y-3">
@@ -823,25 +901,25 @@ export default function AsistenciaTerminalDisplay() {
                       <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-cyan-500 text-sm text-white">
                         1
                       </span>
-                      El socio escanea el QR con su celular.
+                      {terminalText("El socio escanea el QR con su celular.", "The member scans the QR with their phone.")}
                     </p>
                     <p className="flex items-start gap-3 text-base font-bold 2xl:text-lg">
                       <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-cyan-500 text-sm text-white">
                         2
                       </span>
-                      Gym Master valida su cuota y registra la asistencia.
+                      {terminalText("Gym Master valida su cuota y registra la asistencia.", "Gym Master validates their fee status and registers attendance.")}
                     </p>
                     <p className="flex items-start gap-3 text-base font-bold 2xl:text-lg">
                       <span className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-cyan-500 text-sm text-white">
                         3
                       </span>
-                      Esta pantalla muestra bienvenida, deuda o bloqueo.
+                      {terminalText("Esta pantalla muestra bienvenida, deuda o bloqueo.", "This screen shows welcome, debt or blocked status.")}
                     </p>
                   </div>
 
                   {checkInUrl && (
                     <p className="mt-5 break-all rounded-2xl bg-black/10 p-3 text-xs font-semibold opacity-70 dark:bg-white/10">
-                      Token diario activo: {checkInUrl}
+                      {terminalText("Token diario activo", "Active daily token")}: {checkInUrl}
                     </p>
                   )}
                 </div>
@@ -868,24 +946,28 @@ export default function AsistenciaTerminalDisplay() {
                     className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-black uppercase tracking-[0.2em] 2xl:px-4 2xl:py-2 2xl:text-sm ${styles.badge}`}
                   >
                     {event.tipoMovimiento === "salida"
-                      ? "Salida registrada"
+                      ? terminalText("Salida registrada", "Exit registered")
                       : event.variant === "success"
-                        ? "Ingreso autorizado"
+                        ? terminalText("Ingreso autorizado", "Check-in authorized")
                         : event.variant === "debt"
-                          ? "Cuota pendiente"
+                          ? terminalText("Cuota pendiente", "Pending fee")
                           : event.variant === "inactive"
-                            ? "Ingreso bloqueado"
-                            : "Atención"}
+                            ? terminalText("Ingreso bloqueado", "Check-in blocked")
+                            : terminalText("Atención", "Attention")}
                   </span>
 
                   <h2
                     className={`mt-4 text-4xl font-black leading-tight tracking-tight md:text-5xl 2xl:text-6xl ${styles.title}`}
                   >
                     {event.tipoMovimiento === "salida"
-                      ? `¡Hasta luego, ${event.nombre}!`
+                      ? isEnglish
+                        ? `See you soon, ${event.nombre}!`
+                        : `¡Hasta luego, ${event.nombre}!`
                       : event.variant === "success"
-                        ? `¡Bienvenido, ${event.nombre}!`
-                        : event.title}
+                        ? isEnglish
+                          ? `Welcome, ${event.nombre}!`
+                          : `¡Bienvenido, ${event.nombre}!`
+                        : translateText(event.title)}
                   </h2>
 
                   {event.variant !== "success" && (
@@ -895,21 +977,21 @@ export default function AsistenciaTerminalDisplay() {
                   )}
 
                   <p className="mt-4 max-w-4xl text-xl font-semibold leading-relaxed md:text-2xl 2xl:text-3xl">
-                    {event.message}
+                    {translateText(event.message)}
                   </p>
 
                   <div className="mt-8 flex flex-wrap items-center justify-center gap-3 text-sm font-semibold opacity-80 lg:justify-start">
                     <span className="inline-flex items-center gap-2 rounded-full bg-black/10 px-4 py-2 dark:bg-white/10">
                       <Clock className="h-4 w-4" />
-                      Evento: {formatTime(event.timestamp)}
+                      {terminalText("Evento", "Event")}: {formatTime(event.timestamp)}
                     </span>
                     {event.idSocio && (
                       <span className="rounded-full bg-black/10 px-4 py-2 dark:bg-white/10">
-                        ID socio: {event.idSocio}
+                        {terminalText("ID socio", "Member ID")}: {event.idSocio}
                       </span>
                     )}
                     <span className="rounded-full bg-black/10 px-4 py-2 dark:bg-white/10">
-                      Volviendo al QR en 5 segundos
+                      {terminalText("Volviendo al QR en 5 segundos", "Returning to the QR in 5 seconds")}
                     </span>
                   </div>
                 </div>
@@ -921,10 +1003,10 @@ export default function AsistenciaTerminalDisplay() {
             <div className="flex shrink-0 items-center justify-between gap-3 border-b border-white/10 pb-3">
               <div>
                 <p className="text-sm font-bold uppercase tracking-[0.25em] text-cyan-300">
-                  Monitor externo
+                  {terminalText("Monitor externo", "External monitor")}
                 </p>
                 <h3 className="text-2xl font-black leading-tight 2xl:text-3xl">
-                  Actividad reciente
+                  {terminalText("Actividad reciente", "Recent activity")}
                 </h3>
               </div>
               <Wifi className="h-8 w-8 text-emerald-300" />
@@ -949,7 +1031,7 @@ export default function AsistenciaTerminalDisplay() {
                     }}
                   >
                     <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-black/50 px-3 py-1.5 text-xs font-black uppercase tracking-[0.2em] text-cyan-100 backdrop-blur 2xl:px-4 2xl:py-2 2xl:text-sm">
-                      <Megaphone className="h-4 w-4" /> Aviso
+                      <Megaphone className="h-4 w-4" /> {terminalText("Aviso", "Notice")}
                     </span>
                   </div>
                   <div className="space-y-3 p-5 pt-4 text-center 2xl:space-y-4 2xl:p-6 2xl:pt-5">
@@ -962,13 +1044,13 @@ export default function AsistenciaTerminalDisplay() {
                       {activeTerminalAd.cuerpo}
                     </p>
                     <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 2xl:text-sm">
-                      El QR permanece activo para asistencia
+                      {terminalText("El QR permanece activo para asistencia", "The QR remains active for attendance")}
                     </p>
                   </div>
                 </div>
               ) : recentItems.length === 0 ? (
                 <p className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-slate-300">
-                  Todavía no hay ingresos recientes para mostrar.
+                  {terminalText("Todavía no hay ingresos recientes para mostrar.", "There are no recent check-ins to show yet.")}
                 </p>
               ) : (
                 recentItems.map((item) => (
@@ -1011,21 +1093,18 @@ export default function AsistenciaTerminalDisplay() {
                                     : "bg-slate-400/20 text-slate-200"
                             }`}
                           >
-                            {item.tipoMovimiento === "salida"
-                              ? "Salida"
-                              : item.status === "success"
-                                ? "OK"
-                                : item.status === "debt"
-                                  ? "Deuda"
-                                  : item.status === "inactive"
-                                    ? "Bloqueado"
-                                    : "Info"}
+                            {getTerminalStatusLabel(
+                              item.status,
+                              item.tipoMovimiento,
+                              isEnglish,
+                            )}
                           </span>
                         </div>
                         <p className="mt-1 font-mono text-base font-bold text-slate-200 2xl:text-lg">
-                          {item.tipoMovimiento === "salida"
-                            ? "Salida"
-                            : "Ingreso"}
+                          {getTerminalMovementLabel(
+                            item.tipoMovimiento,
+                            isEnglish,
+                          )}
                           : {item.hora}
                         </p>
                       </div>
@@ -1036,9 +1115,10 @@ export default function AsistenciaTerminalDisplay() {
             </div>
 
             <div className="mt-auto shrink-0 rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-sm font-semibold leading-6 text-cyan-50 2xl:p-4 2xl:text-base">
-              Esta pantalla está pensada para el monitor externo. Muestra el QR
-              de ingreso y luego el resultado de la asistencia sin exponer menú,
-              pagos, usuarios ni datos administrativos.
+              {terminalText(
+                "Esta pantalla está pensada para el monitor externo. Muestra el QR de ingreso y luego el resultado de la asistencia sin exponer menú, pagos, usuarios ni datos administrativos.",
+                "This screen is designed for the external monitor. It shows the check-in QR and then the attendance result without exposing menus, payments, users or administrative data.",
+              )}
             </div>
           </aside>
         </div>

--- a/src/components/forms/AsistenciaForm.tsx
+++ b/src/components/forms/AsistenciaForm.tsx
@@ -15,6 +15,7 @@ import {
   updateAsistencia,
 } from "@/services/asistenciaService";
 import { toast } from "sonner";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export interface AsistenciaFormProps {
   asistencia?: Asistencia | null;
@@ -36,6 +37,9 @@ export default function AsistenciaForm({
 }: AsistenciaFormProps) {
   const [form, setForm] = useState(emptyForm);
   const [loading, setLoading] = useState(false);
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const attendanceText = (es: string, en: string) => (isEnglish ? en : es);
 
   useEffect(() => {
     if (asistencia) {
@@ -67,7 +71,7 @@ export default function AsistenciaForm({
           hora_egreso: form.hora_egreso || null,
         };
         await updateAsistencia(undefined as any, asistencia.id, updateData);
-        toast.success("Asistencia actualizada");
+        toast.success(attendanceText("Asistencia actualizada", "Attendance updated"));
       } else {
         const createData: CreateAsistenciaDto = {
           socio_id: form.id_socio,
@@ -76,15 +80,19 @@ export default function AsistenciaForm({
           hora_egreso: form.hora_egreso || null,
         };
         await createAsistencia(undefined as any, createData);
-        toast.success("Asistencia creada");
+        toast.success(attendanceText("Asistencia creada", "Attendance created"));
       }
       setForm(emptyForm);
       onCreated();
     } catch (error: unknown) {
-      let msg = (error as Error).message || "Error al guardar asistencia";
+      let msg =
+        (error as Error).message ||
+        attendanceText("Error al guardar asistencia", "Error saving attendance");
       if (msg.includes("value too long")) {
-        msg =
-          "Uno de los campos excede la cantidad máxima de caracteres permitidos.";
+        msg = attendanceText(
+          "Uno de los campos excede la cantidad máxima de caracteres permitidos.",
+          "One of the fields exceeds the maximum allowed number of characters.",
+        );
       }
       toast.error(msg);
     } finally {
@@ -99,11 +107,11 @@ export default function AsistenciaForm({
     >
       <QaFileNameBadge file="src/components/forms/AsistenciaForm.tsx" />
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="id_socio">ID Socio</Label>
+        <Label htmlFor="id_socio">{attendanceText("ID Socio", "Member ID")}</Label>
         <Input
           id="id_socio"
           name="id_socio"
-          placeholder="Ingrese ID del socio"
+          placeholder={attendanceText("Ingrese ID del socio", "Enter member ID")}
           value={form.id_socio}
           onChange={handleChange}
           required
@@ -111,7 +119,7 @@ export default function AsistenciaForm({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha">Fecha</Label>
+        <Label htmlFor="fecha">{attendanceText("Fecha", "Date")}</Label>
         <Input
           id="fecha"
           name="fecha"
@@ -123,7 +131,7 @@ export default function AsistenciaForm({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="hora_ingreso">Hora Ingreso</Label>
+        <Label htmlFor="hora_ingreso">{attendanceText("Hora Ingreso", "Check-in time")}</Label>
         <Input
           id="hora_ingreso"
           name="hora_ingreso"
@@ -136,12 +144,12 @@ export default function AsistenciaForm({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="hora_egreso">Hora Egreso</Label>
+        <Label htmlFor="hora_egreso">{attendanceText("Hora Egreso", "Check-out time")}</Label>
         <Input
           id="hora_egreso"
           name="hora_egreso"
           type="time"
-          placeholder="HH:MM (Opcional)"
+          placeholder={attendanceText("HH:MM (Opcional)", "HH:MM (Optional)")}
           value={form.hora_egreso}
           onChange={handleChange}
         />
@@ -153,10 +161,10 @@ export default function AsistenciaForm({
         disabled={loading}
       >
         {loading
-          ? "Guardando..."
+          ? attendanceText("Guardando...", "Saving...")
           : asistencia
-            ? "Actualizar Asistencia"
-            : "Registrar Asistencia"}
+            ? attendanceText("Actualizar Asistencia", "Update attendance")
+            : attendanceText("Registrar Asistencia", "Register attendance")}
       </Button>
 
       <Button
@@ -165,7 +173,7 @@ export default function AsistenciaForm({
         className="text-gray-800 bg-gray-200 col-span-full justify-self-end hover:bg-gray-300"
         disabled={loading}
       >
-        Cancelar
+        {attendanceText("Cancelar", "Cancel")}
       </Button>
     </form>
   );

--- a/src/components/forms/UserForm.tsx
+++ b/src/components/forms/UserForm.tsx
@@ -22,6 +22,8 @@ import {
 import { buildInitialPasswordFromDni, getPasswordPolicyChecks } from '@/utils/passwordPolicy';
 import { useCatalogosParametrizables } from '@/hooks/useCatalogosParametrizables';
 import type { CatalogoParametrizableItem, CatalogoParametrizableKey } from '@/interfaces/parametrizacion.interface';
+import { useI18n } from '@/i18n/I18nProvider';
+import { translateNavigationGroup, translateNavigationItem } from '@/i18n/navigationLabels';
 
 export interface UserFormProps {
   usuario?: Usuario | null;
@@ -204,6 +206,7 @@ export default function UserForm({
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const { catalogos } = useCatalogosParametrizables();
+  const { t } = useI18n();
 
   const tiposContratacion = useMemo(
     () => getCatalogItems(catalogos, 'empleado_tipo_contratacion', fallbackTiposContratacion),
@@ -849,30 +852,27 @@ export default function UserForm({
 
       <div className='col-span-full rounded-lg border bg-muted/20 p-4'>
         <div className='mb-3'>
-          <h3 className='text-base font-semibold'>Permisos de menú</h3>
+          <h3 className='text-base font-semibold'>{t('users.form.menuPermissions.title')}</h3>
           <p className='text-sm text-muted-foreground'>
-            Definí qué módulos verá este usuario al iniciar sesión. El administrador conserva acceso total.
+            {t('users.form.menuPermissions.description')}
           </p>
         </div>
 
         {isAdmin ? (
           <div className='rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-100'>
-            El rol administrador tiene control total del panel.
+            {t('users.form.menuPermissions.adminFullAccess')}
           </div>
         ) : (
           <>
             {isInternalUser && (
               <div className='mb-4 rounded-md border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-100'>
-                Este usuario interno puede representar a un empleado administrativo.
-                Marcá solo los módulos que podrá ver y utilizar. El menú lateral
-                mostrará únicamente las opciones habilitadas y las rutas no
-                permitidas quedarán bloqueadas por seguridad.
+{t('users.form.menuPermissions.internalUserHint')}
               </div>
             )}
             <div className='grid gap-4 md:grid-cols-2'>
               {availablePermissions.map((group) => (
               <div key={group.group} className='rounded-md border bg-background p-3'>
-                <p className='mb-2 text-sm font-semibold'>{group.group}</p>
+                <p className='mb-2 text-sm font-semibold'>{translateNavigationGroup(group.group, t)}</p>
                 <div className='space-y-2'>
                   {group.items.map((item) => {
                     const checked = form.permisos_menu.includes(item.key);
@@ -887,7 +887,7 @@ export default function UserForm({
                           onCheckedChange={() => togglePermission(item.key)}
                         />
                         <span>
-                          <span className='font-medium'>{item.label}</span>
+                          <span className='font-medium'>{translateNavigationItem(item.label, t)}</span>
                           <span className='block text-xs text-muted-foreground'>
                             {item.path}
                           </span>

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -30,6 +30,7 @@ import Image from 'next/image';
 import { useAuthStore } from '@/stores/authStore';
 import { LanguageSwitcher } from '@/components/i18n/LanguageSwitcher';
 import { useI18n } from '@/i18n/I18nProvider';
+import { translateNavigationTitle } from '@/i18n/navigationLabels';
 
 function useDarkMode() {
   const [dark, setDark] = React.useState(false);
@@ -64,6 +65,7 @@ export const AppHeader = ({ title }: AppHeaderProps) => {
   const { isMobile, setOpenMobile } = useSidebar();
   const { dark, toggle } = useDarkMode();
   const { t } = useI18n();
+  const translatedTitle = translateNavigationTitle(title, t);
 
   const handleLogout = () => {
     logout();
@@ -94,7 +96,7 @@ export const AppHeader = ({ title }: AppHeaderProps) => {
             className='shrink-0 rounded-sm dark:invert'
           />
           <h1 className='max-w-[34vw] truncate text-sm font-semibold tracking-tight sm:max-w-[46vw] sm:text-base md:max-w-none md:text-xl'>
-            {title}
+            {translatedTitle}
           </h1>
         </div>
 

--- a/src/components/i18n/DashboardInlineI18nSweep.tsx
+++ b/src/components/i18n/DashboardInlineI18nSweep.tsx
@@ -1,0 +1,812 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useI18n } from '@/i18n/I18nProvider';
+
+const TRANSLATIONS: Record<string, string> = {
+  'El Coach IA orienta y ayuda a organizar información del gimnasio. No reemplaza evaluación médica, nutricional ni profesional cuando hay lesiones, síntomas o condiciones clínicas.': 'The AI Coach guides and helps organize gym information. It does not replace medical, nutritional or professional evaluation when there are injuries, symptoms or clinical conditions.',
+  'La ficha médica es una herramienta administrativa y preventiva. No reemplaza diagnóstico ni indicación profesional. Ante alertas clínicas, derivar a un profesional de salud.': 'The medical record is an administrative and preventive tool. It does not replace diagnosis or professional indication. For clinical alerts, refer to a health professional.',
+  'Soy tu Coach IA de Gym Master. Puedo ayudarte con rutinas, dietas y evolución física usando tu contexto del gimnasio cuando esté disponible.': 'I am your Gym Master AI Coach. I can help you with routines, diets and physical evolution using your gym context when available.',
+  'Listado operativo con acceso rápido al perfil 360° del socio: cuota, ficha médica, rutinas, dietas, evolución, mensajes y actividades.': 'Operational list with quick access to the member 360° profile: fee, medical record, routines, diets, evolution, messages and activities.',
+  'Consultá rutinas, dietas y evolución física con continuidad conversacional, contexto operativo y recomendaciones más personalizadas.': 'Consult routines, diets and physical evolution with conversational continuity, operational context and more personalized recommendations.',
+  'Centralizá datos clínicos básicos, apto médico, adjuntos e historial para una revisión rápida antes de entrenamientos o actividades.': 'Centralize basic clinical data, medical clearance, attachments and history for a quick review before workouts or activities.',
+  'Esta pantalla está optimizada para la vista del socio. Para gestionar dietas por socio, usá el Gestor de Dietas.': 'This screen is optimized for the member view. To manage diets by member, use the Diet Manager.',
+  'Buscá por nombre, DNI, email o teléfono y abrí la ficha actual, historial o nueva carga del socio seleccionado.': 'Search by name, ID, email or phone and open the selected member current record, history or new entry.',
+  'Todavía no hay memoria contextual calculada. Enviá una consulta para que el Coach lea el contexto del socio.': 'There is no contextual memory calculated yet. Send a query so the Coach can read the member context.',
+  'Usá el botón 360 para revisar el estado completo antes de contactar o gestionar al socio.': 'Use the 360 button to review the full status before contacting or managing the member.',
+  'La foto ayuda a validar identidad en recepción, asistencia y atención administrativa.': 'The photo helps validate identity at reception, attendance and administrative care.',
+  'Socios que solicitaron inscripción desde mobile y esperan aprobación administrativa.': 'Members who requested enrollment from mobile and are waiting for administrative approval.',
+  'Consultá las dietas asignadas y generá nuevos planes alimentarios para los socios.': 'Review assigned diets and create new meal plans for members.',
+  'Solicitar o revisar ficha médica antes de sostener actividades de mayor exigencia.': 'Request or review the medical record before supporting more demanding activities.',
+  'Resumen transversal para evitar saltar entre pantallas durante soporte o atención': 'Cross-module summary to avoid jumping between screens during support or care',
+  'Las ubicaciones se administran desde Parametrización → Ubicaciones del gimnasio.': 'Locations are managed from Parameterization → Gym locations.',
+  'Control de clases por día, cupos disponibles, ocupación y lista de espera.': 'Control classes by day, available slots, occupancy and waitlist.',
+  'Si el cupo está completo, el socio pasa automáticamente a lista de espera.': 'If capacity is full, the member is automatically moved to the waitlist.',
+  'Ocupación por actividad, distribución semanal y estado de inscripciones.': 'Occupancy by activity, weekly distribution and enrollment status.',
+  'Contame tu objetivo, disponibilidad semanal, nivel y restricciones.': 'Tell me your goal, weekly availability, level and restrictions.',
+  'Filtrá, exportá y abrí el perfil 360° desde la acción de cada fila.': 'Filter, export and open the 360° profile from each row action.',
+  'Definí horario, cupo, instructor, ubicación y estado operativo.': 'Define schedule, capacity, instructor, location and operational status.',
+  'Escribí tu consulta: quiero rutina, dieta, revisar progreso...': 'Write your query: I want a routine, diet, review progress...',
+  'Quiero una rutina para ganar masa muscular 3 días por semana': 'I want a routine to gain muscle mass 3 days per week',
+  'Genera planes usando objetivo, nivel, días y restricciones.': 'Generates plans using goal, level, days and restrictions.',
+  'Crea orientación nutricional con disclaimers de seguridad.': 'Creates nutritional guidance with safety disclaimers.',
+  'No hay socios en lista de espera pendientes de aprobación.': 'There are no waitlisted members pending approval.',
+  'Marcá asistencia, ausencia, cancelación o lista de espera.': 'Mark attendance, absence, cancellation or waitlist.',
+  'Quiero una dieta para bajar grasa sin perder músculo': 'I want a diet to lose fat without losing muscle',
+  'Base de actividades usada para crear turnos y cupos.': 'Activity base used to create shifts and slots.',
+  'Acciones claras para ver rutina, dieta o evolución.': 'Clear actions to view routine, diet or evolution.',
+  'Analiza progreso físico y sugiere próximos ajustes.': 'Analyzes physical progress and suggests next adjustments.',
+  'Socios inactivos o con señales operativas críticas.': 'Inactive members or with critical operational signals.',
+  'Requieren contacto o normalización administrativa.': 'Require contact or administrative normalization.',
+  'No sé por dónde empezar, quiero mejorar mi físico': 'I do not know where to start, I want to improve my fitness',
+  'Socios con alguna señal de seguimiento detectada.': 'Members with a detected follow-up signal.',
+  'señal(es) para priorizar atención administrativa.': 'signal(s) to prioritize administrative attention.',
+  'Chat unificado · Rutinas · Dietas · Evolución': 'Unified chat · Routines · Diets · Evolution',
+  'Estoy estancado, analizá mi evolución física': 'I am stuck, analyze my physical evolution',
+  'Buscá y revisá planes alimentarios cargados.': 'Search and review loaded meal plans.',
+  'Coach IA con memoria contextual del socio': 'AI Coach with member contextual memory',
+  'Alta de socios desde Usuarios → rol Socio': 'Create members from Users → member role',
+  'Diseño responsive sin scroll horizontal.': 'Responsive design without horizontal scroll.',
+  'Fallback seguro para señales sensibles.': 'Safe fallback for sensitive signals.',
+  'Contexto operativo del socio resumido.': 'Summarized operational member context.',
+  'Listado de actividades registradas.': 'Registered activities list.',
+  'Ficha médica pendiente de revisión': 'Medical record pending review',
+  'Requieren revisión administrativa': 'Require administrative review',
+  'Perfiles con contacto de respaldo': 'Profiles with backup contact',
+  'Buscar turno, actividad, zona...': 'Search shift, activity, area...',
+  'Memoria conversacional visible.': 'Visible conversational memory.',
+  'Consolidado operativo del socio': 'Operational member summary',
+  'Seleccionar socio para revisar': 'Select member to review',
+  'Turnos, cupos e inscripciones': 'Shifts, slots and enrollments',
+  'Buscar dieta u objetivo...': 'Search diet or goal...',
+  'REVISIÓN MÉDICA OPERATIVA': 'OPERATIONAL MEDICAL REVIEW',
+  'Pueden operar normalmente': 'Can operate normally',
+  'Buscar por nombre, DNI...': 'Search by name, ID...',
+  'VISTA 360 ADMINISTRATIVA': 'ADMINISTRATIVE 360 VIEW',
+  'Foto de perfil pendiente': 'Profile photo pending',
+  'PANEL DE REVISIÓN ADMIN': 'ADMIN REVIEW PANEL',
+  'VISTA DE REVISIÓN ADMIN': 'ADMIN REVIEW VIEW',
+  'Problemas respiratorios': 'Respiratory problems',
+  'VISTA 360 ADMINISTRADOR': 'ADMINISTRATOR 360 VIEW',
+  'Estado de inscripciones': 'Enrollment status',
+  'Sin instructor asignado': 'No instructor assigned',
+  'Inscripciones recientes': 'Recent enrollments',
+  'Catálogo de actividades': 'Activity catalog',
+  'Ficha médica del socio': 'Member medical record',
+  'controles de evolución': 'evolution checks',
+  'Contacto de emergencia': 'Emergency contact',
+  'Teléfono de emergencia': 'Emergency phone',
+  'Solicitudes pendientes': 'Pending requests',
+  'Enfermedades crónicas': 'Chronic diseases',
+  'ALERTAS DE RIESGO 360': '360 RISK ALERTS',
+  'Seleccionar actividad': 'Select activity',
+  'Seleccionar ubicación': 'Select location',
+  'Confianza: Pendiente': 'Confidence: Pending',
+  'Checklist de calidad': 'Quality checklist',
+  'Base total de socios': 'Total member base',
+  'Contacto y ubicación': 'Contact and location',
+  'BI de turnos y cupos': 'Shifts and slots BI',
+  'Crear / editar turno': 'Create / edit shift',
+  'Total de actividades': 'Total activities',
+  'Historial de Dietas': 'Diet history',
+  'Descargar ficha PDF': 'Download medical PDF',
+  'Frecuencia cardíaca': 'Heart rate',
+  'Problemas cardíacos': 'Heart problems',
+  'Fecha de nacimiento': 'Birth date',
+  'Nombre del contacto': 'Contact name',
+  'Buscar actividad...': 'Search activity...',
+  'Memoria contextual': 'Contextual memory',
+  'Socio seleccionado': 'Selected member',
+  'Lectura rápida 360': 'Quick 360 reading',
+  'GESTIÓN DE DIETAS': 'DIET MANAGEMENT',
+  'Registrar control': 'Register check',
+  'Controles previos': 'Previous checks',
+  'Atención integral': 'Comprehensive care',
+  'Listado de socios': 'Member list',
+  'Módulos del socio': 'Member modules',
+  'Todos los estados': 'All statuses',
+  'Actividad / turno': 'Activity / shift',
+  'Dietas de socios': 'Member diets',
+  'PRÓXIMA REVISIÓN': 'NEXT REVIEW',
+  'Historial médico': 'Medical history',
+  'Cirugías previas': 'Previous surgeries',
+  'Próxima revisión': 'Next review',
+  'Seguimiento leve': 'Light follow-up',
+  'Actividad física': 'Physical activity',
+  'Datos personales': 'Personal data',
+  'Actualizar Socio': 'Update Member',
+  'Nombre del turno': 'Shift name',
+  'Añadir Actividad': 'Add Activity',
+  'Nombre Actividad': 'Activity Name',
+  'Qué puede hacer': 'What it can do',
+  'Nota importante': 'Important note',
+  'Buscar socio...': 'Search member...',
+  'Grupo sanguíneo': 'Blood type',
+  'ESTADO DE CUOTA': 'FEE STATUS',
+  'Nombre completo': 'Full name',
+  'Inscribir socio': 'Enroll member',
+  'Lista de espera': 'Waitlist',
+  'Datos vigentes': 'Current data',
+  'Último control': 'Last check',
+  'CON EMERGENCIA': 'WITH EMERGENCY',
+  'Foto pendiente': 'Photo pending',
+  'Turnos por día': 'Shifts by day',
+  'Vigencia desde': 'Valid from',
+  'Vigencia hasta': 'Valid until',
+  'Todos los días': 'All days',
+  'Actualizado En': 'Updated On',
+  'Próximo paso:': 'Next step:',
+  'Observaciones': 'Notes',
+  'Descargar PDF': 'Download PDF',
+  'Fecha de alta': 'Registration date',
+  'Cupos totales': 'Total slots',
+  'Día y horario': 'Day and time',
+  'Ficha actual': 'Current record',
+  'Sin adjuntos': 'No attachments',
+  'RIESGO MEDIO': 'MEDIUM RISK',
+  'Socio activo': 'Active member',
+  'Riesgo medio': 'Medium risk',
+  'Ficha médica': 'Medical record',
+  'Editar Socio': 'Edit Member',
+  'Lista espera': 'Waitlist',
+  'Nueva Dieta': 'New Diet',
+  'REGISTRADOS': 'REGISTERED',
+  'RIESGO ALTO': 'HIGH RISK',
+  'CON ALERTAS': 'WITH ALERTS',
+  'Actividades': 'Activities',
+  'Cupo máximo': 'Maximum capacity',
+  'Cupo mínimo': 'Minimum capacity',
+  'Crear turno': 'Create shift',
+  'Disponibles': 'Available',
+  'respuestas': 'responses',
+  'Presentado': 'Submitted',
+  'DOCUMENTOS': 'DOCUMENTS',
+  'Medicación': 'Medication',
+  'Socios 360': 'Members 360',
+  'Fecha Alta': 'Created date',
+  'Desactivar': 'Deactivate',
+  'Instructor': 'Instructor',
+  'Actualizar': 'Refresh',
+  'pendientes': 'pending',
+  'Reiniciar': 'Restart',
+  'Evolución': 'Evolution',
+  'Historial': 'History',
+  'INACTIVOS': 'INACTIVE',
+  'Ver ficha': 'View record',
+  'Dirección': 'Address',
+  'Provincia': 'Province',
+  'Masculino': 'Male',
+  'Inscritos': 'Enrolled',
+  'Ocupación': 'Occupancy',
+  'Actividad': 'Activity',
+  'Ubicación': 'Location',
+  'Inscripto': 'Enrolled',
+  'Cancelado': 'Cancelled',
+  'Creado En': 'Created On',
+  'Miércoles': 'Wednesday',
+  'acciones': 'actions',
+  'Imprimir': 'Print',
+  'Exportar': 'Export',
+  'Revisión': 'Review',
+  'Contacto': 'Contact',
+  'Alergias': 'Allergies',
+  'Lesiones': 'Injuries',
+  'Teléfono': 'Phone',
+  'Acciones': 'Actions',
+  'Mensajes': 'Messages',
+  'Femenino': 'Female',
+  'Eliminar': 'Delete',
+  'fuentes': 'sources',
+  'Rutinas': 'Routines',
+  'Activos': 'Active',
+  'Presión': 'Blood pressure',
+  'ACTIVOS': 'ACTIVE',
+  'rutinas': 'routines',
+  'Asistió': 'Attended',
+  'Ausente': 'Absent',
+  'Viernes': 'Friday',
+  'Domingo': 'Sunday',
+  'Enviar': 'Send',
+  'Dietas': 'Diets',
+  'Socios': 'Members',
+  'Estado': 'Status',
+  'Activo': 'Active',
+  'Actual': 'Current',
+  'Altura': 'Height',
+  'Nombre': 'Name',
+  'Riesgo': 'Risk',
+  'Cuotas': 'Fees',
+  'Al día': 'Up to date',
+  'Medias': 'Medium',
+  'Ciudad': 'City',
+  'Turnos': 'Shifts',
+  'Inicio': 'Start',
+  'Espera': 'Wait',
+  'activo': 'active',
+  'Editar': 'Edit',
+  'Martes': 'Tuesday',
+  'Jueves': 'Thursday',
+  'Sábado': 'Saturday',
+  'Lista': 'Ready',
+  'Nueva': 'New',
+  'Todos': 'All',
+  'Altas': 'High',
+  'Leves': 'Low',
+  'Cupos': 'Slots',
+  'Turno': 'Shift',
+  'Socio': 'Member',
+  'Fecha': 'Date',
+  'Lunes': 'Monday',
+  'Hola': 'Hello',
+  'Modo': 'Mode',
+  'Peso': 'Weight',
+  'Sexo': 'Sex',
+  'País': 'Country',
+  'DNI': 'ID',
+  'Día': 'Day',
+  'Ver': 'View',
+  'Con emergencia': 'WITH EMERGENCY',
+  'Riesgo alto': 'HIGH RISK',
+  'Con alertas': 'WITH ALERTS',
+  'actividades': 'activities',
+  'No se encontraron socios para esa búsqueda.': 'No members were found for that search.',
+  'Sin DNI cargado': 'No ID loaded',
+  'Selector rápido': 'Quick selector',
+  'Seleccionar socio': 'Select member',
+  'Aclaración opcional': 'Optional note',
+  'Inscribiendo...': 'Enrolling...',
+  'Routine assistant': 'Routine assistant',
+  'Asistente de Rutinas': 'Routine assistant',
+  'Asistente inteligente': 'Smart assistant',
+  'Contale qué rutina necesitás': 'Tell it what routine you need',
+  'Escribí o dictá tu pedido con tus palabras. El asistente va a interpretar tu objetivo, días disponibles, nivel, prioridades y restricciones antes de generar la rutina.': 'Write or dictate your request in your own words. The assistant will interpret your goal, available days, level, priorities and restrictions before generating the routine.',
+  'Ejemplo': 'Example',
+  'Ayuda': 'Help',
+  'Cómo pedir tu rutina': 'How to ask for your routine',
+  'Podés escribir como hablás. No hace falta usar palabras técnicas.': 'You can write the way you speak. There is no need to use technical words.',
+  'Qué conviene contar': 'What is useful to mention',
+  'Qué querés lograr: ganar masa muscular, bajar de peso, definir, fuerza o resistencia.': 'What you want to achieve: gain muscle mass, lose weight, define, strength or endurance.',
+  'Cuántos días podés entrenar por semana.': 'How many days per week you can train.',
+  'Tu nivel aproximado: principiante, intermedio o avanzado.': 'Your approximate level: beginner, intermediate or advanced.',
+  'Si querés priorizar algún grupo muscular.': 'If you want to prioritize any muscle group.',
+  'Si tenés lesiones, molestias o algo que el asistente deba cuidar.': 'If you have injuries, discomfort or anything the assistant should take care of.',
+  'Objetivos posibles': 'Possible goals',
+  'Podés pedir volumen, definición, bajar de peso, fuerza, resistencia o volver a entrenar de a poco.': 'You can ask for bulking, definition, weight loss, strength, endurance or returning to training gradually.',
+  'Frecuencia muscular': 'Muscle frequency',
+  'Si entrenás pocos días, normalmente se reparte el cuerpo completo o torso/pierna. Si entrenás 5 o 6 días, se puede tocar cada grupo muscular una o dos veces por semana según tu objetivo y recuperación.': 'If you train only a few days, the routine is usually full body or upper/lower. If you train 5 or 6 days, each muscle group can be worked one or two times per week depending on your goal and recovery.',
+  'Quiero bajar de peso. Puedo entrenar 4 días por semana y soy principiante.': 'I want to lose weight. I can train 4 days per week and I am a beginner.',
+  'Quiero una rutina de fuerza de 5 días. Soy avanzado, pero tengo molestias lumbares.': 'I want a 5-day strength routine. I am advanced, but I have lower back discomfort.',
+  'Hace tiempo que no entreno y quiero volver de a poco. Puedo ir 3 veces por semana.': 'I have not trained in a while and I want to come back gradually. I can go 3 times per week.',
+  'Tu pedido': 'Your request',
+  'Estás ingresando como admin. Esta experiencia está orientada al socio logueado.': 'You are entering as admin. This experience is aimed at the logged-in member.',
+  'Escribí o dictá tu pedido': 'Write or dictate your request',
+  'Dictar texto con el micrófono': 'Dictate text with the microphone',
+  'Dictado no disponible en este navegador': 'Dictation is not available in this browser',
+  'Detener dictado': 'Stop dictation',
+  'Dictar con voz': 'Voice dictation',
+  'Voz no disponible': 'Voice unavailable',
+  'Ejemplo: quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia.': 'Example: I want to gain muscle mass, train 6 days, prioritize back and shoulders. I am intermediate and I have lower back pain.',
+  'Dictado continuo activo. Podés pausar al hablar; detenelo cuando termines.': 'Continuous dictation is active. You can pause while speaking; stop it when you finish.',
+  'Incluí objetivo y días para que el asistente pueda interpretar mejor tu rutina.': 'Include your goal and days so the assistant can better interpret your routine.',
+  'Escuchando:': 'Listening:',
+  'Algo que el asistente deba cuidar': 'Anything the assistant should take care of',
+  'Ejemplo: lumbalgia, dolor de rodilla, evitar impacto, prefiero máquinas.': 'Example: lower back pain, knee pain, avoid impact, I prefer machines.',
+  'Idioma': 'Language',
+  'Español': 'Spanish',
+  'Disponible para socio': 'Available for member',
+  'Confirmar y generar rutina': 'Confirm and generate routine',
+  'Revisar pedido': 'Review request',
+  'Ver mis rutinas': 'View my routines',
+  'Resumen interpretado': 'Interpreted summary',
+  'Objetivo': 'Goal',
+  'Nivel': 'Level',
+  'Frecuencia': 'Frequency',
+  'Prioridades': 'Priorities',
+  'Cuidado detectado': 'Detected care',
+  'Revisá estos datos. Si están bien, confirmá para generar la rutina.': 'Review this data. If it is correct, confirm to generate the routine.',
+  'Rutina generada': 'Routine generated',
+  'Conocimiento RAG aplicado': 'Applied RAG knowledge',
+  'Se recuperaron': 'Recovered',
+  'referencias de ejercicios reales para orientar la rutina.': 'real exercise references to guide the routine.',
+  'Advertencias técnicas': 'Technical warnings',
+  'Ir al menú Rutinas': 'Go to Routines menu',
+  'por defecto': 'by default',
+  'días por semana': 'days per week',
+  'Loading...': 'Loading...',
+  'Cargando...': 'Loading...',
+  'No members were found for that search.': 'No members were found for that search.',
+  'Registrados': 'Registered',
+  'Vista 360 administrador': 'Administrator 360 view',
+  'care administrativa.': 'administrative care.',
+  'Sin novedades': 'No updates',
+  'Última actualización:': 'Last update:',
+  'Abrir módulo': 'Open module',
+  'Evolution física': 'Physical evolution',
+  'Seguimiento corporal': 'Body tracking',
+  'Sin inscripciones activas': 'No active enrollments',
+  'inscriptas': 'enrolled',
+  'Señales útiles para atención, retención y seguimiento administrativo.': 'Useful signals for care, retention and administrative follow-up.',
+  'Seguimiento saludable': 'Healthy follow-up',
+  'Conviene solicitar o revisar ficha médica vigente.': 'It is advisable to request or review a current medical record.',
+  'Edad': 'Age',
+  'Alertas de riesgo 360': '360 risk alerts',
+  'Sin estado': 'No status',
+  'Sin datos': 'No data',
+  'Última revisión:': 'Last review:',
+  '0 pending · 0 inscriptas': '0 pending · 0 enrolled',
+  'Member list registrados con lectura rápida de riesgo.': 'Member list registered with quick risk reading.',
+  'Última revisión': 'Last review',
+  'física': 'physical',
+  'Status de cuota': 'Fee status',
+  'STATUS DE CUOTA': 'FEE STATUS',
+  'Status general': 'Overall status',
+  'Risk administrativo': 'Administrative risk',
+  'Puede operar normalmente como socio active.': 'The member can operate normally as an active member.',
+  'Light follow-up: revisar las alertas 360 antes de cerrar la atención.': 'Light follow-up: review the 360 alerts before closing the case.',
+  'Date alta': 'Registration date',
+  'Contact emergencia': 'Emergency contact',
+  'Phone emergencia': 'Emergency phone',
+  'Descuento active': 'Active discount',
+  'status de cuota': 'fee status',
+  'status general': 'overall status',
+  'risk administrativo': 'administrative risk',
+  'contact emergencia': 'emergency contact',
+  'phone emergencia': 'emergency phone',
+  'descuento active': 'active discount',
+  'Confianza:': 'Confidence:',
+  'Confianza': 'Confidence',
+  'Pendiente': 'Pending',
+  '“Quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia.”': '“I want to gain muscle mass, train 6 days, prioritize back and shoulders. I am intermediate and I have lower back pain.”',
+  '"Quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia."': '"I want to gain muscle mass, train 6 days, prioritize back and shoulders. I am intermediate and I have lower back pain."',
+  'Quiero ganar masa muscular, entrenar 6 días, priorizar espalda y hombros. Soy intermedio y tengo lumbalgia.': 'I want to gain muscle mass, train 6 days, prioritize back and shoulders. I am intermediate and I have lower back pain.',
+  'gestión de dietas': 'diet management',
+  'GESTION DE DIETAS': 'DIET MANAGEMENT',
+  'Gestión de dietas': 'Diet management',
+  'Goal nutricional': 'Nutritional goal',
+  'Objetivo nutricional': 'Nutritional goal',
+  'Seleccione objetivo': 'Select goal',
+  'Date inicio': 'Start date',
+  'Fecha inicio': 'Start date',
+  'Date fin': 'End date',
+  'Fecha fin': 'End date',
+  'Pedido u objetivo del socio': 'Member request or goal',
+  'Restricciones o cuidados': 'Restrictions or precautions',
+  'Preferencias alimentarias': 'Food preferences',
+  'Generar dieta': 'Generate diet',
+  'Generando...': 'Generating...',
+  'Cerrar': 'Close',
+  'Ejemplo: quiero bajar grasa sin perder músculo, entreno 3 días y necesito comidas simples.': 'Example: I want to lose fat without losing muscle, I train 3 days and I need simple meals.',
+  'Example: quiero bajar grasa sin perder músculo, entreno 3 días y necesito comidas simples.': 'Example: I want to lose fat without losing muscle, I train 3 days and I need simple meals.',
+  'Ejemplo: hipertensión, diabetes, alergias, intolerancias, medicación, embarazo.': 'Example: hypertension, diabetes, allergies, intolerances, medication, pregnancy.',
+  'Example: hipertensión, diabetes, alergias, intolerancias, medicación, embarazo.': 'Example: hypertension, diabetes, allergies, intolerances, medication, pregnancy.',
+  'Ejemplo: prefiero pollo, arroz, verduras, sin lactosa, económico y fácil de preparar.': 'Example: I prefer chicken, rice, vegetables, lactose-free, affordable and easy to prepare.',
+  'Example: prefiero pollo, arroz, verduras, sin lactosa, económico y fácil de preparar.': 'Example: I prefer chicken, rice, vegetables, lactose-free, affordable and easy to prepare.',
+  'Volumen': 'Volume',
+  'Definición': 'Definition',
+  'Bajar de peso': 'Lose weight',
+  'Aumentar fuerza': 'Increase strength',
+  'Mejorar resistencia': 'Improve endurance',
+  'Mantenimiento': 'Maintenance',
+  'Ganar masa muscular': 'Gain muscle mass',
+  'Bajar grasa sin perder masa muscular': 'Lose fat without losing muscle mass',
+  'Review médica operativa': 'Operational medical review',
+  'REVIEW MÉDICA OPERATIVA': 'OPERATIONAL MEDICAL REVIEW',
+  'Vista de revisión admin': 'Admin review view',
+  'Panel de revisión admin': 'Admin review panel',
+  'APTO MÉDICO': 'MEDICAL CLEARANCE',
+  'Apto médico': 'Medical clearance',
+  'Documentos': 'Documents',
+  'Archivos adjuntos': 'Attachments',
+  'Cargando datos socios...': 'Loading member data...',
+  'Cargando datos de socios...': 'Loading member data...',
+  'Members · vista administrativa': 'Members · administrative view',
+  'Members · Vista administrativa': 'Members · Administrative view',
+  'vista administrativa': 'administrative view',
+  'Vista administrativa': 'Administrative view',
+  'VISTA ADMINISTRATIVA': 'ADMINISTRATIVE VIEW',
+  'Total de socios': 'Total members',
+  'total de socios': 'total members',
+  'TOTAL DE SOCIOS': 'TOTAL MEMBERS',
+  'Evolution demo mensual para BI y recorrido del socio.': 'Monthly evolution demo for BI and member journey.',
+  'Fin': 'End'
+};
+
+const TRANSLATION_ENTRIES = Object.entries(TRANSLATIONS).sort(
+  ([a], [b]) => b.length - a.length,
+);
+
+const EXACT_ONLY_TRANSLATIONS: Record<string, string> = {
+  'Dentro ahora': 'Inside now',
+  'Capacidad configurada': 'Configured capacity',
+  'Ocupación': 'Occupancy',
+  'Ocupación normal. Hay disponibilidad operativa.': 'Normal occupancy. Operational capacity is available.',
+  'Ocupación moderada. El gimnasio opera con margen disponible.': 'Moderate occupancy. The gym is operating with available margin.',
+  'Ocupación alta. Recomendado monitorear accesos y horarios pico.': 'High occupancy. Monitor access points and peak hours.',
+  'Listado de Asistencias': 'Attendance roster',
+  'Readydo de Asistencias': 'Attendance roster',
+  'Añadir Asistencia': 'Add attendance',
+  'Todos los períodos': 'All periods',
+  'All los períodos': 'All periods',
+  'Últimos 7 días': 'Last 7 days',
+  'Mes actual': 'Current month',
+  'Año actual': 'Current year',
+  'Salida / Aforo': 'Exit / Capacity',
+  'Modo terminal': 'Terminal mode',
+  'Mode terminal': 'Terminal mode',
+  'Actualización automática cada': 'Automatic refresh every',
+  'Currentización automática cada': 'Automatic refresh every',
+  'Sincronizando asistencias...': 'Syncing attendances...',
+  'Última actualización': 'Last update',
+  'Name de Member': 'Member name',
+  'Nombre de Socio': 'Member name',
+  'Hora Ingreso': 'Check-in time',
+  'Hora Egreso': 'Check-out time',
+  'Total de asistencias': 'Total attendances',
+  'Listado de asistencias registradas.': 'Registered attendance list.',
+  'Readydo de asistencias registradas.': 'Registered attendance list.',
+  'asistencias ordenadas por ingreso reciente.': 'attendances ordered by recent check-in.',
+  'Empleado *': 'Employee *',
+  'Período *': 'Period *',
+  'Periodo *': 'Period *',
+  'Concepto': 'Concept',
+  'URL de comprobante': 'Receipt URL',
+  'URL comprobante': 'Receipt URL',
+  'Empleado:': 'Employee:',
+  'Base:': 'Base:',
+  'Bonos:': 'Bonuses:',
+  'Neto:': 'Net:',
+  'Sueldo mensual demo': 'Monthly salary demo',
+  'sueldo demo': 'salary demo',
+  'qa_demo_database_seed_large_20260607 - sueldo demo': 'qa_demo_database_seed_large_20260607 - salary demo',
+  'dd/mm/aaaa': 'dd/mm/yyyy',
+  'Registros': 'Records',
+  'Total neto': 'Total net',
+  'Pagado': 'Paid',
+  'Pagados': 'Paid',
+  'Pendiente': 'Pending',
+  'Pendientes': 'Pending',
+  'pending': 'Pending',
+  'pendiente': 'Pending',
+  'Anulado': 'Canceled',
+  'Anulados': 'Canceled',
+  'anulado': 'Canceled',
+  'Sueldos de empleados': 'Employee salaries',
+  'Registro opcional de liquidaciones, pagos y recibos del personal.': 'Optional record of payroll settlements, payments and staff receipts.',
+  'Período': 'Period',
+  'Periodo': 'Period',
+  'Base': 'Base',
+  'Bonos': 'Bonuses',
+  'Desc.': 'Disc.',
+  'Neto': 'Net',
+  'Estado': 'Status',
+  'Pago': 'Payment',
+  'Acciones': 'Actions',
+  'Buscar empleado, DNI, concepto, medio...': 'Search employee, ID, concept, payment method...',
+  'Mostrando': 'Showing',
+  'registros.': 'records.',
+  'Detalle de sueldo': 'Salary detail',
+  'Editar sueldo': 'Edit salary',
+  'Nuevo sueldo': 'New salary',
+  'Bonos / adicionales': 'Bonuses / additions',
+  'Descuentos': 'Discounts',
+  'Monto neto': 'Net amount',
+  'Medio de pago': 'Payment method',
+  'Fecha de pago': 'Payment date',
+  'Comprobante': 'Receipt',
+  'Observaciones': 'Notes',
+  'Sin observaciones.': 'No notes.',
+  'Abrir comprobante': 'Open receipt',
+  'Descargar recibo PDF': 'Download receipt PDF',
+  'Sueldo mensual': 'Monthly salary',
+  'Seleccionar empleado': 'Select employee',
+  'Transferencia': 'Bank transfer',
+  'Efectivo': 'Cash',
+  'Tarjeta débito': 'Debit card',
+  'Tarjeta crédito': 'Credit card',
+  'Otro': 'Other',
+  'Registrar sueldo': 'Register salary',
+  'Guardar cambios': 'Save changes',
+  'Resumen de liquidación': 'Payroll summary',
+  'Sin seleccionar': 'Not selected',
+  'No hay sueldos registrados para los filtros seleccionados.': 'No salaries registered for the selected filters.',
+  'Empleado activo': 'Active employee',
+  'Empleado active': 'Active employee',
+  'Puesto, área y turno se cargan desde combos base para mantener datos homogéneos. Más adelante estos valores podrán moverse a catálogos parametrizables administrados por cada gimnasio.': 'Position, area and shift are loaded from base combos to keep data consistent. Later these values may move to configurable catalogs managed by each gym.',
+  'Este empleado es administrativo. En una próxima feature se desplegarán aquí los permisos de menú/RBAC para definir qué módulos puede ver y utilizar.': 'This employee is administrative. In a future feature, menu/RBAC permissions will be displayed here to define which modules they can view and use.',
+  'Refresh empleado': 'Refresh employee',
+  'Actualizar empleado': 'Update employee',
+  'Edit empleado': 'Edit employee',
+  'Editar empleado': 'Edit employee',
+  'Edit Empleado': 'Edit employee',
+  'Tipo de empleado': 'Employee type',
+  'Tipo de Empleado': 'Employee type',
+  'Puesto / responsabilidad': 'Position / responsibility',
+  'Puesto / Responsabilidad': 'Position / responsibility',
+  'Sueldo base de referencia': 'Reference base salary',
+  'Sueldo base referencia': 'Reference base salary',
+  'Notes internas': 'Internal notes',
+  'Notas internas': 'Internal notes',
+  'Detalle de empleado': 'Employee detail',
+  'Detalle de Empleado': 'Employee detail',
+  'Puesto': 'Position',
+  'Área': 'Area',
+  'Area': 'Area',
+  'Registration date': 'Registration date',
+  'Fecha de alta': 'Registration date',
+  'Date de inicio laboral': 'Employment start date',
+  'Fecha de inicio laboral': 'Employment start date',
+  'Inicio laboral': 'Employment start date',
+  'Date de baja laboral': 'Employment end date',
+  'Fecha de baja laboral': 'Employment end date',
+  'Baja laboral': 'Employment end date',
+  'Tipo de contratación': 'Employment type',
+  'Sueldo base': 'Base salary',
+  'Horarios / disponibilidad': 'Schedule / availability',
+  'Horario / disponibilidad': 'Schedule / availability',
+  'mensual': 'Monthly',
+  'Mensual': 'Monthly',
+  'Tarde': 'Afternoon',
+  'Administración y caja': 'Administration and cash desk',
+  'Monday a viernes de 15:00 a 18:00': 'Monday to Friday from 15:00 to 18:00',
+  'lunes a viernes de 15:00 a 18:00': 'Monday to Friday from 15:00 to 18:00',
+  'Lunes a viernes de 15:00 a 18:00': 'Monday to Friday from 15:00 to 18:00',
+  'Total empleados': 'Total employees',
+  'Total de empleados': 'Total employees',
+  'Administrativos': 'Administrative',
+  'Nómina estimada': 'Estimated payroll',
+  'Listado de Empleados': 'Employee roster',
+  'Listado de empleados': 'Employee roster',
+  'Readydo de Empleados': 'Employee roster',
+  'Readydo de empleados': 'Employee roster',
+  'Readydos de Empleados': 'Employee roster',
+  'Readydos de empleados': 'Employee roster',
+  'Gestión integral de empleados, responsabilidades y base para sueldos/RBAC.': 'Comprehensive employee management, responsibilities and payroll/RBAC base.',
+  'Todos los tipos': 'All types',
+  'All los tipos': 'All types',
+  'Añadir Empleado': 'Add employee',
+  'Empleado': 'Employee',
+  'Tipo': 'Type',
+  'Área / puesto': 'Area / position',
+  'Alta': 'Hire date',
+  'Sueldo ref.': 'Reference salary',
+  'Listado de empleados registrados.': 'Registered employee list.',
+  'Readydo de empleados registrados.': 'Registered employee list.',
+  'Readydos de empleados registrados.': 'Registered employee list.',
+  'Administrativo': 'Administrative',
+  'Entrenador': 'Trainer',
+  'Mantenimiento': 'Maintenance',
+  'Limpieza': 'Cleaning',
+  'Recepción': 'Reception',
+  'Administración': 'Administration',
+  'Recepción y administración': 'Reception and administration',
+  'Caja y atención al socio': 'Cash desk and member service',
+  'Atención bar/snack': 'Bar/snack service',
+  'Entrenamiento': 'Training',
+  'Buscar empleado, ID, tipo, área...': 'Search employee, ID, type, area...',
+  'Enrolleds por actividad': 'Enrolled by activity',
+  'Inscritos por actividad': 'Enrolled by activity',
+  'Cancelar edición': 'Cancel editing',
+  'Refresh turno': 'Refresh shift',
+  'Actualizar turno': 'Refresh shift',
+  'Nombre de Activity': 'Activity name',
+  'Creado en': 'Created on',
+  'Currentizado en': 'Updated on',
+  'Actualizado en': 'Updated on',
+  'Total activities': 'Total activities',
+  'Total de actividades': 'Total activities',
+  'Nombre de Actividad': 'Activity name',
+  'Nombre de actividad': 'Activity name',
+  'Name de Activity': 'Activity name',
+  'Name de actividad': 'Activity name',
+  'Crear Actividad': 'Create activity',
+  'Crear Activity': 'Create activity',
+  'Actualizar Actividad': 'Update activity',
+  'Actualizar Activity': 'Update activity',
+  'Ingrese nombre de la actividad': 'Enter activity name',
+  'Cancelar': 'Cancel',
+  'medio': 'Medium',
+  'Medio': 'Medium',
+  'MEDIO': 'MEDIUM',
+};
+
+const EXACT_ONLY_REVERSE_TRANSLATIONS: Record<string, string> = Object.entries(
+  EXACT_ONLY_TRANSLATIONS,
+).reduce(
+  (acc, [from, to]) => {
+    if (!(to in acc)) acc[to] = from;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+const REVERSE_TRANSLATIONS: Record<string, string> = Object.entries(TRANSLATIONS).reduce(
+  (acc, [from, to]) => {
+    if (!(to in acc)) acc[to] = from;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+const SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'SVG', 'CANVAS']);
+
+function replaceAllLiteral(value: string, from: string, to: string) {
+  return value.split(from).join(to);
+}
+
+function translateValueForLocale(value: string, locale: string) {
+  if (!value) return value;
+
+  const leading = value.match(/^\s*/)?.[0] ?? '';
+  const trailing = value.match(/\s*$/)?.[0] ?? '';
+  const trimmed = value.trim();
+
+  if (!trimmed) return value;
+
+  const isEnglish = locale === 'en';
+  const exactOnlyDictionary = isEnglish
+    ? EXACT_ONLY_TRANSLATIONS
+    : EXACT_ONLY_REVERSE_TRANSLATIONS;
+  const dictionary = isEnglish ? TRANSLATIONS : REVERSE_TRANSLATIONS;
+
+  const exactOnly = exactOnlyDictionary[trimmed];
+  if (exactOnly) return `${leading}${exactOnly}${trailing}`;
+
+  const exact = dictionary[trimmed];
+  if (exact) return `${leading}${exact}${trailing}`;
+
+  if (!isEnglish) {
+    return value;
+  }
+
+  let next = value;
+  for (const [from, to] of TRANSLATION_ENTRIES) {
+    if (next.includes(from)) {
+      next = replaceAllLiteral(next, from, to);
+    }
+  }
+
+  return next;
+}
+
+function shouldSkipElement(element: Element | null) {
+  if (!element) return false;
+  if (SKIP_TAGS.has(element.tagName)) return true;
+  if (element.closest('[data-i18n-sweep="off"]')) return true;
+  return false;
+}
+
+function translateTextNode(
+  node: Text,
+  originals: WeakMap<Text, string>,
+  locale: string,
+) {
+  if (shouldSkipElement(node.parentElement)) return;
+
+  const currentValue = node.nodeValue ?? '';
+
+  if (!originals.has(node)) {
+    originals.set(node, currentValue);
+  }
+
+  const translated = translateValueForLocale(currentValue, locale);
+
+  if (node.nodeValue !== translated) {
+    node.nodeValue = translated;
+  }
+}
+
+function translateAttributes(
+  element: Element,
+  originals: WeakMap<Element, Record<string, string>>,
+  locale: string,
+) {
+  if (shouldSkipElement(element)) return;
+
+  const attrs = ['placeholder', 'title', 'aria-label'];
+  const originalAttrs = originals.get(element) ?? {};
+  let changed = false;
+
+  for (const attr of attrs) {
+    if (!element.hasAttribute(attr)) continue;
+
+    if (!(attr in originalAttrs)) {
+      originalAttrs[attr] = element.getAttribute(attr) ?? '';
+      changed = true;
+    }
+
+    const current = element.getAttribute(attr) ?? '';
+    const translated = translateValueForLocale(current, locale);
+
+    if (element.getAttribute(attr) !== translated) {
+      element.setAttribute(attr, translated);
+    }
+  }
+
+  if (changed || Object.keys(originalAttrs).length) {
+    originals.set(element, originalAttrs);
+  }
+}
+
+function sweepDashboardTexts(
+  root: ParentNode,
+  locale: string,
+  textOriginals: WeakMap<Text, string>,
+  attrOriginals: WeakMap<Element, Record<string, string>>,
+) {
+  const textWalker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let textNode = textWalker.nextNode();
+
+  while (textNode) {
+    translateTextNode(textNode as Text, textOriginals, locale);
+    textNode = textWalker.nextNode();
+  }
+
+  const elements =
+    root instanceof Element
+      ? [root, ...Array.from(root.querySelectorAll('*'))]
+      : Array.from(root.querySelectorAll('*'));
+
+  for (const element of elements) {
+    translateAttributes(element, attrOriginals, locale);
+  }
+}
+
+export default function DashboardInlineI18nSweep() {
+  const { locale } = useI18n();
+  const textOriginals = useRef(new WeakMap<Text, string>());
+  const attrOriginals = useRef(new WeakMap<Element, Record<string, string>>());
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const root = document.body;
+    const runSweep = () =>
+      sweepDashboardTexts(root, locale, textOriginals.current, attrOriginals.current);
+
+    runSweep();
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.TEXT_NODE) {
+            translateTextNode(node as Text, textOriginals.current, locale);
+            return;
+          }
+
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            sweepDashboardTexts(
+              node as Element,
+              locale,
+              textOriginals.current,
+              attrOriginals.current,
+            );
+          }
+        });
+
+        if (mutation.type === 'characterData' && mutation.target.nodeType === Node.TEXT_NODE) {
+          translateTextNode(mutation.target as Text, textOriginals.current, locale);
+        }
+
+        if (mutation.type === 'attributes' && mutation.target.nodeType === Node.ELEMENT_NODE) {
+          translateAttributes(
+            mutation.target as Element,
+            attrOriginals.current,
+            locale,
+          );
+        }
+      }
+    });
+
+    observer.observe(root, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['placeholder', 'title', 'aria-label'],
+    });
+
+    return () => observer.disconnect();
+  }, [locale]);
+
+  return null;
+}

--- a/src/components/modal/AsistenciaModal.tsx
+++ b/src/components/modal/AsistenciaModal.tsx
@@ -10,6 +10,7 @@ import {
 import AsistenciaForm from "../forms/AsistenciaForm";
 import FechaHora from "@/components/ui/FechaHora";
 import { Asistencia } from "@/interfaces/asistencia.interface";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function AsistenciaModal({
   open,
@@ -22,6 +23,10 @@ export default function AsistenciaModal({
   onCreated: () => void;
   asistencia?: Asistencia | null;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const attendanceText = (es: string, en: string) => (isEnglish ? en : es);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="w-full max-w-5xl sm:max-w-4xl">
@@ -29,7 +34,9 @@ export default function AsistenciaModal({
         <DialogHeader>
           <div className="flex gap-4 justify-between items-center w-full">
             <DialogTitle>
-              {asistencia ? "Editar Asistencia" : "Nueva Asistencia"}
+              {asistencia
+                ? attendanceText("Editar Asistencia", "Edit attendance")
+                : attendanceText("Nueva Asistencia", "New attendance")}
             </DialogTitle>
             <FechaHora />
           </div>

--- a/src/components/modal/AsistenciaViewModal.tsx
+++ b/src/components/modal/AsistenciaViewModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Asistencia } from "@/interfaces/asistencia.interface";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function AsistenciaViewModal({
   open,
@@ -19,6 +20,10 @@ export default function AsistenciaViewModal({
   onClose: () => void;
   asistencia?: Asistencia | null;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const attendanceText = (es: string, en: string) => (isEnglish ? en : es);
+
   if (!open || !asistencia) return null;
 
   return (
@@ -27,28 +32,28 @@ export default function AsistenciaViewModal({
         <QaFileNameBadge file="src/components/modal/AsistenciaViewModal.tsx" />
         <DialogHeader>
           <DialogTitle className="text-foreground">
-            Detalles de Asistencia
+            {attendanceText("Detalles de Asistencia", "Attendance details")}
           </DialogTitle>
         </DialogHeader>
         <div className="mt-4 space-y-3">
           <p className="text-foreground">
-            <strong>ID Asistencia:</strong> {asistencia.id}
+            <strong>{attendanceText("ID Asistencia", "Attendance ID")}:</strong> {asistencia.id}
           </p>
           <p className="text-foreground">
-            <strong>ID Socio:</strong> {asistencia.socio_id}
+            <strong>{attendanceText("ID Socio", "Member ID")}:</strong> {asistencia.socio_id}
           </p>
           <p className="text-foreground">
-            <strong>Fecha:</strong> {asistencia.fecha}
+            <strong>{attendanceText("Fecha", "Date")}:</strong> {asistencia.fecha}
           </p>
           <p className="text-foreground">
-            <strong>Hora Ingreso:</strong> {asistencia.hora_ingreso}
+            <strong>{attendanceText("Hora Ingreso", "Check-in time")}:</strong> {asistencia.hora_ingreso}
           </p>
           <p className="text-foreground">
-            <strong>Hora Egreso:</strong> {asistencia.hora_egreso || "-"}
+            <strong>{attendanceText("Hora Egreso", "Check-out time")}:</strong> {asistencia.hora_egreso || "-"}
           </p>
         </div>
         <div className="flex justify-end mt-6">
-          <Button onClick={onClose}>Cerrar</Button>
+          <Button onClick={onClose}>{attendanceText("Cerrar", "Close")}</Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/sidebar/SidebarSection.tsx
+++ b/src/components/sidebar/SidebarSection.tsx
@@ -12,95 +12,10 @@ import {
 import Link from "next/link";
 import { SidebarItemType } from "./sidebarConfig";
 import { useI18n } from "@/i18n/I18nProvider";
-
-
-const SIDEBAR_GROUP_KEYS: Record<string, string> = {
-  General: 'sidebar.groups.general',
-  'Mi Gimnasio': 'sidebar.groups.myGym',
-  'Mi Coach': 'sidebar.groups.myCoach',
-  'Mi Salud': 'sidebar.groups.myHealth',
-  Comunicación: 'sidebar.groups.communication',
-  'Personal y Operaciones': 'sidebar.groups.personalOperations',
-  Infraestructura: 'sidebar.groups.infrastructure',
-  'Entrenamiento y Salud': 'sidebar.groups.trainingHealth',
-  'Comercial y Stock': 'sidebar.groups.commercialStock',
-  'Finanzas y BI': 'sidebar.groups.financeBi',
-  'IA y RAG': 'sidebar.groups.aiRag',
-  'Comunicación y Soporte': 'sidebar.groups.communicationSupport',
-  'Administración del Sistema': 'sidebar.groups.systemAdministration',
-  'Configuración Personal': 'sidebar.groups.personalSettings',
-};
-
-const SIDEBAR_ITEM_KEYS: Record<string, string> = {
-  Inicio: 'sidebar.items.home',
-  'Control de Asistencia': 'sidebar.items.attendanceControl',
-  'Pagar cuota': 'sidebar.items.payFee',
-  'Historial de pagos': 'sidebar.items.paymentHistory',
-  'Cuota - Precio': 'sidebar.items.feePrice',
-  Rutina: 'sidebar.items.routine',
-  Dieta: 'sidebar.items.diet',
-  'Coach IA': 'sidebar.items.aiCoach',
-  'Asistente de Rutinas': 'sidebar.items.routineAssistant',
-  'Asistente de Dietas': 'sidebar.items.dietAssistant',
-  'Evolución Física': 'sidebar.items.physicalEvolution',
-  'Ficha Médica': 'sidebar.items.medicalRecord',
-  Mensajes: 'sidebar.items.messages',
-  Socios: 'sidebar.items.members',
-  Actividades: 'sidebar.items.activities',
-  Empleados: 'sidebar.items.employees',
-  Sueldos: 'sidebar.items.salaries',
-  Asistencias: 'sidebar.items.attendances',
-  'Salida / Aforo': 'sidebar.items.exitCapacity',
-  'Mantenimiento Edilicio': 'sidebar.items.buildingMaintenance',
-  'Lector QR/barra': 'sidebar.items.qrBarcodeReader',
-  'Etiquetas QR': 'sidebar.items.qrLabels',
-  Equipamientos: 'sidebar.items.equipment',
-  'Preventivos Equipos': 'sidebar.items.equipmentPreventive',
-  'Gestión de Rutinas': 'sidebar.items.routineManagement',
-  'Gestión de Dietas': 'sidebar.items.dietManagement',
-  'Gestión Evolución Física': 'sidebar.items.physicalEvolutionManagement',
-  'Media de Ejercicios': 'sidebar.items.exerciseMedia',
-  'Comercial / Kiosco': 'sidebar.items.commercialKiosk',
-  'POS / Kiosco': 'sidebar.items.posKiosk',
-  'Caja / Cashup': 'sidebar.items.cashup',
-  'Compras / Reposición': 'sidebar.items.purchasesReplenishment',
-  Ventas: 'sidebar.items.sales',
-  Compras: 'sidebar.items.purchases',
-  Productos: 'sidebar.items.products',
-  'Stock Ledger': 'sidebar.items.stockLedger',
-  'Códigos / Etiquetas': 'sidebar.items.codesLabels',
-  'BI Packs / Promos': 'sidebar.items.packPromosBi',
-  Proveedores: 'sidebar.items.suppliers',
-  Servicios: 'sidebar.items.services',
-  'Servicios / Packs / Promos': 'sidebar.items.servicesPacksPromos',
-  Pagos: 'sidebar.items.payments',
-  Cuotas: 'sidebar.items.fees',
-  'Gastos / Egresos': 'sidebar.items.expenses',
-  'Finanzas / BI': 'sidebar.items.financeBi',
-  'BI Socios / Promociones': 'sidebar.items.membersPromotionsBi',
-  'Ranking / Bonificación': 'sidebar.items.rankingBonus',
-  'RAG Corpus': 'sidebar.items.ragCorpus',
-  Notificaciones: 'sidebar.items.notifications',
-  'Mensajes Socios': 'sidebar.items.memberMessages',
-  Avisos: 'sidebar.items.notices',
-  'Ayuda / Manuales': 'sidebar.items.helpManuals',
-  'Soporte Dragon Pyramid': 'sidebar.items.dragonSupport',
-  'Respaldo / Exportación': 'sidebar.items.backupExport',
-  Usuarios: 'sidebar.items.users',
-  'Datos del Gimnasio': 'sidebar.items.gymData',
-  Parametrización: 'sidebar.items.parametrization',
-  Perfil: 'sidebar.items.profile',
-  Preferencias: 'sidebar.items.preferences',
-};
-
-function translateSidebarLabel(
-  value: string,
-  keys: Record<string, string>,
-  t: (key: string) => string,
-) {
-  const key = keys[value];
-  return key ? t(key) : value;
-}
+import {
+  translateNavigationGroup,
+  translateNavigationItem,
+} from "@/i18n/navigationLabels";
 
 interface Props {
   title: string;
@@ -118,7 +33,7 @@ export const SidebarSection: React.FC<Props> = ({
   closeSidebar,
 }) => {
   const { t } = useI18n();
-  const translatedTitle = translateSidebarLabel(title, SIDEBAR_GROUP_KEYS, t);
+  const translatedTitle = translateNavigationGroup(title, t);
 
   return (
     <SidebarGroup>
@@ -139,7 +54,7 @@ export const SidebarSection: React.FC<Props> = ({
                   <span className="shrink-0 text-muted-foreground">
                     {item.level === 2 ? "●" : item.level === 3 ? "○" : ""}
                   </span>
-                  <span className="truncate">{translateSidebarLabel(item.title, SIDEBAR_ITEM_KEYS, t)}</span>
+                  <span className="truncate">{translateNavigationItem(item.title, t)}</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/src/components/tables/AsistenciaTable.tsx
+++ b/src/components/tables/AsistenciaTable.tsx
@@ -14,6 +14,7 @@ import {
   TableCaption,
 } from "@/components/ui/table";
 import { Asistencia } from "@/interfaces/asistencia.interface";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function AsistenciaTable({
   asistencias,
@@ -32,6 +33,10 @@ export default function AsistenciaTable({
   onRegisterExit?: (asistencia: Asistencia) => void | Promise<void>;
   totalAsistencias?: number;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const attendanceText = (es: string, en: string) => (isEnglish ? en : es);
+
   if (loading) {
     return (
       <div className="space-y-2">
@@ -45,7 +50,7 @@ export default function AsistenciaTable({
   if (asistencias.length === 0 && !loading) {
     return (
       <div className="py-10 text-center text-muted-foreground">
-        No hay asistencias registradas aún.
+        {attendanceText("No hay asistencias registradas aún.", "No attendances registered yet.")}
       </div>
     );
   }
@@ -54,11 +59,11 @@ export default function AsistenciaTable({
     <Table className="w-full overflow-hidden text-sm border rounded-md border-border">
       <TableHeader>
         <TableRow className="bg-muted/50 text-muted-foreground">
-          <TableHead>Nombre de Socio</TableHead>
-          <TableHead>Fecha</TableHead>
-          <TableHead>Hora Ingreso</TableHead>
-          <TableHead>Hora Egreso</TableHead>
-          <TableHead>Acciones</TableHead>
+          <TableHead>{attendanceText("Nombre de Socio", "Member name")}</TableHead>
+          <TableHead>{attendanceText("Fecha", "Date")}</TableHead>
+          <TableHead>{attendanceText("Hora Ingreso", "Check-in time")}</TableHead>
+          <TableHead>{attendanceText("Hora Egreso", "Check-out time")}</TableHead>
+          <TableHead>{attendanceText("Acciones", "Actions")}</TableHead>
         </TableRow>
       </TableHeader>
 
@@ -81,15 +86,13 @@ export default function AsistenciaTable({
                 size="sm"
                 variant="outline"
                 onClick={() => onView && onView(a)}
-              >
-                Ver
-              </Button>
+              >{attendanceText("Ver", "View")}</Button>
               {!a.hora_egreso && onRegisterExit && (
                 <Button
                   size="sm"
                   variant="outline"
                   onClick={() => onRegisterExit(a)}
-                  title="Registrar salida"
+                  title={attendanceText("Registrar salida", "Register exit")}
                   className="border-emerald-200 text-emerald-700 hover:bg-emerald-50"
                 >
                   <LogOut className="w-4 h-4" />
@@ -110,14 +113,14 @@ export default function AsistenciaTable({
 
       <TableFooter>
         <TableRow>
-          <TableCell colSpan={4}>Total de asistencias</TableCell>
+          <TableCell colSpan={4}>{attendanceText("Total de asistencias", "Total attendances")}</TableCell>
           <TableCell className="text-right">
             {totalAsistencias ?? asistencias.length}
           </TableCell>
         </TableRow>
       </TableFooter>
 
-      <TableCaption>Listado de asistencias registradas.</TableCaption>
+      <TableCaption>{attendanceText("Listado de asistencias registradas.", "Registered attendance list.")}</TableCaption>
     </Table>
   );
 }

--- a/src/i18n/commercialUi.ts
+++ b/src/i18n/commercialUi.ts
@@ -691,6 +691,8 @@ const enCommercialUi: Record<string, string> = {
   'Página': 'Page',
   'Anterior': 'Previous',
   'Siguiente': 'Next',
+  'actividades': 'activities',
+  'socios': 'members',
   'Productos activos': 'Active products',
   'Sin stock': 'Out of stock',
   'Inventario estimado': 'Estimated inventory',

--- a/src/i18n/dictionaries.ts
+++ b/src/i18n/dictionaries.ts
@@ -111,6 +111,23 @@ export const dictionaries: Record<GymMasterLocale, I18nDictionary> = {
       },
       logout: 'Cerrar sesión',
     },
+    navigationTitles: {
+      myActivities: 'Mis actividades',
+      routines: 'Rutinas',
+      diets: 'Dietas',
+      routineManager: 'Gestor de Rutinas',
+      dietManager: 'Gestor de Dietas',
+      physicalEvolutionManager: 'Gestor de Evolución Física',
+      equipmentPreventiveDetail: 'Preventivos de Equipamientos',
+      monthlyRankingBonus: 'Ranking y bonificación mensual',
+      saleDetails: 'Detalles de Venta',
+      routineDetail: 'Detalle de Rutina',
+      physicalEvolutionDetail: 'Detalle de Evolución Física',
+      dietDetail: 'Detalle de Dieta',
+      commercialCodesLabels: 'Códigos y etiquetas comerciales',
+      commercialStockAlerts: 'Alertas de stock comercial',
+    },
+
     header: {
       toggleTheme: 'Cambiar modo claro/oscuro',
       lightMode: 'Modo claro',
@@ -130,6 +147,17 @@ export const dictionaries: Record<GymMasterLocale, I18nDictionary> = {
       editProfile: 'Editar perfil',
       logout: 'Cerrar sesión',
     },
+    users: {
+      form: {
+        menuPermissions: {
+          title: 'Permisos de menú',
+          description: 'Definí qué módulos verá este usuario al iniciar sesión. El administrador conserva acceso total.',
+          adminFullAccess: 'El rol administrador tiene control total del panel.',
+          internalUserHint: 'Este usuario interno puede representar a un empleado administrativo. Marcá solo los módulos que podrá ver y utilizar. El menú lateral mostrará únicamente las opciones habilitadas y las rutas no permitidas quedarán bloqueadas por seguridad.',
+        },
+      },
+    },
+
     login: {
       entryTitle: 'Elegí cómo ingresar',
       entryDescription: 'Seleccioná el acceso correspondiente para continuar en Gym Master.',
@@ -899,6 +927,23 @@ export const dictionaries: Record<GymMasterLocale, I18nDictionary> = {
       },
       logout: 'Log out',
     },
+    navigationTitles: {
+      myActivities: 'My activities',
+      routines: 'Routines',
+      diets: 'Diets',
+      routineManager: 'Routine manager',
+      dietManager: 'Diet manager',
+      physicalEvolutionManager: 'Physical evolution manager',
+      equipmentPreventiveDetail: 'Equipment preventive tasks',
+      monthlyRankingBonus: 'Monthly ranking and bonus',
+      saleDetails: 'Sale details',
+      routineDetail: 'Routine detail',
+      physicalEvolutionDetail: 'Physical evolution detail',
+      dietDetail: 'Diet detail',
+      commercialCodesLabels: 'Commercial codes and labels',
+      commercialStockAlerts: 'Commercial stock alerts',
+    },
+
     header: {
       toggleTheme: 'Toggle light/dark mode',
       lightMode: 'Light mode',
@@ -915,6 +960,17 @@ export const dictionaries: Record<GymMasterLocale, I18nDictionary> = {
       editProfile: 'Edit profile',
       logout: 'Log out',
     },
+    users: {
+      form: {
+        menuPermissions: {
+          title: 'Menu permissions',
+          description: 'Define which modules this user will see when signing in. Administrators keep full access.',
+          adminFullAccess: 'The administrator role has full control of the dashboard.',
+          internalUserHint: 'This internal user can represent an administrative employee. Select only the modules they can view and use. The sidebar will show only enabled options and unauthorized routes will remain blocked for security.',
+        },
+      },
+    },
+
     login: {
       entryTitle: 'Choose how to sign in',
       entryDescription: 'Select the right access point to continue in Gym Master.',

--- a/src/i18n/navigationLabels.ts
+++ b/src/i18n/navigationLabels.ts
@@ -1,0 +1,148 @@
+export type NavigationTranslator = (key: string) => string;
+
+export const NAVIGATION_GROUP_KEYS: Record<string, string> = {
+  General: 'sidebar.groups.general',
+  'Mi Gimnasio': 'sidebar.groups.myGym',
+  'Mi Coach': 'sidebar.groups.myCoach',
+  'Mi Salud': 'sidebar.groups.myHealth',
+  Comunicación: 'sidebar.groups.communication',
+  'Personal y Operaciones': 'sidebar.groups.personalOperations',
+  Infraestructura: 'sidebar.groups.infrastructure',
+  'Entrenamiento y Salud': 'sidebar.groups.trainingHealth',
+  'Comercial y Stock': 'sidebar.groups.commercialStock',
+  'Finanzas y BI': 'sidebar.groups.financeBi',
+  'IA y RAG': 'sidebar.groups.aiRag',
+  'Comunicación y Soporte': 'sidebar.groups.communicationSupport',
+  'Administración del Sistema': 'sidebar.groups.systemAdministration',
+  'Configuración Personal': 'sidebar.groups.personalSettings',
+  'Configuración personal': 'sidebar.groups.personalSettings',
+};
+
+export const NAVIGATION_ITEM_KEYS: Record<string, string> = {
+  Inicio: 'sidebar.items.home',
+  Home: 'sidebar.items.home',
+  'Control de Asistencia': 'sidebar.items.attendanceControl',
+  'Pagar cuota': 'sidebar.items.payFee',
+  'Historial de pagos': 'sidebar.items.paymentHistory',
+  'Cuota - Precio': 'sidebar.items.feePrice',
+  Rutina: 'sidebar.items.routine',
+  Rutinas: 'navigationTitles.routines',
+  Dieta: 'sidebar.items.diet',
+  Dietas: 'navigationTitles.diets',
+  'Coach IA': 'sidebar.items.aiCoach',
+  'Asistente de Rutinas': 'sidebar.items.routineAssistant',
+  'Asistente de Dietas': 'sidebar.items.dietAssistant',
+  'Evolución Física': 'sidebar.items.physicalEvolution',
+  'Evolución física': 'sidebar.items.physicalEvolution',
+  'Ficha Médica': 'sidebar.items.medicalRecord',
+  'Ficha médica': 'sidebar.items.medicalRecord',
+  Mensajes: 'sidebar.items.messages',
+  Socios: 'sidebar.items.members',
+  Actividades: 'sidebar.items.activities',
+  Empleados: 'sidebar.items.employees',
+  Sueldos: 'sidebar.items.salaries',
+  Asistencias: 'sidebar.items.attendances',
+  'Salida / Aforo': 'sidebar.items.exitCapacity',
+  'Mantenimiento Edilicio': 'sidebar.items.buildingMaintenance',
+  'Lector QR/barra': 'sidebar.items.qrBarcodeReader',
+  'Etiquetas QR': 'sidebar.items.qrLabels',
+  Equipamientos: 'sidebar.items.equipment',
+  'Preventivos Equipos': 'sidebar.items.equipmentPreventive',
+  'Preventivos de Equipamientos': 'navigationTitles.equipmentPreventiveDetail',
+  'Gestión de Rutinas': 'sidebar.items.routineManagement',
+  'Gestor de Rutinas': 'navigationTitles.routineManager',
+  'Gestión de Dietas': 'sidebar.items.dietManagement',
+  'Gestor de Dietas': 'navigationTitles.dietManager',
+  'Gestión Evolución Física': 'sidebar.items.physicalEvolutionManagement',
+  'Gestor de Evolución Física': 'navigationTitles.physicalEvolutionManager',
+  'Media de Ejercicios': 'sidebar.items.exerciseMedia',
+  'Comercial / Kiosco': 'sidebar.items.commercialKiosk',
+  'POS / Kiosco': 'sidebar.items.posKiosk',
+  'Caja / Cashup': 'sidebar.items.cashup',
+  'Compras / Reposición': 'sidebar.items.purchasesReplenishment',
+  Ventas: 'sidebar.items.sales',
+  Compras: 'sidebar.items.purchases',
+  Productos: 'sidebar.items.products',
+  'Stock Ledger': 'sidebar.items.stockLedger',
+  'Códigos / Etiquetas': 'sidebar.items.codesLabels',
+  'Códigos y etiquetas comerciales': 'navigationTitles.commercialCodesLabels',
+  'BI Packs / Promos': 'sidebar.items.packPromosBi',
+  Proveedores: 'sidebar.items.suppliers',
+  Servicios: 'sidebar.items.services',
+  'Servicios / Packs / Promos': 'sidebar.items.servicesPacksPromos',
+  'Servicios / Packs / Promociones': 'sidebar.items.servicesPacksPromos',
+  Pagos: 'sidebar.items.payments',
+  Cuotas: 'sidebar.items.fees',
+  'Gastos / Egresos': 'sidebar.items.expenses',
+  'Finanzas / BI': 'sidebar.items.financeBi',
+  'BI Socios / Promociones': 'sidebar.items.membersPromotionsBi',
+  'Ranking / Bonificación': 'sidebar.items.rankingBonus',
+  'Ranking y bonificación mensual': 'navigationTitles.monthlyRankingBonus',
+  'RAG Corpus': 'sidebar.items.ragCorpus',
+  Notificaciones: 'sidebar.items.notifications',
+  'Mensajes Socios': 'sidebar.items.memberMessages',
+  'Mensajes de socios': 'sidebar.items.memberMessages',
+  Avisos: 'sidebar.items.notices',
+  'Ayuda / Manuales': 'sidebar.items.helpManuals',
+  'Soporte Dragon Pyramid': 'sidebar.items.dragonSupport',
+  'Respaldo / Exportación': 'sidebar.items.backupExport',
+  Usuarios: 'sidebar.items.users',
+  'Datos del Gimnasio': 'sidebar.items.gymData',
+  Parametrización: 'sidebar.items.parametrization',
+  Perfil: 'sidebar.items.profile',
+  'Mi perfil': 'header.profile',
+  Preferencias: 'sidebar.items.preferences',
+  'Mis actividades': 'navigationTitles.myActivities',
+  'Detalles de Venta': 'navigationTitles.saleDetails',
+  'Detalle de Rutina': 'navigationTitles.routineDetail',
+  'Detalle de Evolución Física': 'navigationTitles.physicalEvolutionDetail',
+  'Detalle de Dieta': 'navigationTitles.dietDetail',
+  'Alertas de stock comercial': 'navigationTitles.commercialStockAlerts',
+};
+
+export const NAVIGATION_TITLE_KEYS: Record<string, string> = {
+  ...NAVIGATION_GROUP_KEYS,
+  ...NAVIGATION_ITEM_KEYS,
+};
+
+function normalizeNavigationLabel(value: string) {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function buildNormalizedMap(source: Record<string, string>) {
+  return Object.entries(source).reduce<Record<string, string>>((acc, [label, key]) => {
+    acc[normalizeNavigationLabel(label)] = key;
+    return acc;
+  }, {});
+}
+
+const NORMALIZED_GROUP_KEYS = buildNormalizedMap(NAVIGATION_GROUP_KEYS);
+const NORMALIZED_ITEM_KEYS = buildNormalizedMap(NAVIGATION_ITEM_KEYS);
+const NORMALIZED_TITLE_KEYS = buildNormalizedMap(NAVIGATION_TITLE_KEYS);
+
+export function translateNavigationLabel(
+  value: string,
+  keys: Record<string, string>,
+  normalizedKeys: Record<string, string>,
+  t: NavigationTranslator,
+) {
+  const key = keys[value] ?? normalizedKeys[normalizeNavigationLabel(value)];
+  return key ? t(key) : value;
+}
+
+export function translateNavigationGroup(value: string, t: NavigationTranslator) {
+  return translateNavigationLabel(value, NAVIGATION_GROUP_KEYS, NORMALIZED_GROUP_KEYS, t);
+}
+
+export function translateNavigationItem(value: string, t: NavigationTranslator) {
+  return translateNavigationLabel(value, NAVIGATION_ITEM_KEYS, NORMALIZED_ITEM_KEYS, t);
+}
+
+export function translateNavigationTitle(value: string, t: NavigationTranslator) {
+  return translateNavigationLabel(value, NAVIGATION_TITLE_KEYS, NORMALIZED_TITLE_KEYS, t);
+}


### PR DESCRIPTION
# PR: i18n navigation menus final sweep v1

## Branch

`feature/i18n-navigation-menus-final-sweep-v1`

## Objetivo

Completar una auditoría quirúrgica de internacionalización ES/EN en navegación, menús y pantallas administrativas del dashboard, corrigiendo textos mixtos, etiquetas no traducidas, estados dinámicos visibles, modales y loaders sin alterar lógica de negocio, endpoints, base de datos ni exportaciones.

## Alcance funcional

- Menús laterales y cabeceras del dashboard.
- Traducción defensiva de textos inline mediante `DashboardInlineI18nSweep`.
- Pantallas y modales revisados en Admin:
  - Dashboard principal.
  - Coach IA.
  - Asistente de rutinas.
  - Asistente de dietas.
  - Ficha médica.
  - Socios / Members.
  - Vista 360 de socio.
  - Actividades.
  - Empleados.
  - Sueldos.
  - Asistencias.
  - Terminal de asistencia.
- Ajustes visuales puntuales en combos/selects de Actividades en modo claro.
- Fix de carga no bloqueante del dashboard para evitar bucles al alternar idioma y abrir/cerrar modal 360.

## Cambios técnicos principales

### i18n base y navegación

- Se extendieron labels de navegación en `navigationLabels.ts` y diccionarios ES/EN.
- Se integró traducción en `SidebarSection`, `AppHeader` y formularios donde correspondía.
- Se agregó/extendió `DashboardInlineI18nSweep` como capa defensiva exact-only para textos persistentes del dashboard.
- Se corrigió el comportamiento exact-only para evitar reemplazos parciales peligrosos al volver de EN a ES.

### Dashboard y carga

- Se ajustó la carga del dashboard para no bloquear la UI ante endpoints lentos o fallidos.
- Se evitó que el recorrido EN → modal 360 → ES → modal 360 deje el dashboard congelado.

### Socios / Members y modal 360

- Se corrigieron textos mixtos en listado de socios, métricas, badges, botones, paginación y totalizadores.
- Se corrigieron remanentes en vista 360: status, riesgo administrativo, contacto de emergencia, fecha de alta, descuentos y módulos del socio.
- Se tradujeron labels visibles en tarjetas, lectura rápida, alertas y módulos relacionados.

### Coach, rutinas y dietas

- Se corrigieron remanentes en Coach IA, memoria contextual y confianza pendiente.
- Se corrigió el ejemplo del asistente de rutinas en modo inglés.
- Se corrigieron remanentes de gestión de dietas, formulario New Diet, placeholders, ejemplos, objetivos, restricciones y preferencias.

### Ficha médica

- Se corrigieron labels mixtos en hero, panel admin, revisión, apto médico, documentos, adjuntos y estados de revisión.

### Actividades

- Se corrigieron textos en la página de actividades, BI, turnos, inscripción, catálogo, modales de alta/edición/detalle.
- Se ajustaron selects/combos en modo claro para mejorar contraste y lectura.

### Empleados y sueldos

- Se corrigieron textos en listado de empleados, loaders, modales de detalle y edición.
- Se corrigieron etiquetas mixtas en sueldos, tabla, filtros, modales de edición, resumen de liquidación y campos requeridos.

### Asistencias y terminal

- Se corrigieron textos en página de asistencias, tabla, paginación, auto-refresh, estado de aforo y modales de view/edit.
- Se corrigió la terminal de asistencia en inglés: título, QR, pasos, monitor externo, actividad reciente, estados y mensajes visibles.

## Archivos principales modificados

- `src/i18n/navigationLabels.ts`
- `src/i18n/dictionaries.ts`
- `src/i18n/commercialUi.ts`
- `src/app/dashboard/layout.tsx`
- `src/app/dashboard/page.tsx`
- `src/app/dashboard/actividades/page.tsx`
- `src/app/dashboard/empleados/page.tsx`
- `src/app/dashboard/empleados-sueldos/page.tsx`
- `src/app/dashboard/asistencias/page.tsx`
- `src/components/i18n/DashboardInlineI18nSweep.tsx`
- `src/components/sidebar/SidebarSection.tsx`
- `src/components/header/AppHeader.tsx`
- `src/components/forms/UserForm.tsx`
- `src/components/forms/AsistenciaForm.tsx`
- `src/components/tables/AsistenciaTable.tsx`
- `src/components/modal/AsistenciaModal.tsx`
- `src/components/modal/AsistenciaViewModal.tsx`
- `src/components/asistencia/AsistenciaTerminalDisplay.tsx`

## Fuera de alcance

- No se modificó base de datos.
- No se modificaron endpoints.
- No se modificó Swagger/OpenAPI.
- No se modificó autenticación.
- No se modificó lógica de negocio de asistencias, socios, sueldos ni aforo.
- No se modificaron reportes PDF, exportaciones Excel, tickets ni etiquetas QR. Quedan para una feature futura dedicada a reportes/exportaciones multiidioma.

## Validación sugerida

```bash
cd /e/gym-master-2026/sistema/gym-master
rm -rf .next
npm run build
npm run dev -- -p 3001
```

## QA funcional recomendado

- Alternar ES/EN desde el dashboard.
- Revisar menú lateral en ambos idiomas.
- Abrir `/dashboard/socios`, modal 360, cerrar, alternar idioma, volver a abrir 360.
- Revisar `/dashboard/coach`.
- Revisar `/dashboard/rutinas/asistente`.
- Revisar `/dashboard/dietas`, New Diet y formularios.
- Revisar `/dashboard/ficha-medica`.
- Revisar `/dashboard/actividades`, selects, modales y catálogo.
- Revisar `/dashboard/empleados`, modales de detalle y edición.
- Revisar `/dashboard/empleados-sueldos`, tabla y modal de sueldo.
- Revisar `/dashboard/asistencias`, view/edit modal.
- Revisar `/dashboard/asistencias/terminal` en inglés.

## Checklist

- [x] Textos principales ES/EN corregidos en navegación y pantallas auditadas.
- [x] Modales principales revisados.
- [x] Loaders visibles revisados.
- [x] Paginaciones y totales visibles revisados.
- [x] Estados dinámicos visibles revisados donde fueron detectados.
- [x] Fix no bloqueante para dashboard/modal 360.
- [x] Sin cambios de DB.
- [x] Sin cambios de endpoints.
- [x] Sin cambios de Swagger/OpenAPI.
- [x] Reportes PDF/Excel/tickets/QR labels quedan para feature futura.

## Commit sugerido

```bash
git add src docs
git commit -m "fix: complete dashboard navigation i18n sweep"
git push -u origin $(git branch --show-current)
```
