### PR TITLE
feat(i18n): continue admin dashboard final sweep v2

### DIFF
--- a/README_APPLY_FIX_OTROS_GASTOS_I18N_DUPLICATES.md
+++ b/README_APPLY_FIX_OTROS_GASTOS_I18N_DUPLICATES.md
@@ -1,0 +1,66 @@
+# Patch fix: otrosGastosI18n duplicate object keys
+
+Este patch corrige el error de build:
+
+```txt
+Type error: An object literal cannot have multiple properties with the same name.
+src/utils/otrosGastosI18n.ts
+```
+
+## Aplicación con robocopy
+
+Desde Git Bash:
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+
+mkdir -p ../temp-robocopy/i18n_es_en_admin_dashboard_final_sweep_v2_otros_gastos_i18n_duplicates_fix_v1
+```
+
+Descomprimí este ZIP en:
+
+```txt
+E:\gym-master-2026\sistema\temp-robocopy\i18n_es_en_admin_dashboard_final_sweep_v2_otros_gastos_i18n_duplicates_fix_v1
+```
+
+Luego aplicá:
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+
+robocopy   "E:\gym-master-2026\sistema\temp-robocopy\i18n_es_en_admin_dashboard_final_sweep_v2_otros_gastos_i18n_duplicates_fix_v1\chatgpt_patch"   "."   /E /XD .git node_modules .next .vercel /XF package-lock.json
+```
+
+Robocopy puede devolver `1` aunque haya salido bien.
+
+## Ejecutar corrección
+
+```bash
+node scripts/fix-otros-gastos-i18n-duplicates.mjs
+```
+
+## Validar build
+
+```bash
+rm -rf .next
+npm run build
+```
+
+## Limpiar PWA antes del commit
+
+```bash
+git checkout -- public/sw.js
+rm -f public/fallback-*.js
+git status --short
+```
+
+## Opcional: no commitear el script temporal
+
+Si el build pasa, podés borrar el script antes de `git add`:
+
+```bash
+rm -f scripts/fix-otros-gastos-i18n-duplicates.mjs
+git status --short
+```
+
+El cambio real debe quedar únicamente en `src/utils/otrosGastosI18n.ts`.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_CUOTAS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_CUOTAS_FIX_V1.md
@@ -1,0 +1,19 @@
+# Gym Master — Admin dashboard final sweep v2 — Cuotas / Fees fix v1
+
+## Scope
+Route: `/dashboard/cuotas`
+
+## Changes
+- Translates fixed UI strings ES/EN for the fees page.
+- Fixes mixed labels such as `Readydo de Fees`, `Más reciente a antigua`, `Descripción`, `Fecha Inicio`, `Activo`, `Acciones`, `Añadir Cuota`, etc.
+- Translates table actions, empty states, pagination item label, confirm dialogs, and toasts.
+- Translates fee modal and fee detail modal labels.
+- Adds light/dark styling improvements for cards, table, buttons, filters, inputs, and modals.
+- Adds presentation-only month translation for fee descriptions such as `ABRIL/2025` -> `APRIL/2025` in English mode.
+
+## Safety
+- No DB changes.
+- No endpoint changes.
+- No Swagger/OpenAPI changes.
+- No fee business logic changes.
+- No payment logic changes.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_FINANZAS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_FINANZAS_FIX_V1.md
@@ -1,0 +1,25 @@
+# Gym Master — i18n ES/EN admin dashboard final sweep v2 — Finanzas / BI fix v1
+
+## Scope
+Route: `/dashboard/finanzas`
+
+## Changes
+- Translates the fixed UI copy in the Finance / BI screen for ES/EN.
+- Fixes header title `Finanzas / BI` -> `Finance / BI` in English.
+- Translates hero, date filters, buttons, KPI cards, executive summary, suggested decision, chart titles, legends, empty states, category panels, and the monthly summary table.
+- Adds presentation-only translation for known dynamic category labels coming from data/catalogs, such as:
+  - `Ventas de productos / kiosco` -> `Product / kiosk sales`
+  - `Fees / membresías` -> `Fees / memberships`
+  - `Compras a proveedores` -> `Supplier purchases`
+  - `Gastos pending` -> `Pending expenses`
+  - `Gasto demo ...` -> `Demo expense ...`
+  - `Luz` -> `Electricity`
+- Improves dark mode locally for cards, KPI blocks, category cards, chart containers, and the monthly table.
+
+## Safety
+- No DB changes.
+- No endpoint changes.
+- No Swagger/OpenAPI changes.
+- No finance calculations changed.
+- No chart data mapping changed.
+- Export/PDF generation logic remains functionally unchanged.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_NOTIFICACIONES_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_NOTIFICACIONES_FIX_V1.md
@@ -1,0 +1,21 @@
+# i18n ES/EN Admin Dashboard Final Sweep V2 - Notificaciones fix v1
+
+Scope:
+- `/dashboard/notificaciones`
+- `NotificacionModal`
+- `NotificacionForm`
+- `NotificacionTable`
+- `NotificacionViewModal`
+
+Changes:
+- Localized the notifications center UI for ES/EN.
+- Localized filters, KPI cards, operational health panels, priorities, table headers, empty/loading states, toast messages and confirmations.
+- Localized notification status/type/channel/terminal labels shown in the table and detail modal.
+- Localized the create/edit notification modal: base template, type, channel, status, recipients, terminal output block, neon color, duration/frequency, and submit buttons.
+- No DB, endpoints, Swagger/OpenAPI, notification services, terminal delivery logic or data model changes.
+
+Validation suggested:
+- Toggle ES/EN in `/dashboard/notificaciones`.
+- Open `New notification`, check select options and terminal block in EN.
+- Check table rows, badges, filters, view modal and edit modal in EN.
+- Run `npm run build`.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V1.md
@@ -1,0 +1,19 @@
+# Gym Master — i18n ES/EN Admin Dashboard Final Sweep v2 — Otros gastos fix v1
+
+## Alcance
+Ruta: `/dashboard/otros-gastos`
+
+## Cambios
+- Traducción ES/EN de labels, filtros, botones, tabla, footer/paginación, modal de alta/edición y modal de detalle.
+- Traducción de presentación para estados, medios de pago y textos demo/semilla visibles como `Gasto demo`, `Sin clasificar`, `Comp.`.
+- Mejora puntual de dark mode local: cards KPI, tabla, badges de estado, panel informativo y modales.
+- Agrega iconos mnemotécnicos en cards KPI superiores.
+- No toca DB, endpoints, Swagger/OpenAPI ni lógica de gastos/comprobantes.
+
+## Archivos
+- `src/app/dashboard/otros-gastos/page.tsx`
+- `src/components/tables/OtrosGastosTable.tsx`
+- `src/components/modal/OtrosGastosModal.tsx`
+- `src/components/modal/OtrosGastosViewModal.tsx`
+- `src/components/forms/OtrosGastosForm.tsx`
+- `src/utils/otrosGastosI18n.ts`

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V2.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V2.md
@@ -1,0 +1,20 @@
+# Gym Master — i18n ES/EN Admin Dashboard Final Sweep v2 — Otros Gastos Fix v2
+
+## Scope
+- Route: `/dashboard/otros-gastos`
+- Component: receipt upload area in the expense/outflow form.
+
+## Changes
+- Replaces the native visible file input with a custom localized upload control.
+- Avoids browser/OS native text like `Seleccionar archivo / Sin archivos seleccionados` appearing while the app is in English.
+- Adds localized labels:
+  - `Seleccionar archivo` -> `Select file`
+  - `Sin archivo seleccionado` -> `No file selected`
+  - `Subiendo...` -> `Uploading...`
+
+## Safety
+- No DB changes.
+- No endpoint changes.
+- No Swagger/OpenAPI changes.
+- No upload logic changes.
+- The hidden file input still uses the same `handleFileChange` flow.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V3.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V3.md
@@ -1,0 +1,25 @@
+# Gym Master — i18n ES/EN Admin Dashboard Final Sweep v2 — Otros Gastos Fix v3
+
+## Alcance
+- Ruta: `/dashboard/otros-gastos`
+- Corrección incremental sobre `otros_gastos_fix_v2`.
+- Traduce las opciones del combo `Expense type` que venían desde catálogos/DB en español.
+
+## Traducciones agregadas
+- `Sueldos` -> `Salaries`
+- `Mantenimiento` -> `Maintenance`
+- `Servicios` -> `Services`
+- `Insumos` -> `Supplies`
+- `Alquiler` -> `Rent`
+- `Impuestos` -> `Taxes`
+- `Limpieza` -> `Cleaning`
+- `Otros` -> `Other`
+- `Reparación/Reparaciones` -> `Repair/Repairs`
+- `Servicios públicos` -> `Utilities`
+- `Honorarios` -> `Professional fees`
+
+## Seguridad
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica de gastos ni comprobantes.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V4.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V4.md
@@ -1,0 +1,19 @@
+# Gym Master — i18n ES/EN Admin Dashboard Final Sweep v2 — Otros Gastos Fix v4
+
+## Alcance
+Ruta: `/dashboard/otros-gastos`
+
+## Cambio
+- Corrige la descripción dinámica que aparece debajo del combo `Expense type`.
+- Las descripciones de catálogo que vienen desde DB en español ahora se traducen en presentación cuando el idioma activo es `en`.
+
+Ejemplo:
+- `Gastos asociados a mantenimiento de equipamiento o infraestructura.`
+- `Expenses related to equipment or infrastructure maintenance.`
+
+## Seguridad
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica de creación/edición de gastos.
+- No cambia lógica de comprobantes.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V5.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V5.md
@@ -1,0 +1,42 @@
+# Gym Master — i18n ES/EN Admin Dashboard Final Sweep v2 — Otros Gastos fix v5
+
+## Alcance
+Ruta: `/dashboard/otros-gastos`.
+
+Fix incremental sobre `otros_gastos_fix_v4`.
+
+## Corrección
+El combo `Expense type` ya traducía el nombre del tipo, pero la descripción dinámica debajo del combo seguía mostrando textos en español para algunos valores del catálogo/DB.
+
+Este fix amplía el resolver de presentación para cubrir las descripciones de todos los tipos conocidos del combo:
+
+- Unclassified / sin tipo
+- Salaries
+- Maintenance
+- Services
+- Supplies
+- Rent
+- Taxes
+- Cleaning
+- Marketing
+- Other
+- Utilities / servicios públicos
+- Repair / repairs
+- Professional fees
+
+También agrega heurística defensiva por palabras clave para variantes de descripciones provenientes de DB, por ejemplo:
+
+- `Luz, agua, internet, software u otros servicios.` → `Electricity, water, internet, software, or other services.`
+- descripciones de sueldos/jornales/liquidaciones
+- mantenimiento/equipamiento/infraestructura/reparación
+- insumos/oficina/suministros
+- alquiler/renta/local/depósito
+- impuestos/tasas/fiscal/retenciones
+- limpieza/higiene/desinfección
+- marketing/publicidad/comunicación/campañas
+
+## Archivo modificado
+- `src/utils/otrosGastosI18n.ts`
+
+## Seguridad
+No toca DB, endpoints, Swagger/OpenAPI, lógica de gastos, comprobantes ni uploads.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V6.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_FIX_V6.md
@@ -1,0 +1,24 @@
+# Gym Master — Admin dashboard i18n ES/EN final sweep v2 — Otros gastos fix v6
+
+## Scope
+Route: `/dashboard/otros-gastos`
+
+Incremental fix over `otros_gastos_fix_v5`.
+
+## What changed
+- Extends the expense type description resolver so the dynamic helper text under `Expense type` is translated for all known catalog options.
+- Adds exact and defensive translations for descriptions such as:
+  - `Gastos no clasificados.` -> `Unclassified expenses.`
+  - `Pagos mensuales a empleados.` -> `Monthly payments to employees.`
+  - `Pagos a empleados.` -> `Payments to employees.`
+- Keeps existing translations for maintenance, services, supplies, rent, taxes, cleaning, marketing and other operational categories.
+
+## Safety
+- No DB changes.
+- No endpoint changes.
+- No Swagger/OpenAPI changes.
+- No business logic changes.
+- Only presentation/i18n helper changed.
+
+## Modified files
+- `src/utils/otrosGastosI18n.ts`

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_I18N_DUPLICATES_FIX_V2.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_OTROS_GASTOS_I18N_DUPLICATES_FIX_V2.md
@@ -1,0 +1,18 @@
+# I18N ES/EN Admin Dashboard Final Sweep V2 - Otros Gastos i18n duplicates fix v2
+
+## Alcance
+
+Corrige el error de build en `src/utils/otrosGastosI18n.ts` provocado por claves duplicadas dentro del objeto `enOtrosGastosUi`.
+
+## Error corregido
+
+```txt
+Type error: An object literal cannot have multiple properties with the same name.
+src/utils/otrosGastosI18n.ts
+```
+
+## Cambio
+
+Se reemplaza `src/utils/otrosGastosI18n.ts` por la versión equivalente sin claves duplicadas. Mantiene las traducciones agregadas en los fixes previos de Otros Gastos.
+
+No toca DB, endpoints, Swagger/OpenAPI ni lógica funcional.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_PAGOS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_PAGOS_FIX_V1.md
@@ -1,0 +1,32 @@
+# Gym Master — Admin Dashboard Final Sweep v2 — Pagos i18n/dark fix v1
+
+## Alcance
+Ruta: `/dashboard/pagos`
+
+## Cambios
+- Traducción ES/EN de UI fija de pagos:
+  - header, título, subtítulo y filtros.
+  - botones de PDF, Excel y pago manual.
+  - tabla de pagos, footer, caption y paginación.
+  - modal de alta/edición de pago.
+  - formulario de pago manual.
+  - modal de detalle de pago.
+- Traducción de presentación para estados y métodos comunes:
+  - `pagado` -> `Paid`
+  - `pendiente` -> `Pending`
+  - `cancelado` -> `Canceled`
+  - `efectivo` -> `Cash`
+  - `transferencia` -> `Bank transfer`
+- Mejora puntual de dark mode:
+  - card principal de pagos.
+  - tabla y hover de filas.
+  - botones de exportación en dark.
+  - modales de pago/detalle.
+  - panel de descuentos del formulario.
+
+## Seguridad
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica de pagos, Stripe, descuentos ni recibos.
+- No cambia PDF/Excel estructuralmente; solo labels de presentación según idioma activo.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_PAGOS_FIX_V2.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_PAGOS_FIX_V2.md
@@ -1,0 +1,17 @@
+# I18N ES/EN Admin Dashboard Final Sweep v2 - Pagos Fix v2
+
+## Alcance
+- Refina `src/components/forms/PagoForm.tsx`.
+- Corrige mensajes dinámicos de preview de descuento/bonificación que llegan desde la lógica de pagos en español mientras la UI está en inglés.
+
+## Cambios
+- Agrega `translatePaymentPreviewMessage` para traducción de presentación.
+- Traduce frases como:
+  - `Pagando 2 o más cuotas por adelantado obtenés 10% de descuento.`
+  - `Pagando 2 o más cuotas se aplicará 10% de descuento.`
+- No modifica cálculos, reglas de descuento, cuotas, DB, endpoints ni Swagger/OpenAPI.
+
+## QA
+- Abrir `/dashboard/pagos` en EN.
+- Abrir `Register manual payment`.
+- Confirmar que el panel `Applied discounts and bonus` no muestre frases en español.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_RAG_CORPUS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_RAG_CORPUS_FIX_V1.md
@@ -1,0 +1,10 @@
+# i18n ES/EN admin dashboard final sweep v2 - RAG Corpus fix v1
+
+Scope: `/dashboard/rag-corpus`.
+
+- Adds ES/EN translations for the RAG corpus admin page.
+- Translates KPI labels, coverage sections, controlled batch actions, corpus domains, recommendations, loading/error fallback text, and last-run title.
+- Adds local dark-mode polish for cards, inputs, table, progress bars, and status blocks.
+- Does not touch database, endpoints, Swagger/OpenAPI, ingestion/vectorization logic, or RAG services.
+
+Apply with robocopy from `chatgpt_patch` into the project root.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_SOCIOS_RANKING_BONIFICACION_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V2_SOCIOS_RANKING_BONIFICACION_FIX_V1.md
@@ -1,0 +1,25 @@
+# I18N ES/EN Admin Dashboard Final Sweep v2 - Socios ranking bonificación fix v1
+
+## Scope
+
+Route: `/dashboard/socios-ranking-bonificacion`.
+
+## Changes
+
+- Adds local ES/EN presentation translation through `useI18n`.
+- Translates visible EN UI residuals:
+  - main title/subtitle
+  - KPI cards
+  - period/filter card
+  - chart card and empty states
+  - ranking table headers, statuses, action buttons and pagination
+  - commercial rules and backend warnings shown on screen
+- Translates export labels for Excel/PDF without changing business calculations.
+- Adds dark-mode polishing for KPI cards, panels, table, badges, warnings and rule cards.
+
+## Not changed
+
+- No database changes.
+- No API endpoint changes.
+- No Swagger/OpenAPI changes.
+- No ranking or bonus calculation changes.

--- a/src/app/dashboard/bi-socios-demografia-promociones/page.tsx
+++ b/src/app/dashboard/bi-socios-demografia-promociones/page.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import ExcelJS from 'exceljs';
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import ExcelJS from "exceljs";
 import {
   Bar,
   BarChart,
@@ -18,7 +18,7 @@ import {
   Tooltip,
   XAxis,
   YAxis,
-} from 'recharts';
+} from "recharts";
 import {
   CalendarDays,
   FileSpreadsheet,
@@ -31,25 +31,35 @@ import {
   VenusAndMars,
   WalletCards,
   type LucideIcon,
-} from 'lucide-react';
-import { toast } from 'sonner';
-import { AppFooter } from '@/components/footer/AppFooter';
-import { AppHeader } from '@/components/header/AppHeader';
-import { AppSidebar } from '@/components/sidebar/AppSidebar';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
-import { SociosDemografiaBiResponse } from '@/interfaces/sociosDemografiaBi.interface';
-import { formatCurrencyARS } from '@/lib/comercial/productos';
-import { getSociosDemografiaPromocionesBi } from '@/services/sociosDemografiaBiService';
-import { useAuthStore } from '@/stores/authStore';
-import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
-import { downloadCommercialReportPdf } from '@/utils/commercialReportPdf';
-import { formatFrontendDate } from '@/utils/dateFormat';
+} from "lucide-react";
+import { toast } from "sonner";
+import { AppFooter } from "@/components/footer/AppFooter";
+import { AppHeader } from "@/components/header/AppHeader";
+import { AppSidebar } from "@/components/sidebar/AppSidebar";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { SociosDemografiaBiResponse } from "@/interfaces/sociosDemografiaBi.interface";
+import { formatCurrencyARS } from "@/lib/comercial/productos";
+import { getSociosDemografiaPromocionesBi } from "@/services/sociosDemografiaBiService";
+import { useAuthStore } from "@/stores/authStore";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
+import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
+import { formatFrontendDate } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
-const CHART_COLORS = ['#0284c7', '#ec4899', '#64748b', '#16a34a', '#f97316', '#7c3aed', '#dc2626'];
+const CHART_COLORS = [
+  "#0284c7",
+  "#ec4899",
+  "#64748b",
+  "#16a34a",
+  "#f97316",
+  "#7c3aed",
+  "#dc2626",
+];
 
 function todayISO() {
   return new Date().toISOString().slice(0, 10);
@@ -60,19 +70,199 @@ function firstDayOfCurrentYearISO() {
 }
 
 function formatNumber(value?: number | null) {
-  return new Intl.NumberFormat('es-AR', {
+  return new Intl.NumberFormat("es-AR", {
     maximumFractionDigits: 0,
   }).format(Number(value ?? 0));
 }
 
 function formatPercent(value?: number | null) {
-  if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
+  if (value === null || value === undefined || Number.isNaN(Number(value)))
+    return "-";
   return `${Number(value).toFixed(1)}%`;
 }
 
-function formatAge(value?: number | null) {
-  if (value === null || value === undefined) return '-';
-  return `${Number(value).toFixed(1)} años`;
+function biTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function normalizeBiText(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function formatAge(locale: GymMasterLocale, value?: number | null) {
+  if (value === null || value === undefined) return "-";
+  return locale === "en"
+    ? `${Number(value).toFixed(1)} years`
+    : `${Number(value).toFixed(1)} años`;
+}
+
+const AGE_BAND_TRANSLATIONS: Record<string, string> = {
+  "menores de 18": "Under 18",
+  "18 a 24": "18 to 24",
+  "25 a 34": "25 to 34",
+  "35 a 44": "35 to 44",
+  "45 a 54": "45 to 54",
+  "55 o mas": "55 or older",
+  "sin fecha de nacimiento": "No birth date",
+};
+
+const GENDER_TRANSLATIONS: Record<string, string> = {
+  hombres: "Men",
+  hombre: "Men",
+  mujeres: "Women",
+  mujer: "Women",
+  "sin dato": "No data",
+  "no data": "No data",
+};
+
+function translateAgeBand(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+  return AGE_BAND_TRANSLATIONS[normalizeBiText(raw)] ?? raw;
+}
+
+function translateGenderLabel(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+  return GENDER_TRANSLATIONS[normalizeBiText(raw)] ?? raw;
+}
+
+function translateSegmentLabel(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  return raw
+    .split("·")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => translateGenderLabel(locale, translateAgeBand(locale, part)))
+    .join(" · ");
+}
+
+function translatePriority(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const normalized = normalizeBiText(raw);
+  if (normalized === "alta") return "High";
+  if (normalized === "media") return "Medium";
+  if (normalized === "baja") return "Low";
+  return raw;
+}
+
+function translateRankingType(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const normalized = normalizeBiText(raw);
+  if (normalized === "producto") return "Product";
+  if (normalized === "servicio") return "Service";
+  if (normalized === "venta_sin_detalle") return "Sale without detail";
+  return raw;
+}
+
+function biSalesCount(locale: GymMasterLocale, count: number) {
+  return locale === "en"
+    ? `${formatNumber(count)} registered ${count === 1 ? "sale" : "sales"}`
+    : `${formatNumber(count)} ventas registradas`;
+}
+
+function translatePromotionTitle(
+  locale: GymMasterLocale,
+  value?: string | null,
+) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const translations: Record<string, string> = {
+    "campana de fidelizacion para el segmento mas activo":
+      "Loyalty campaign for the most active segment",
+    "reactivacion de socios con baja asistencia":
+      "Member reactivation with low attendance",
+    "promocion cruzada para segmento con mayor consumo":
+      "Cross-sell promotion for the highest-consumption segment",
+    "oferta principal para la franja demografica dominante":
+      "Main offer for the dominant demographic group",
+    "impulsar producto o servicio de mayor traccion":
+      "Promote the highest-traction product or service",
+  };
+
+  return translations[normalizeBiText(raw)] ?? raw;
+}
+
+function translatePromotionAction(
+  locale: GymMasterLocale,
+  value?: string | null,
+) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const translations: Record<string, string> = {
+    "ofrecer beneficio por continuidad, desafio mensual o programa de referidos para capitalizar el habito de asistencia.":
+      "Offer a continuity benefit, monthly challenge, or referral program to capitalize on the attendance habit.",
+    "enviar campana de motivacion, rutina breve de reinicio o promocion de acompanamiento por entrenador.":
+      "Send a motivation campaign, short restart routine, or trainer-supported promotion.",
+    "crear combo de producto/servicio asociado al comportamiento de compra del segmento.":
+      "Create a product/service bundle associated with the segment purchase behavior.",
+    "ajustar comunicacion, horarios y beneficios comerciales a la franja con mayor presencia.":
+      "Adjust communication, schedules, and commercial benefits for the age range with the strongest presence.",
+    "usar este item como gancho comercial, pack mensual o beneficio de renovacion.":
+      "Use this item as a commercial hook, monthly pack, or renewal benefit.",
+  };
+
+  return translations[normalizeBiText(raw)] ?? raw;
+}
+
+function translatePromotionDescription(
+  locale: GymMasterLocale,
+  item: {
+    titulo?: string | null;
+    descripcion?: string | null;
+    segmento?: string | null;
+  },
+) {
+  const raw = String(item.descripcion ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const title = normalizeBiText(item.titulo);
+  const segment = translateSegmentLabel(locale, item.segmento);
+  if (title.includes("fidelizacion")) {
+    const attendances =
+      raw.match(/concentra\s+(\d[\d.,]*)\s+asistencias/i)?.[1] ?? "";
+    return `${segment} concentrates ${attendances} attendances in the period.`;
+  }
+
+  if (title.includes("reactivacion")) {
+    return `${segment} shows low relative attendance during the analyzed period.`;
+  }
+
+  if (title.includes("promocion cruzada")) {
+    const amount = raw.match(/consumo por\s+([\d.,]+)\s+ARS/i)?.[1] ?? "";
+    return `${segment} generated consumption of ARS ${amount}.`;
+  }
+
+  if (title.includes("franja demografica")) {
+    const members = raw.match(/reúne\s+(\d[\d.,]*)\s+socios/i)?.[1] ?? "";
+    return `${segment} brings together ${members} active members.`;
+  }
+
+  if (title.includes("mayor traccion")) {
+    const itemName = raw.split(" lidera ")[0] || raw;
+    return `${itemName} leads the consumption ranking for ${segment}.`;
+  }
+
+  return raw
+    .replace(/asistencias en el período/gi, "attendances in the period")
+    .replace(/socios activos/gi, "active members")
+    .replace(
+      /muestra baja asistencia relativa durante el período analizado/gi,
+      "shows low relative attendance during the analyzed period",
+    );
 }
 
 function MetricCard({
@@ -80,32 +270,35 @@ function MetricCard({
   value,
   description,
   icon: Icon,
-  tone = 'default',
+  tone = "default",
 }: {
   title: string;
   value: string;
   description: string;
   icon: LucideIcon;
-  tone?: 'default' | 'blue' | 'green' | 'pink' | 'warning';
+  tone?: "default" | "blue" | "green" | "pink" | "warning";
 }) {
   const toneClass = {
-    default: 'bg-slate-100 text-slate-700',
-    blue: 'bg-sky-50 text-sky-700',
-    green: 'bg-emerald-50 text-emerald-700',
-    pink: 'bg-pink-50 text-pink-700',
-    warning: 'bg-amber-50 text-amber-700',
+    default:
+      "bg-slate-100 text-slate-700 dark:bg-neutral-900 dark:text-neutral-200",
+    blue: "bg-sky-50 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
+    green:
+      "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300",
+    pink: "bg-pink-50 text-pink-700 dark:bg-pink-950/50 dark:text-pink-300",
+    warning:
+      "bg-amber-50 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300",
   }[tone];
 
   return (
-    <Card>
-      <CardContent className='flex items-center justify-between gap-4 p-5'>
-        <div className='space-y-1'>
-          <p className='text-sm text-muted-foreground'>{title}</p>
-          <p className='text-2xl font-bold'>{value}</p>
-          <p className='text-xs text-muted-foreground'>{description}</p>
+    <Card className="bg-white text-slate-950 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
+      <CardContent className="flex items-center justify-between gap-4 p-5">
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">{title}</p>
+          <p className="text-2xl font-bold">{value}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
         </div>
         <div className={`rounded-full p-3 ${toneClass}`}>
-          <Icon className='h-5 w-5' />
+          <Icon className="h-5 w-5" />
         </div>
       </CardContent>
     </Card>
@@ -114,7 +307,7 @@ function MetricCard({
 
 function EmptyChart({ label }: { label: string }) {
   return (
-    <div className='flex h-full items-center justify-center text-center text-sm text-muted-foreground'>
+    <div className="flex h-full items-center justify-center text-center text-sm text-muted-foreground">
       {label}
     </div>
   );
@@ -122,6 +315,8 @@ function EmptyChart({ label }: { label: string }) {
 
 export default function BiSociosDemografiaPromocionesPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => biTx(locale, es, en);
   const router = useRouter();
   const [desde, setDesde] = useState(firstDayOfCurrentYearISO());
   const [hasta, setHasta] = useState(todayISO());
@@ -134,7 +329,7 @@ export default function BiSociosDemografiaPromocionesPage() {
 
   useEffect(() => {
     if (isInitialized && !isAuthenticated) {
-      router.push('/auth/login');
+      router.push("/auth/login");
     }
   }, [isAuthenticated, isInitialized, router]);
 
@@ -145,7 +340,13 @@ export default function BiSociosDemografiaPromocionesPage() {
       const response = await getSociosDemografiaPromocionesBi({ desde, hasta });
       setData(response);
     } catch (error: any) {
-      toast.error(error.message || 'No se pudo cargar el BI demográfico de socios');
+      toast.error(
+        error.message ||
+          c(
+            "No se pudo cargar el BI demográfico de socios",
+            "Unable to load members demographic BI",
+          ),
+      );
       setData(null);
     } finally {
       setLoading(false);
@@ -161,77 +362,188 @@ export default function BiSociosDemografiaPromocionesPage() {
 
   const metricas = data?.metricas;
   const generoData = useMemo(
-    () => (data?.distribucion_genero ?? []).filter((item) => item.cantidad > 0),
-    [data]
+    () =>
+      (data?.distribucion_genero ?? [])
+        .filter((item) => item.cantidad > 0)
+        .map((item) => ({
+          ...item,
+          label: translateGenderLabel(locale, item.label),
+        })),
+    [data, locale],
   );
-  const franjasData = useMemo(() => data?.franjas_etarias ?? [], [data]);
+  const franjasData = useMemo(
+    () =>
+      (data?.franjas_etarias ?? []).map((item) => ({
+        ...item,
+        franja: translateAgeBand(locale, item.franja),
+      })),
+    [data, locale],
+  );
   const altasData = useMemo(() => data?.altas_mensuales ?? [], [data]);
-  const asistenciaData = useMemo(() => data?.asistencia_por_segmento.slice(0, 10) ?? [], [data]);
-  const consumoData = useMemo(() => data?.consumo_por_segmento.slice(0, 10) ?? [], [data]);
-  const rankingData = useMemo(() => data?.ranking_productos_servicios.slice(0, 8) ?? [], [data]);
+  const asistenciaData = useMemo(
+    () =>
+      (data?.asistencia_por_segmento.slice(0, 10) ?? []).map((item) => ({
+        ...item,
+        segmento: translateSegmentLabel(locale, item.segmento),
+      })),
+    [data, locale],
+  );
+  const consumoData = useMemo(
+    () =>
+      (data?.consumo_por_segmento.slice(0, 10) ?? []).map((item) => ({
+        ...item,
+        segmento: translateSegmentLabel(locale, item.segmento),
+      })),
+    [data, locale],
+  );
+  const rankingData = useMemo(
+    () =>
+      (data?.ranking_productos_servicios.slice(0, 8) ?? []).map((item) => ({
+        ...item,
+        tipo: translateRankingType(locale, item.tipo),
+        segmento: translateSegmentLabel(locale, item.segmento),
+      })),
+    [data, locale],
+  );
+  const promocionesData = useMemo(
+    () =>
+      (data?.promociones_sugeridas ?? []).map((item) => ({
+        ...item,
+        titulo: translatePromotionTitle(locale, item.titulo),
+        descripcion: translatePromotionDescription(locale, item),
+        segmento: translateSegmentLabel(locale, item.segmento),
+        accion_sugerida: translatePromotionAction(locale, item.accion_sugerida),
+        prioridad: translatePriority(locale, item.prioridad),
+      })),
+    [data, locale],
+  );
 
   const handleExportExcel = async () => {
     if (!data) return;
 
     const workbook = new ExcelJS.Workbook();
-    const resumen = workbook.addWorksheet('Resumen');
+    const resumen = workbook.addWorksheet(c("Resumen", "Summary"));
     resumen.columns = [
-      { header: 'Métrica', key: 'metrica', width: 34 },
-      { header: 'Valor', key: 'valor', width: 18 },
+      { header: c("Métrica", "Metric"), key: "metrica", width: 34 },
+      { header: c("Valor", "Value"), key: "valor", width: 18 },
     ];
     resumen.addRows([
-      { metrica: 'Total socios', valor: data.metricas.total_socios },
-      { metrica: 'Socios activos', valor: data.metricas.socios_activos },
-      { metrica: 'Hombres', valor: data.metricas.hombres },
-      { metrica: 'Mujeres', valor: data.metricas.mujeres },
-      { metrica: 'Edad promedio', valor: data.metricas.edad_promedio ?? '-' },
-      { metrica: 'Altas período', valor: data.metricas.altas_periodo },
-      { metrica: 'Asistencias período', valor: data.metricas.asistencias_periodo },
-      { metrica: 'Pagos período', valor: data.metricas.pagos_periodo },
-      { metrica: 'Consumo período', valor: data.metricas.consumo_periodo },
+      {
+        metrica: c("Total socios", "Total members"),
+        valor: data.metricas.total_socios,
+      },
+      {
+        metrica: c("Socios activos", "Active members"),
+        valor: data.metricas.socios_activos,
+      },
+      { metrica: c("Hombres", "Men"), valor: data.metricas.hombres },
+      { metrica: c("Mujeres", "Women"), valor: data.metricas.mujeres },
+      {
+        metrica: c("Edad promedio", "Average age"),
+        valor: data.metricas.edad_promedio ?? "-",
+      },
+      {
+        metrica: c("Altas período", "Period sign-ups"),
+        valor: data.metricas.altas_periodo,
+      },
+      {
+        metrica: c("Asistencias período", "Period attendance"),
+        valor: data.metricas.asistencias_periodo,
+      },
+      {
+        metrica: c("Pagos período", "Period payments"),
+        valor: data.metricas.pagos_periodo,
+      },
+      {
+        metrica: c("Consumo período", "Period consumption"),
+        valor: data.metricas.consumo_periodo,
+      },
     ]);
 
-    const franjas = workbook.addWorksheet('Franjas etarias');
+    const franjas = workbook.addWorksheet(c("Franjas etarias", "Age ranges"));
     franjas.columns = [
-      { header: 'Franja', key: 'franja', width: 24 },
-      { header: 'Socios', key: 'cantidad_socios', width: 12 },
-      { header: '% socios', key: 'porcentaje_socios', width: 12 },
-      { header: 'Hombres', key: 'hombres', width: 12 },
-      { header: 'Mujeres', key: 'mujeres', width: 12 },
-      { header: 'Altas', key: 'altas_periodo', width: 12 },
-      { header: 'Asistencias', key: 'asistencias_periodo', width: 14 },
-      { header: 'Pagos', key: 'pagos_periodo', width: 18 },
-      { header: 'Consumo', key: 'consumo_periodo', width: 18 },
+      { header: c("Franja", "Age range"), key: "franja", width: 24 },
+      { header: c("Socios", "Members"), key: "cantidad_socios", width: 12 },
+      {
+        header: c("% socios", "% members"),
+        key: "porcentaje_socios",
+        width: 12,
+      },
+      { header: c("Hombres", "Men"), key: "hombres", width: 12 },
+      { header: c("Mujeres", "Women"), key: "mujeres", width: 12 },
+      { header: c("Altas", "Sign-ups"), key: "altas_periodo", width: 12 },
+      {
+        header: c("Asistencias", "Attendance"),
+        key: "asistencias_periodo",
+        width: 14,
+      },
+      { header: c("Pagos", "Payments"), key: "pagos_periodo", width: 18 },
+      {
+        header: c("Consumo", "Consumption"),
+        key: "consumo_periodo",
+        width: 18,
+      },
     ];
-    data.franjas_etarias.forEach((item) => franjas.addRow(item));
+    data.franjas_etarias.forEach((item) =>
+      franjas.addRow({
+        ...item,
+        franja: translateAgeBand(locale, item.franja),
+      }),
+    );
 
-    const ranking = workbook.addWorksheet('Ranking consumo');
+    const ranking = workbook.addWorksheet(
+      c("Ranking consumo", "Consumption ranking"),
+    );
     ranking.columns = [
-      { header: 'Item', key: 'item', width: 34 },
-      { header: 'Tipo', key: 'tipo', width: 14 },
-      { header: 'Segmento', key: 'segmento', width: 34 },
-      { header: 'Cantidad', key: 'cantidad', width: 12 },
-      { header: 'Total', key: 'total', width: 18 },
+      { header: "Item", key: "item", width: 34 },
+      { header: c("Tipo", "Type"), key: "tipo", width: 14 },
+      { header: c("Segmento", "Segment"), key: "segmento", width: 34 },
+      { header: c("Cantidad", "Quantity"), key: "cantidad", width: 12 },
+      { header: "Total", key: "total", width: 18 },
     ];
-    data.ranking_productos_servicios.forEach((item) => ranking.addRow(item));
+    data.ranking_productos_servicios.forEach((item) =>
+      ranking.addRow({
+        ...item,
+        tipo: translateRankingType(locale, item.tipo),
+        segmento: translateSegmentLabel(locale, item.segmento),
+      }),
+    );
 
-    const promociones = workbook.addWorksheet('Promociones sugeridas');
+    const promociones = workbook.addWorksheet(
+      c("Promociones sugeridas", "Suggested promotions"),
+    );
     promociones.columns = [
-      { header: 'Título', key: 'titulo', width: 36 },
-      { header: 'Segmento', key: 'segmento', width: 32 },
-      { header: 'Prioridad', key: 'prioridad', width: 12 },
-      { header: 'Acción sugerida', key: 'accion_sugerida', width: 60 },
+      { header: c("Título", "Title"), key: "titulo", width: 36 },
+      { header: c("Segmento", "Segment"), key: "segmento", width: 32 },
+      { header: c("Prioridad", "Priority"), key: "prioridad", width: 12 },
+      {
+        header: c("Acción sugerida", "Suggested action"),
+        key: "accion_sugerida",
+        width: 60,
+      },
     ];
-    data.promociones_sugeridas.forEach((item) => promociones.addRow(item));
+    data.promociones_sugeridas.forEach((item) =>
+      promociones.addRow({
+        ...item,
+        titulo: translatePromotionTitle(locale, item.titulo),
+        descripcion: translatePromotionDescription(locale, item),
+        segmento: translateSegmentLabel(locale, item.segmento),
+        accion_sugerida: translatePromotionAction(locale, item.accion_sugerida),
+        prioridad: translatePriority(locale, item.prioridad),
+      }),
+    );
 
     const buffer = await workbook.xlsx.writeBuffer();
     const blob = new Blob([buffer], {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     });
     const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = buildTimestampedDownloadFileName('bi-socios-demografia-promociones', 'xlsx');
+    a.download = buildTimestampedDownloadFileName(
+      "bi-socios-demografia-promociones",
+      "xlsx",
+    );
     a.click();
     window.URL.revokeObjectURL(url);
   };
@@ -241,164 +553,327 @@ export default function BiSociosDemografiaPromocionesPage() {
 
     try {
       await downloadCommercialReportPdf({
-        title: 'BI Socios',
-        subtitle: 'Demografía, asistencia, consumo y oportunidades comerciales.',
-        fileName: 'bi-socios-demografia-promociones',
+        title: c("BI Socios", "Members BI"),
+        subtitle: c(
+          "Demografía, asistencia, consumo y oportunidades comerciales.",
+          "Demographics, attendance, consumption, and commercial opportunities.",
+        ),
+        fileName: "bi-socios-demografia-promociones",
         rows: data.franjas_etarias,
         metrics: [
-          { label: 'Socios', value: formatNumber(data.metricas.total_socios) },
-          { label: 'Hombres', value: `${formatNumber(data.metricas.hombres)} (${formatPercent(data.metricas.porcentaje_hombres)})` },
-          { label: 'Mujeres', value: `${formatNumber(data.metricas.mujeres)} (${formatPercent(data.metricas.porcentaje_mujeres)})` },
-          { label: 'Edad prom.', value: formatAge(data.metricas.edad_promedio) },
-        ],
-        filtersLabel: `Período: ${formatFrontendDate(data.desde)} al ${formatFrontendDate(data.hasta)}`,
-        charts: [
           {
-            title: 'Socios por franja etaria',
-            kind: 'bars',
-            data: data.franjas_etarias.map((item) => ({ ...item })),
-            labelKey: 'franja',
-            series: [{ key: 'cantidad_socios', label: 'Socios', color: [2, 132, 199] }],
+            label: c("Socios", "Members"),
+            value: formatNumber(data.metricas.total_socios),
           },
           {
-            title: 'Altas mensuales',
-            kind: 'line',
+            label: c("Hombres", "Men"),
+            value: `${formatNumber(data.metricas.hombres)} (${formatPercent(data.metricas.porcentaje_hombres)})`,
+          },
+          {
+            label: c("Mujeres", "Women"),
+            value: `${formatNumber(data.metricas.mujeres)} (${formatPercent(data.metricas.porcentaje_mujeres)})`,
+          },
+          {
+            label: c("Edad prom.", "Avg. age"),
+            value: formatAge(locale, data.metricas.edad_promedio),
+          },
+        ],
+        filtersLabel: `${c("Período", "Period")}: ${formatFrontendDate(data.desde)} ${c("al", "to")} ${formatFrontendDate(data.hasta)}`,
+        charts: [
+          {
+            title: c("Socios por franja etaria", "Members by age range"),
+            kind: "bars",
+            data: data.franjas_etarias.map((item) => ({
+              ...item,
+              franja: translateAgeBand(locale, item.franja),
+            })),
+            labelKey: "franja",
+            series: [
+              {
+                key: "cantidad_socios",
+                label: c("Socios", "Members"),
+                color: [2, 132, 199],
+              },
+            ],
+          },
+          {
+            title: c("Altas mensuales", "Monthly sign-ups"),
+            kind: "line",
             data: data.altas_mensuales.map((item) => ({ ...item })),
-            labelKey: 'periodo_label',
-            series: [{ key: 'total', label: 'Altas', color: [22, 163, 74] }],
+            labelKey: "periodo_label",
+            series: [
+              {
+                key: "total",
+                label: c("Altas", "Sign-ups"),
+                color: [22, 163, 74],
+              },
+            ],
           },
         ],
         columns: [
-          { header: 'Franja', width: 34, getValue: (row) => row.franja },
-          { header: 'Socios', width: 22, getValue: (row) => row.cantidad_socios, align: 'right' },
-          { header: '%', width: 18, getValue: (row) => formatPercent(row.porcentaje_socios), align: 'right' },
-          { header: 'Hombres', width: 22, getValue: (row) => row.hombres, align: 'right' },
-          { header: 'Mujeres', width: 22, getValue: (row) => row.mujeres, align: 'right' },
-          { header: 'Altas', width: 22, getValue: (row) => row.altas_periodo, align: 'right' },
-          { header: 'Asist.', width: 22, getValue: (row) => row.asistencias_periodo, align: 'right' },
-          { header: 'Consumo', width: 28, getValue: (row) => formatCurrencyARS(row.consumo_periodo), align: 'right' },
+          {
+            header: c("Franja", "Age range"),
+            width: 34,
+            getValue: (row) => translateAgeBand(locale, row.franja),
+          },
+          {
+            header: c("Socios", "Members"),
+            width: 22,
+            getValue: (row) => row.cantidad_socios,
+            align: "right",
+          },
+          {
+            header: "%",
+            width: 18,
+            getValue: (row) => formatPercent(row.porcentaje_socios),
+            align: "right",
+          },
+          {
+            header: c("Hombres", "Men"),
+            width: 22,
+            getValue: (row) => row.hombres,
+            align: "right",
+          },
+          {
+            header: c("Mujeres", "Women"),
+            width: 22,
+            getValue: (row) => row.mujeres,
+            align: "right",
+          },
+          {
+            header: c("Altas", "Sign-ups"),
+            width: 22,
+            getValue: (row) => row.altas_periodo,
+            align: "right",
+          },
+          {
+            header: c("Asist.", "Attendance"),
+            width: 22,
+            getValue: (row) => row.asistencias_periodo,
+            align: "right",
+          },
+          {
+            header: c("Consumo", "Consumption"),
+            width: 28,
+            getValue: (row) => formatCurrencyARS(row.consumo_periodo),
+            align: "right",
+          },
         ],
       });
     } catch {
-      toast.error('No se pudo generar el PDF de BI de socios');
+      toast.error(
+        c(
+          "No se pudo generar el PDF de BI de socios",
+          "Unable to generate members BI PDF",
+        ),
+      );
     }
   };
 
-  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isInitialized) return <div>{c("Cargando...", "Loading...")}</div>;
   if (!isAuthenticated) return null;
 
   return (
     <SidebarProvider>
-      <div className='flex min-h-screen w-full'>
+      <div className="flex min-h-screen w-full">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title='BI Socios / Promociones' />
-          <main className='flex-1 space-y-6 p-6'>
-            <section className='rounded-2xl border bg-white p-6 shadow-sm'>
-              <div className='flex flex-col justify-between gap-4 lg:flex-row lg:items-center'>
-                <div className='space-y-2'>
-                  <p className='text-xs font-semibold uppercase tracking-[0.24em] text-sky-600'>
-                    Business Intelligence comercial
+          <AppHeader
+            title={c("BI Socios / Promociones", "Members / Promotions BI")}
+          />
+          <main className="flex-1 space-y-6 bg-slate-50 p-6 dark:bg-neutral-950">
+            <section className="rounded-2xl border bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
+              <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-600">
+                    {c(
+                      "Business Intelligence comercial",
+                      "Commercial business intelligence",
+                    )}
                   </p>
-                  <h1 className='text-2xl font-bold'>Socios, demografía y promociones</h1>
-                  <p className='max-w-3xl text-sm leading-relaxed text-muted-foreground'>
-                    Analizá género, edad, altas, asistencia, pagos y consumo para tomar decisiones comerciales basadas en datos reales del gimnasio.
+                  <h1 className="text-2xl font-bold">
+                    {c(
+                      "Socios, demografía y promociones",
+                      "Members, demographics, and promotions",
+                    )}
+                  </h1>
+                  <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
+                    {c(
+                      "Analizá género, edad, altas, asistencia, pagos y consumo para tomar decisiones comerciales basadas en datos reales del gimnasio.",
+                      "Analyze gender, age, sign-ups, attendance, payments, and consumption to make commercial decisions based on real gym data.",
+                    )}
                   </p>
                 </div>
-                <div className='flex flex-wrap gap-2'>
-                  <Button asChild variant='outline'>
-                    <Link href='/dashboard/socios'>Socios</Link>
+                <div className="flex flex-wrap gap-2">
+                  <Button asChild variant="outline">
+                    <Link href="/dashboard/socios">
+                      {c("Socios", "Members")}
+                    </Link>
                   </Button>
-                  <Button asChild variant='outline'>
-                    <Link href='/dashboard/finanzas'>Finanzas</Link>
+                  <Button asChild variant="outline">
+                    <Link href="/dashboard/finanzas">
+                      {c("Finanzas", "Finance")}
+                    </Link>
                   </Button>
-                  <Button asChild variant='outline'>
-                    <Link href='/dashboard/notificaciones'>Campañas</Link>
+                  <Button asChild variant="outline">
+                    <Link href="/dashboard/notificaciones">
+                      {c("Campañas", "Campaigns")}
+                    </Link>
                   </Button>
                 </div>
               </div>
             </section>
 
-            <Card>
-              <CardContent className='flex flex-col gap-4 p-4 lg:flex-row lg:items-end lg:justify-between'>
-                <div className='grid flex-1 grid-cols-1 gap-3 md:grid-cols-2 lg:max-w-xl'>
-                  <div className='space-y-2'>
-                    <Label htmlFor='fecha-desde'>Fecha desde</Label>
-                    <Input id='fecha-desde' type='date' value={desde} onChange={(event) => setDesde(event.target.value)} />
+            <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
+              <CardContent className="flex flex-col gap-4 p-4 lg:flex-row lg:items-end lg:justify-between">
+                <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-2 lg:max-w-xl">
+                  <div className="space-y-2">
+                    <Label htmlFor="fecha-desde">
+                      {c("Fecha desde", "Date from")}
+                    </Label>
+                    <Input
+                      id="fecha-desde"
+                      type="date"
+                      value={desde}
+                      onChange={(event) => setDesde(event.target.value)}
+                    />
                   </div>
-                  <div className='space-y-2'>
-                    <Label htmlFor='fecha-hasta'>Fecha hasta</Label>
-                    <Input id='fecha-hasta' type='date' value={hasta} onChange={(event) => setHasta(event.target.value)} />
+                  <div className="space-y-2">
+                    <Label htmlFor="fecha-hasta">
+                      {c("Fecha hasta", "Date to")}
+                    </Label>
+                    <Input
+                      id="fecha-hasta"
+                      type="date"
+                      value={hasta}
+                      onChange={(event) => setHasta(event.target.value)}
+                    />
                   </div>
                 </div>
-                <div className='flex flex-wrap gap-2'>
-                  <Button type='button' onClick={loadData} disabled={loading} className='bg-[#02a8e1] hover:bg-[#0288b1]'>
-                    <RefreshCcw className='mr-2 h-4 w-4' />
-                    {loading ? 'Actualizando...' : 'Actualizar'}
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    onClick={loadData}
+                    disabled={loading}
+                    className="bg-[#02a8e1] hover:bg-[#0288b1]"
+                  >
+                    <RefreshCcw className="mr-2 h-4 w-4" />
+                    {loading
+                      ? c("Actualizando...", "Refreshing...")
+                      : c("Actualizar", "Refresh")}
                   </Button>
-                  <Button type='button' variant='outline' onClick={handleDownloadPdf} disabled={!data} className='border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]'>
-                    <FileText className='mr-2 h-4 w-4' />
-                    Descargar PDF
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleDownloadPdf}
+                    disabled={!data}
+                    className="border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                  >
+                    <FileText className="mr-2 h-4 w-4" />
+                    {c("Descargar PDF", "Download PDF")}
                   </Button>
-                  <Button type='button' variant='outline' onClick={handleExportExcel} disabled={!data} className='border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]'>
-                    <FileSpreadsheet className='mr-2 h-4 w-4' />
-                    Exportar
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleExportExcel}
+                    disabled={!data}
+                    className="border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                  >
+                    <FileSpreadsheet className="mr-2 h-4 w-4" />
+                    {c("Exportar", "Export")}
                   </Button>
                 </div>
               </CardContent>
             </Card>
 
-            <section className='grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4'>
+            <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
               <MetricCard
-                title='Socios activos'
-                value={loading || !metricas ? '...' : formatNumber(metricas.socios_activos)}
-                description={`${metricas ? formatNumber(metricas.total_socios) : '-'} socios totales`}
+                title={c("Socios activos", "Active members")}
+                value={
+                  loading || !metricas
+                    ? "..."
+                    : formatNumber(metricas.socios_activos)
+                }
+                description={`${metricas ? formatNumber(metricas.total_socios) : "-"} ${c("socios totales", "total members")}`}
                 icon={Users}
-                tone='blue'
+                tone="blue"
               />
               <MetricCard
-                title='Distribución'
-                value={loading || !metricas ? '...' : `${formatPercent(metricas.porcentaje_hombres)} / ${formatPercent(metricas.porcentaje_mujeres)}`}
-                description='Hombres / mujeres registrados.'
+                title={c("Distribución", "Distribution")}
+                value={
+                  loading || !metricas
+                    ? "..."
+                    : `${formatPercent(metricas.porcentaje_hombres)} / ${formatPercent(metricas.porcentaje_mujeres)}`
+                }
+                description={c(
+                  "Hombres / mujeres registrados.",
+                  "Registered men / women.",
+                )}
                 icon={VenusAndMars}
-                tone='pink'
+                tone="pink"
               />
               <MetricCard
-                title='Edad promedio'
-                value={loading || !metricas ? '...' : formatAge(metricas.edad_promedio)}
-                description={`${metricas ? formatNumber(metricas.altas_periodo) : '-'} altas en el período`}
+                title={c("Edad promedio", "Average age")}
+                value={
+                  loading || !metricas
+                    ? "..."
+                    : formatAge(locale, metricas.edad_promedio)
+                }
+                description={`${metricas ? formatNumber(metricas.altas_periodo) : "-"} ${c("altas en el período", "sign-ups in the period")}`}
                 icon={CalendarDays}
-                tone='green'
+                tone="green"
               />
               <MetricCard
-                title='Consumo socio'
-                value={loading || !metricas ? '...' : formatCurrencyARS(metricas.consumo_periodo)}
-                description={`${metricas ? formatNumber(metricas.asistencias_periodo) : '-'} asistencias analizadas`}
+                title={c("Consumo socio", "Member consumption")}
+                value={
+                  loading || !metricas
+                    ? "..."
+                    : formatCurrencyARS(metricas.consumo_periodo)
+                }
+                description={`${metricas ? formatNumber(metricas.asistencias_periodo) : "-"} ${c("asistencias analizadas", "attendances analyzed")}`}
                 icon={WalletCards}
-                tone='warning'
+                tone="warning"
               />
             </section>
 
-            <section className='grid grid-cols-1 gap-4 xl:grid-cols-3'>
-              <Card>
+            <section className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
                 <CardHeader>
-                  <CardTitle className='flex items-center gap-2 text-lg'>
-                    <Percent className='h-5 w-5 text-sky-600' />
-                    Género
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <Percent className="h-5 w-5 text-sky-600" />
+                    {c("Género", "Gender")}
                   </CardTitle>
                 </CardHeader>
-                <CardContent className='h-[320px]'>
+                <CardContent className="h-[320px]">
                   {generoData.length === 0 ? (
-                    <EmptyChart label='Sin datos de género para graficar.' />
+                    <EmptyChart
+                      label={c(
+                        "Sin datos de género para graficar.",
+                        "No gender data to chart.",
+                      )}
+                    />
                   ) : (
-                    <ResponsiveContainer width='100%' height='100%'>
+                    <ResponsiveContainer width="100%" height="100%">
                       <PieChart>
-                        <Pie data={generoData} dataKey='cantidad' nameKey='label' innerRadius={55} outerRadius={95} paddingAngle={3} label>
+                        <Pie
+                          data={generoData}
+                          dataKey="cantidad"
+                          nameKey="label"
+                          innerRadius={55}
+                          outerRadius={95}
+                          paddingAngle={3}
+                          label
+                        >
                           {generoData.map((_, index) => (
-                            <Cell key={`genero-${index}`} fill={CHART_COLORS[index % CHART_COLORS.length]} />
+                            <Cell
+                              key={`genero-${index}`}
+                              fill={CHART_COLORS[index % CHART_COLORS.length]}
+                            />
                           ))}
                         </Pie>
-                        <Tooltip formatter={(value) => formatNumber(Number(value))} />
+                        <Tooltip
+                          formatter={(value) => formatNumber(Number(value))}
+                        />
                         <Legend />
                       </PieChart>
                     </ResponsiveContainer>
@@ -406,27 +881,50 @@ export default function BiSociosDemografiaPromocionesPage() {
                 </CardContent>
               </Card>
 
-              <Card className='xl:col-span-2'>
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100 xl:col-span-2">
                 <CardHeader>
-                  <CardTitle className='flex items-center gap-2 text-lg'>
-                    <Users className='h-5 w-5 text-sky-600' />
-                    Franjas etarias
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <Users className="h-5 w-5 text-sky-600" />
+                    {c("Franjas etarias", "Age ranges")}
                   </CardTitle>
                 </CardHeader>
-                <CardContent className='h-[320px]'>
+                <CardContent className="h-[320px]">
                   {franjasData.length === 0 ? (
-                    <EmptyChart label='Sin franjas etarias para graficar.' />
+                    <EmptyChart
+                      label={c(
+                        "Sin franjas etarias para graficar.",
+                        "No age ranges to chart.",
+                      )}
+                    />
                   ) : (
-                    <ResponsiveContainer width='100%' height='100%'>
+                    <ResponsiveContainer width="100%" height="100%">
                       <BarChart data={franjasData}>
-                        <CartesianGrid strokeDasharray='3 3' />
-                        <XAxis dataKey='franja' />
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="franja" />
                         <YAxis />
                         <Tooltip />
                         <Legend />
-                        <Bar dataKey='hombres' name='Hombres' stackId='a' fill='#0284c7' radius={[6, 6, 0, 0]} />
-                        <Bar dataKey='mujeres' name='Mujeres' stackId='a' fill='#ec4899' radius={[6, 6, 0, 0]} />
-                        <Bar dataKey='sin_genero' name='Sin dato' stackId='a' fill='#64748b' radius={[6, 6, 0, 0]} />
+                        <Bar
+                          dataKey="hombres"
+                          name={c("Hombres", "Men")}
+                          stackId="a"
+                          fill="#0284c7"
+                          radius={[6, 6, 0, 0]}
+                        />
+                        <Bar
+                          dataKey="mujeres"
+                          name={c("Mujeres", "Women")}
+                          stackId="a"
+                          fill="#ec4899"
+                          radius={[6, 6, 0, 0]}
+                        />
+                        <Bar
+                          dataKey="sin_genero"
+                          name={c("Sin dato", "No data")}
+                          stackId="a"
+                          fill="#64748b"
+                          radius={[6, 6, 0, 0]}
+                        />
                       </BarChart>
                     </ResponsiveContainer>
                   )}
@@ -434,50 +932,75 @@ export default function BiSociosDemografiaPromocionesPage() {
               </Card>
             </section>
 
-            <section className='grid grid-cols-1 gap-4 xl:grid-cols-2'>
-              <Card>
+            <section className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
                 <CardHeader>
-                  <CardTitle className='flex items-center gap-2 text-lg'>
-                    <TrendingUp className='h-5 w-5 text-sky-600' />
-                    Altas mensuales
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <TrendingUp className="h-5 w-5 text-sky-600" />
+                    {c("Altas mensuales", "Monthly sign-ups")}
                   </CardTitle>
                 </CardHeader>
-                <CardContent className='h-[320px]'>
+                <CardContent className="h-[320px]">
                   {altasData.length === 0 ? (
-                    <EmptyChart label='No hay altas para el período seleccionado.' />
+                    <EmptyChart
+                      label={c(
+                        "No hay altas para el período seleccionado.",
+                        "No sign-ups for the selected period.",
+                      )}
+                    />
                   ) : (
-                    <ResponsiveContainer width='100%' height='100%'>
+                    <ResponsiveContainer width="100%" height="100%">
                       <LineChart data={altasData}>
-                        <CartesianGrid strokeDasharray='3 3' />
-                        <XAxis dataKey='periodo_label' />
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="periodo_label" />
                         <YAxis />
                         <Tooltip />
                         <Legend />
-                        <Line type='monotone' dataKey='total' name='Altas' stroke='#16a34a' strokeWidth={3} />
+                        <Line
+                          type="monotone"
+                          dataKey="total"
+                          name={c("Altas", "Sign-ups")}
+                          stroke="#16a34a"
+                          strokeWidth={3}
+                        />
                       </LineChart>
                     </ResponsiveContainer>
                   )}
                 </CardContent>
               </Card>
 
-              <Card>
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
                 <CardHeader>
-                  <CardTitle className='flex items-center gap-2 text-lg'>
-                    <Megaphone className='h-5 w-5 text-sky-600' />
-                    Asistencia por segmento
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <Megaphone className="h-5 w-5 text-sky-600" />
+                    {c("Asistencia por segmento", "Attendance by segment")}
                   </CardTitle>
                 </CardHeader>
-                <CardContent className='h-[320px]'>
+                <CardContent className="h-[320px]">
                   {asistenciaData.length === 0 ? (
-                    <EmptyChart label='Sin asistencias segmentadas para el período.' />
+                    <EmptyChart
+                      label={c(
+                        "Sin asistencias segmentadas para el período.",
+                        "No segmented attendance for the period.",
+                      )}
+                    />
                   ) : (
-                    <ResponsiveContainer width='100%' height='100%'>
-                      <BarChart data={asistenciaData} layout='vertical' margin={{ left: 70 }}>
-                        <CartesianGrid strokeDasharray='3 3' />
-                        <XAxis type='number' />
-                        <YAxis type='category' dataKey='segmento' width={130} />
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart
+                        data={asistenciaData}
+                        layout="vertical"
+                        margin={{ left: 70 }}
+                      >
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis type="number" />
+                        <YAxis type="category" dataKey="segmento" width={130} />
                         <Tooltip />
-                        <Bar dataKey='asistencias' name='Asistencias' fill='#7c3aed' radius={[0, 6, 6, 0]} />
+                        <Bar
+                          dataKey="asistencias"
+                          name={c("Asistencias", "Attendance")}
+                          fill="#7c3aed"
+                          radius={[0, 6, 6, 0]}
+                        />
                       </BarChart>
                     </ResponsiveContainer>
                   )}
@@ -485,23 +1008,37 @@ export default function BiSociosDemografiaPromocionesPage() {
               </Card>
             </section>
 
-            <section className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
-              <Card>
+            <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
                 <CardHeader>
-                  <CardTitle className='text-lg'>Consumo por segmento</CardTitle>
+                  <CardTitle className="text-lg">
+                    {c("Consumo por segmento", "Consumption by segment")}
+                  </CardTitle>
                 </CardHeader>
-                <CardContent className='space-y-3'>
+                <CardContent className="space-y-3">
                   {consumoData.length === 0 ? (
-                    <p className='text-sm text-muted-foreground'>No hay ventas asociadas a socios para el período.</p>
+                    <p className="text-sm text-muted-foreground">
+                      {c(
+                        "No hay ventas asociadas a socios para el período.",
+                        "No sales associated with members for the period.",
+                      )}
+                    </p>
                   ) : (
                     consumoData.map((item) => (
-                      <div key={item.segmento} className='rounded-xl border p-3'>
-                        <div className='flex items-start justify-between gap-3'>
+                      <div
+                        key={item.segmento}
+                        className="rounded-xl border bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900/70"
+                      >
+                        <div className="flex items-start justify-between gap-3">
                           <div>
-                            <p className='font-medium'>{item.segmento}</p>
-                            <p className='text-xs text-muted-foreground'>{item.cantidad_ventas} ventas registradas</p>
+                            <p className="font-medium">{item.segmento}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {biSalesCount(locale, item.cantidad_ventas)}
+                            </p>
                           </div>
-                          <p className='font-semibold'>{formatCurrencyARS(item.total)}</p>
+                          <p className="font-semibold">
+                            {formatCurrencyARS(item.total)}
+                          </p>
                         </div>
                       </div>
                     ))
@@ -509,22 +1046,41 @@ export default function BiSociosDemografiaPromocionesPage() {
                 </CardContent>
               </Card>
 
-              <Card>
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
                 <CardHeader>
-                  <CardTitle className='text-lg'>Ranking productos / servicios</CardTitle>
+                  <CardTitle className="text-lg">
+                    {c(
+                      "Ranking productos / servicios",
+                      "Product / service ranking",
+                    )}
+                  </CardTitle>
                 </CardHeader>
-                <CardContent className='space-y-3'>
+                <CardContent className="space-y-3">
                   {rankingData.length === 0 ? (
-                    <p className='text-sm text-muted-foreground'>No hay detalle de productos o servicios consumidos por socios.</p>
+                    <p className="text-sm text-muted-foreground">
+                      {c(
+                        "No hay detalle de productos o servicios consumidos por socios.",
+                        "No product or service consumption details for members.",
+                      )}
+                    </p>
                   ) : (
                     rankingData.map((item) => (
-                      <div key={`${item.tipo}-${item.item}-${item.segmento}`} className='rounded-xl border p-3'>
-                        <div className='flex items-start justify-between gap-3'>
+                      <div
+                        key={`${item.tipo}-${item.item}-${item.segmento}`}
+                        className="rounded-xl border bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900/70"
+                      >
+                        <div className="flex items-start justify-between gap-3">
                           <div>
-                            <p className='font-medium'>{item.item}</p>
-                            <p className='text-xs text-muted-foreground'>{item.tipo} · {item.segmento} · {formatNumber(item.cantidad)} unidades</p>
+                            <p className="font-medium">{item.item}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {item.tipo} · {item.segmento} ·{" "}
+                              {formatNumber(item.cantidad)}{" "}
+                              {c("unidades", "units")}
+                            </p>
                           </div>
-                          <p className='font-semibold'>{formatCurrencyARS(item.total)}</p>
+                          <p className="font-semibold">
+                            {formatCurrencyARS(item.total)}
+                          </p>
                         </div>
                       </div>
                     ))
@@ -533,69 +1089,122 @@ export default function BiSociosDemografiaPromocionesPage() {
               </Card>
             </section>
 
-            <Card>
+            <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
               <CardHeader>
-                <CardTitle className='flex items-center gap-2 text-lg'>
-                  <Megaphone className='h-5 w-5 text-sky-600' />
-                  Promociones sugeridas
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <Megaphone className="h-5 w-5 text-sky-600" />
+                  {c("Promociones sugeridas", "Suggested promotions")}
                 </CardTitle>
               </CardHeader>
-              <CardContent className='grid grid-cols-1 gap-4 lg:grid-cols-2'>
-                {(data?.promociones_sugeridas ?? []).length === 0 ? (
-                  <p className='text-sm text-muted-foreground'>No hay sugerencias suficientes para el período seleccionado.</p>
+              <CardContent className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                {promocionesData.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    {c(
+                      "No hay sugerencias suficientes para el período seleccionado.",
+                      "There are not enough suggestions for the selected period.",
+                    )}
+                  </p>
                 ) : (
-                  data!.promociones_sugeridas.map((item) => (
-                    <div key={`${item.titulo}-${item.segmento}`} className='rounded-2xl border bg-slate-50 p-4'>
-                      <div className='flex items-start justify-between gap-3'>
+                  promocionesData.map((item) => (
+                    <div
+                      key={`${item.titulo}-${item.segmento}`}
+                      className="rounded-2xl border bg-slate-50 p-4 dark:border-neutral-800 dark:bg-neutral-900/70"
+                    >
+                      <div className="flex items-start justify-between gap-3">
                         <div>
-                          <p className='font-semibold'>{item.titulo}</p>
-                          <p className='mt-1 text-sm text-muted-foreground'>{item.descripcion}</p>
+                          <p className="font-semibold">{item.titulo}</p>
+                          <p className="mt-1 text-sm text-muted-foreground">
+                            {item.descripcion}
+                          </p>
                         </div>
-                        <span className='rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase text-sky-700'>
+                        <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase text-sky-700 dark:bg-sky-950/50 dark:text-sky-300">
                           {item.prioridad}
                         </span>
                       </div>
-                      <p className='mt-3 text-sm'><strong>Segmento:</strong> {item.segmento}</p>
-                      <p className='mt-1 text-sm'><strong>Acción:</strong> {item.accion_sugerida}</p>
+                      <p className="mt-3 text-sm">
+                        <strong>{c("Segmento:", "Segment:")}</strong>{" "}
+                        {item.segmento}
+                      </p>
+                      <p className="mt-1 text-sm">
+                        <strong>{c("Acción:", "Action:")}</strong>{" "}
+                        {item.accion_sugerida}
+                      </p>
                     </div>
                   ))
                 )}
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
               <CardHeader>
-                <CardTitle className='text-lg'>Resumen por franja etaria</CardTitle>
+                <CardTitle className="text-lg">
+                  {c("Resumen por franja etaria", "Summary by age range")}
+                </CardTitle>
               </CardHeader>
-              <CardContent className='overflow-x-auto'>
-                <table className='w-full min-w-[980px] text-sm'>
+              <CardContent className="overflow-x-auto">
+                <table className="w-full min-w-[980px] text-sm">
                   <thead>
-                    <tr className='border-b bg-slate-50 text-left'>
-                      <th className='p-3'>Franja</th>
-                      <th className='p-3 text-right'>Socios</th>
-                      <th className='p-3 text-right'>%</th>
-                      <th className='p-3 text-right'>Hombres</th>
-                      <th className='p-3 text-right'>Mujeres</th>
-                      <th className='p-3 text-right'>Edad prom.</th>
-                      <th className='p-3 text-right'>Altas</th>
-                      <th className='p-3 text-right'>Asistencias</th>
-                      <th className='p-3 text-right'>Pagos</th>
-                      <th className='p-3 text-right'>Consumo</th>
+                    <tr className="border-b bg-slate-50 text-left dark:border-neutral-800 dark:bg-neutral-900/80">
+                      <th className="p-3">{c("Franja", "Age range")}</th>
+                      <th className="p-3 text-right">
+                        {c("Socios", "Members")}
+                      </th>
+                      <th className="p-3 text-right">%</th>
+                      <th className="p-3 text-right">{c("Hombres", "Men")}</th>
+                      <th className="p-3 text-right">
+                        {c("Mujeres", "Women")}
+                      </th>
+                      <th className="p-3 text-right">
+                        {c("Edad prom.", "Avg. age")}
+                      </th>
+                      <th className="p-3 text-right">
+                        {c("Altas", "Sign-ups")}
+                      </th>
+                      <th className="p-3 text-right">
+                        {c("Asistencias", "Attendance")}
+                      </th>
+                      <th className="p-3 text-right">
+                        {c("Pagos", "Payments")}
+                      </th>
+                      <th className="p-3 text-right">
+                        {c("Consumo", "Consumption")}
+                      </th>
                     </tr>
                   </thead>
                   <tbody>
                     {franjasData.map((item) => (
-                      <tr key={item.franja} className='border-b'>
-                        <td className='p-3 font-medium'>{item.franja}</td>
-                        <td className='p-3 text-right'>{formatNumber(item.cantidad_socios)}</td>
-                        <td className='p-3 text-right'>{formatPercent(item.porcentaje_socios)}</td>
-                        <td className='p-3 text-right'>{formatNumber(item.hombres)}</td>
-                        <td className='p-3 text-right'>{formatNumber(item.mujeres)}</td>
-                        <td className='p-3 text-right'>{formatAge(item.edad_promedio)}</td>
-                        <td className='p-3 text-right'>{formatNumber(item.altas_periodo)}</td>
-                        <td className='p-3 text-right'>{formatNumber(item.asistencias_periodo)}</td>
-                        <td className='p-3 text-right'>{formatCurrencyARS(item.pagos_periodo)}</td>
-                        <td className='p-3 text-right'>{formatCurrencyARS(item.consumo_periodo)}</td>
+                      <tr
+                        key={item.franja}
+                        className="border-b dark:border-neutral-800"
+                      >
+                        <td className="p-3 font-medium">{item.franja}</td>
+                        <td className="p-3 text-right">
+                          {formatNumber(item.cantidad_socios)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatPercent(item.porcentaje_socios)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatNumber(item.hombres)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatNumber(item.mujeres)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatAge(locale, item.edad_promedio)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatNumber(item.altas_periodo)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatNumber(item.asistencias_periodo)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatCurrencyARS(item.pagos_periodo)}
+                        </td>
+                        <td className="p-3 text-right">
+                          {formatCurrencyARS(item.consumo_periodo)}
+                        </td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/app/dashboard/cuotas/page.tsx
+++ b/src/app/dashboard/cuotas/page.tsx
@@ -18,7 +18,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
-import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -28,13 +28,42 @@ import {
 import { PaginationControls } from "@/components/ui/PaginationControls";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { formatFrontendDate } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
 
 const CUOTAS_PAGE_SIZE = 10;
+
+function translateFeeDescription(value: string | null | undefined, isEnglish: boolean) {
+  if (!value || !isEnglish) return value || "-";
+
+  const monthMap: Record<string, string> = {
+    ENERO: "JANUARY",
+    FEBRERO: "FEBRUARY",
+    MARZO: "MARCH",
+    ABRIL: "APRIL",
+    MAYO: "MAY",
+    JUNIO: "JUNE",
+    JULIO: "JULY",
+    AGOSTO: "AUGUST",
+    SEPTIEMBRE: "SEPTEMBER",
+    SETIEMBRE: "SEPTEMBER",
+    OCTUBRE: "OCTOBER",
+    NOVIEMBRE: "NOVEMBER",
+    DICIEMBRE: "DECEMBER",
+  };
+
+  return value.replace(
+    /\b(ENERO|FEBRERO|MARZO|ABRIL|MAYO|JUNIO|JULIO|AGOSTO|SEPTIEMBRE|SETIEMBRE|OCTUBRE|NOVIEMBRE|DICIEMBRE)\b/gi,
+    (match) => monthMap[match.toUpperCase()] || match,
+  );
+}
 
 export default function CuotasPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } =
     useAuthStore();
   const router = useRouter();
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
   const [cuotas, setCuotas] = useState<Cuota[]>([]);
   const [filteredCuotas, setFilteredCuotas] = useState<Cuota[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -70,44 +99,73 @@ export default function CuotasPage() {
   const handleDownloadPdf = async () => {
     try {
       await downloadCommercialReportPdf({
-        title: "Listado de Cuotas",
-        subtitle: "Reporte de cuotas, períodos y estado vigente.",
-        fileName: "listado-cuotas-gym-master",
+        title: tx("Listado de Cuotas", "Fees list"),
+        subtitle: tx(
+          "Reporte de cuotas, períodos y estado vigente.",
+          "Report of fees, periods, and current status.",
+        ),
+        fileName: isEnglish ? "fees-list-gym-master" : "listado-cuotas-gym-master",
         rows: filteredCuotas,
         metrics: [
-          { label: "Cuotas filtradas", value: filteredCuotas.length },
-          { label: "Activas", value: filteredCuotas.filter((c) => c.activo).length },
+          { label: tx("Cuotas filtradas", "Filtered fees"), value: filteredCuotas.length },
+          {
+            label: tx("Activas", "Active"),
+            value: filteredCuotas.filter((c) => c.activo).length,
+          },
         ],
-        filtersLabel: `Estado: ${filtroLabel} · Orden: ${ordenamientoLabel}${searchTerm.trim() ? ` · Búsqueda: ${searchTerm.trim()}` : ""}`,
+        filtersLabel: `${tx("Estado", "Status")}: ${filtroLabel} · ${tx("Orden", "Sort")}: ${ordenamientoLabel}${
+          searchTerm.trim() ? ` · ${tx("Búsqueda", "Search")}: ${searchTerm.trim()}` : ""
+        }`,
         columns: [
-          { header: "Descripción", width: 55, getValue: (c) => c.descripcion },
-          { header: "Monto", width: 26, getValue: (c) => `$${Number(c.monto || 0).toLocaleString("es-AR")}`, align: "right" },
-          { header: "Período", width: 30, getValue: (c) => c.periodo || "-" },
-          { header: "Fecha inicio", width: 30, getValue: (c) => formatFrontendDate(c.fecha_inicio) },
-          { header: "Fecha fin", width: 30, getValue: (c) => formatFrontendDate(c.fecha_fin) },
-          { header: "Estado", width: 24, getValue: (c) => (c.activo ? "Activa" : "Inactiva") },
+          {
+            header: tx("Descripción", "Description"),
+            width: 55,
+            getValue: (c) => translateFeeDescription(c.descripcion, isEnglish),
+          },
+          {
+            header: tx("Monto", "Amount"),
+            width: 26,
+            getValue: (c) => `$${Number(c.monto || 0).toLocaleString("es-AR")}`,
+            align: "right",
+          },
+          { header: tx("Período", "Period"), width: 30, getValue: (c) => c.periodo || "-" },
+          {
+            header: tx("Fecha inicio", "Start date"),
+            width: 30,
+            getValue: (c) => formatFrontendDate(c.fecha_inicio),
+          },
+          {
+            header: tx("Fecha fin", "End date"),
+            width: 30,
+            getValue: (c) => formatFrontendDate(c.fecha_fin),
+          },
+          {
+            header: tx("Estado", "Status"),
+            width: 24,
+            getValue: (c) => (c.activo ? tx("Activa", "Active") : tx("Inactiva", "Inactive")),
+          },
         ],
       });
     } catch {
-      toast.error("No se pudo generar el PDF de cuotas");
+      toast.error(tx("No se pudo generar el PDF de cuotas", "Could not generate the fees PDF"));
     }
   };
 
   const handleExportExcel = async () => {
     const workbook = new ExcelJS.Workbook();
-    const worksheet = workbook.addWorksheet("Cuotas");
+    const worksheet = workbook.addWorksheet(tx("Cuotas", "Fees"));
 
     worksheet.columns = [
-      { header: "Descripción", key: "descripcion", width: 30 },
-      { header: "Monto", key: "monto", width: 15 },
-      { header: "Período", key: "periodo", width: 20 },
-      { header: "Fecha Inicio", key: "fecha_inicio", width: 20 },
-      { header: "Fecha Fin", key: "fecha_fin", width: 20 },
+      { header: tx("Descripción", "Description"), key: "descripcion", width: 30 },
+      { header: tx("Monto", "Amount"), key: "monto", width: 15 },
+      { header: tx("Período", "Period"), key: "periodo", width: 20 },
+      { header: tx("Fecha Inicio", "Start date"), key: "fecha_inicio", width: 20 },
+      { header: tx("Fecha Fin", "End date"), key: "fecha_fin", width: 20 },
     ];
 
     filteredCuotas.forEach((c) => {
       worksheet.addRow({
-        descripcion: c.descripcion,
+        descripcion: translateFeeDescription(c.descripcion, isEnglish),
         monto: c.monto,
         periodo: c.periodo,
         fecha_inicio: formatFrontendDate(c.fecha_inicio),
@@ -122,7 +180,7 @@ export default function CuotasPage() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = buildTimestampedDownloadFileName("listado-cuotas", "xlsx");
+    a.download = buildTimestampedDownloadFileName(isEnglish ? "fees-list" : "listado-cuotas", "xlsx");
     a.click();
     window.URL.revokeObjectURL(url);
   };
@@ -180,18 +238,18 @@ export default function CuotasPage() {
 
   const filtroLabel =
     filtroActivo === "todos"
-      ? "Todos"
+      ? tx("Todos", "All")
       : filtroActivo === "activos"
-      ? "Activos"
-      : "Inactivos";
+      ? tx("Activos", "Active")
+      : tx("Inactivos", "Inactive");
 
   const ordenamientoLabel =
     ordenamiento === "reciente"
-      ? "Más reciente a antigua"
-      : "Más antigua a reciente";
+      ? tx("Más reciente a antigua", "Newest to oldest")
+      : tx("Más antigua a reciente", "Oldest to newest");
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{tx("Cargando...", "Loading...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -203,16 +261,16 @@ export default function CuotasPage() {
       <div className="flex w-full min-h-screen">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Cuotas" />
-          <main className="flex-1 p-6 space-y-6">
-            <Card className="w-full">
-              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
-                <h2 className="text-xl font-bold">Listado de Cuotas</h2>
+          <AppHeader title={tx("Cuotas", "Fees")} />
+          <main className="flex-1 p-6 space-y-6 dark:bg-black">
+            <Card className="w-full dark:border-neutral-800 dark:bg-neutral-950/80">
+              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap dark:border-neutral-800">
+                <h2 className="text-xl font-bold text-foreground">{tx("Listado de Cuotas", "Fees list")}</h2>
                 <div className="flex flex-wrap items-center w-full gap-2 md:w-auto">
                   <div className="flex items-center flex-grow gap-2 md:flex-grow-0">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="outline" className="min-w-[120px]">
+                        <Button variant="outline" className="min-w-[120px] dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100">
                           {filtroLabel}
                         </Button>
                       </DropdownMenuTrigger>
@@ -223,7 +281,7 @@ export default function CuotasPage() {
                             filtroActivo === "todos" ? "font-bold" : ""
                           }
                         >
-                          Todos
+                          {tx("Todos", "All")}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onSelect={() => setFiltroActivo("activos")}
@@ -231,7 +289,7 @@ export default function CuotasPage() {
                             filtroActivo === "activos" ? "font-bold" : ""
                           }
                         >
-                          Activos
+                          {tx("Activos", "Active")}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onSelect={() => setFiltroActivo("inactivos")}
@@ -239,13 +297,13 @@ export default function CuotasPage() {
                             filtroActivo === "inactivos" ? "font-bold" : ""
                           }
                         >
-                          Inactivos
+                          {tx("Inactivos", "Inactive")}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="outline" className="min-w-[180px]">
+                        <Button variant="outline" className="min-w-[180px] dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100">
                           {ordenamientoLabel}
                         </Button>
                       </DropdownMenuTrigger>
@@ -256,7 +314,7 @@ export default function CuotasPage() {
                             ordenamiento === "reciente" ? "font-bold" : ""
                           }
                         >
-                          Más reciente a antigua
+                          {tx("Más reciente a antigua", "Newest to oldest")}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onSelect={() => setOrdenamiento("antigua")}
@@ -264,7 +322,7 @@ export default function CuotasPage() {
                             ordenamiento === "antigua" ? "font-bold" : ""
                           }
                         >
-                          Más antigua a reciente
+                          {tx("Más antigua a reciente", "Oldest to newest")}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
@@ -272,8 +330,8 @@ export default function CuotasPage() {
                       <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
                       <Input
                         type="search"
-                        placeholder="Buscar por descripción, período..."
-                        className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
+                        placeholder={tx("Buscar por descripción, período...", "Search by description, period...")}
+                        className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full dark:border-neutral-800 dark:bg-black dark:text-neutral-100 dark:placeholder:text-neutral-500"
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
                       />
@@ -282,26 +340,26 @@ export default function CuotasPage() {
                   <Button
                     onClick={handleDownloadPdf}
                     variant="outline"
-                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd] dark:border-cyan-900/70 dark:bg-neutral-950 dark:text-cyan-300 dark:hover:bg-cyan-950/30"
                   >
                     <FileText className="w-4 h-4" />
-                    <span className="hidden sm:inline">Descargar PDF</span>
+                    <span className="hidden sm:inline">{tx("Descargar PDF", "Download PDF")}</span>
                   </Button>
                   <Button
                     variant="outline"
                     onClick={handleExportExcel}
-                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd] dark:border-cyan-900/70 dark:bg-neutral-950 dark:text-cyan-300 dark:hover:bg-cyan-950/30"
                   >
                     <FileSpreadsheet className="w-4 h-4" />
-                    <span className="hidden sm:inline">Exportar</span>
+                    <span className="hidden sm:inline">{tx("Exportar", "Export")}</span>
                   </Button>
                   {isAdminOnly && (
                     <Button
                       onClick={() => setOpenModal(true)}
                       className="bg-[#02a8e1] hover:bg-[#0288b1]"
                     >
-                      <span className="hidden sm:inline">Añadir Cuota</span>
-                      <span className="sm:hidden">Añadir</span>
+                      <span className="hidden sm:inline">{tx("Añadir Cuota", "Add fee")}</span>
+                      <span className="sm:hidden">{tx("Añadir", "Add")}</span>
                     </Button>
                   )}
                 </div>
@@ -321,16 +379,16 @@ export default function CuotasPage() {
                     }}
                     onDelete={async (cuota) => {
                       const confirmar = window.confirm(
-                        "¿Está seguro de eliminar la cuota?"
+                        tx("¿Está seguro de eliminar la cuota?", "Are you sure you want to delete this fee?")
                       );
                       if (!confirmar) return;
 
                       try {
                         await deleteCuota(cuota.id);
-                        toast.success("Cuota eliminada correctamente");
+                        toast.success(tx("Cuota eliminada correctamente", "Fee deleted successfully"));
                         await loadCuotas();
                       } catch (err) {
-                        toast.error("Error al eliminar cuota");
+                        toast.error(tx("Error al eliminar cuota", "Error deleting fee"));
                       }
                     }}
                   />
@@ -340,7 +398,7 @@ export default function CuotasPage() {
                   totalItems={totalCuotas}
                   pageSize={CUOTAS_PAGE_SIZE}
                   onPageChange={setCurrentPage}
-                  itemLabel="cuotas"
+                  itemLabel={tx("cuotas", "fees")}
                 />
               </CardContent>
             </Card>

--- a/src/app/dashboard/finanzas/page.tsx
+++ b/src/app/dashboard/finanzas/page.tsx
@@ -44,6 +44,8 @@ import { getFinanzasDashboardBi } from "@/services/finanzasService";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDate } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
 function todayISO() {
   return new Date().toISOString().slice(0, 10);
@@ -61,6 +63,57 @@ function formatPercent(value?: number | null) {
   return `${Number(value).toFixed(1)}%`;
 }
 
+function financeTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function normalizeFinanceText(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+const FINANCE_DYNAMIC_TRANSLATIONS: Record<string, string> = {
+  "ventas de productos / kiosco": "Product / kiosk sales",
+  "fees / membresias": "Fees / memberships",
+  "compras a proveedores": "Supplier purchases",
+  "gastos pending": "Pending expenses",
+  "gastos pendientes": "Pending expenses",
+  "luz": "Electricity",
+};
+
+function translateFinanceCategory(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const normalized = normalizeFinanceText(raw);
+  if (FINANCE_DYNAMIC_TRANSLATIONS[normalized]) {
+    return FINANCE_DYNAMIC_TRANSLATIONS[normalized];
+  }
+
+  const demoExpenseMatch = normalized.match(/^gasto demo (.+)$/);
+  if (demoExpenseMatch) {
+    return `Demo expense ${demoExpenseMatch[1]}`;
+  }
+
+  if (normalized.includes("gasto") && normalized.includes("demo")) {
+    return raw.replace(/gasto demo/gi, "Demo expense").replace(/gasto/gi, "Expense");
+  }
+
+  return raw;
+}
+
+function financeRecordCount(locale: GymMasterLocale, count: number) {
+  if (locale === "en") {
+    return `${count} ${count === 1 ? "record" : "records"}`;
+  }
+
+  return `${count} ${count === 1 ? "registro" : "registros"}`;
+}
+
 function MetricCard({
   title,
   value,
@@ -75,15 +128,15 @@ function MetricCard({
   tone?: "default" | "income" | "expense" | "warning" | "result";
 }) {
   const toneClass = {
-    default: "bg-slate-100 text-slate-700",
-    income: "bg-emerald-50 text-emerald-700",
-    expense: "bg-red-50 text-red-700",
-    warning: "bg-amber-50 text-amber-700",
-    result: "bg-sky-50 text-sky-700",
+    default: "bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-200",
+    income: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300",
+    expense: "bg-red-50 text-red-700 dark:bg-red-950/50 dark:text-red-300",
+    warning: "bg-amber-50 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300",
+    result: "bg-sky-50 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
   }[tone];
 
   return (
-    <Card className="bg-white text-slate-950 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100">
+    <Card className="bg-white text-slate-950 dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
       <CardContent className="flex items-center justify-between gap-4 p-5">
         <div className="space-y-1">
           <p className="text-sm text-muted-foreground">{title}</p>
@@ -102,13 +155,15 @@ function CategoryList({
   title,
   items,
   emptyLabel,
+  locale,
 }: {
   title: string;
   items: Array<{ categoria: string; total: number; cantidad: number }>;
   emptyLabel: string;
+  locale: GymMasterLocale;
 }) {
   return (
-    <Card>
+    <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
       <CardHeader>
         <CardTitle className="text-lg">{title}</CardTitle>
       </CardHeader>
@@ -119,13 +174,13 @@ function CategoryList({
           items.slice(0, 8).map((item) => (
             <div
               key={`${title}-${item.categoria}`}
-              className="rounded-xl border p-3"
+              className="rounded-xl border bg-white p-3 dark:border-neutral-800 dark:bg-neutral-900/70"
             >
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="font-medium">{item.categoria}</p>
+                  <p className="font-medium">{translateFinanceCategory(locale, item.categoria)}</p>
                   <p className="text-xs text-muted-foreground">
-                    {item.cantidad} registros
+                    {financeRecordCount(locale, item.cantidad)}
                   </p>
                 </div>
                 <p className="font-semibold">{formatCurrencyARS(item.total)}</p>
@@ -140,6 +195,8 @@ function CategoryList({
 
 export default function FinanzasIngresosEgresosBiPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => financeTx(locale, es, en);
   const router = useRouter();
   const [desde, setDesde] = useState(firstDayOfCurrentYearISO());
   const [hasta, setHasta] = useState(todayISO());
@@ -163,7 +220,7 @@ export default function FinanzasIngresosEgresosBiPage() {
       const response = await getFinanzasDashboardBi({ desde, hasta });
       setData(response);
     } catch (error: any) {
-      toast.error(error.message || "No se pudo cargar el BI financiero");
+      toast.error(error.message || c("No se pudo cargar el BI financiero", "Unable to load financial BI"));
       setData(null);
     } finally {
       setLoading(false);
@@ -182,38 +239,38 @@ export default function FinanzasIngresosEgresosBiPage() {
   const financialSignal = useMemo(() => {
     if (!metricas) {
       return {
-        label: "Sin datos financieros",
+        label: c("Sin datos financieros", "No financial data"),
         description:
-          "Seleccioná un período y actualizá para generar una lectura ejecutiva.",
+          c("Seleccioná un período y actualizá para generar una lectura ejecutiva.", "Select a period and refresh to generate an executive summary."),
         tone: "neutral" as const,
       };
     }
 
     if (metricas.resultado_neto < 0) {
       return {
-        label: "Resultado negativo",
+        label: c("Resultado negativo", "Negative result"),
         description:
-          "Revisá egresos y compromisos pendientes antes de ampliar gastos operativos.",
+          c("Revisá egresos y compromisos pendientes antes de ampliar gastos operativos.", "Review outflows and pending commitments before increasing operating expenses."),
         tone: "danger" as const,
       };
     }
 
     if (metricas.compromisos_pendientes > metricas.ingresos_total * 0.35) {
       return {
-        label: "Compromisos altos",
+        label: c("Compromisos altos", "High commitments"),
         description:
-          "Hay obligaciones relevantes frente a los ingresos del período. Priorizá pagos críticos.",
+          c("Hay obligaciones relevantes frente a los ingresos del período. Priorizá pagos críticos.", "There are significant obligations compared with period income. Prioritize critical payments."),
         tone: "warning" as const,
       };
     }
 
     return {
-      label: "Operación financieramente estable",
+      label: c("Operación financieramente estable", "Financially stable operation"),
       description:
-        "El resultado neto acompaña la operación comercial. Mantener seguimiento mensual.",
+        c("El resultado neto acompaña la operación comercial. Mantener seguimiento mensual.", "Net result supports the commercial operation. Keep monthly monitoring."),
       tone: "success" as const,
     };
-  }, [metricas]);
+  }, [c, metricas]);
 
   const handleExportExcel = async () => {
     if (!data) return;
@@ -385,7 +442,7 @@ export default function FinanzasIngresosEgresosBiPage() {
     }
   };
 
-  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isInitialized) return <div>{c("Cargando...", "Loading...")}</div>;
   if (!isAuthenticated) return null;
 
   return (
@@ -393,41 +450,40 @@ export default function FinanzasIngresosEgresosBiPage() {
       <div className="flex h-[100dvh] max-h-[100dvh] w-full overflow-hidden">
         <AppSidebar />
         <SidebarInset className="!grid !min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden">
-          <AppHeader title="Finanzas / BI" />
-          <main className="min-h-0 space-y-6 overflow-y-auto overflow-x-hidden p-4 pb-8 sm:p-6">
-            <section className="rounded-2xl border bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100">
+          <AppHeader title={c("Finanzas / BI", "Finance / BI")} />
+          <main className="min-h-0 space-y-6 overflow-y-auto overflow-x-hidden p-4 pb-8 dark:bg-black sm:p-6">
+            <section className="rounded-2xl border bg-white p-6 shadow-sm dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
               <div className="flex flex-col justify-between gap-4 lg:flex-row lg:items-center">
                 <div className="space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-600">
-                    Business Intelligence financiero
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-sky-600 dark:text-cyan-300">
+                    {c("Business Intelligence financiero", "Financial business intelligence")}
                   </p>
                   <h1 className="text-2xl font-bold">
-                    Ingresos, egresos y resultado neto
+                    {c("Ingresos, egresos y resultado neto", "Income, outflows, and net result")}
                   </h1>
                   <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">
-                    Consolidá cuotas, ventas, compras y gastos para obtener una
-                    vista financiera operativa del gimnasio.
+                    {c("Consolidá cuotas, ventas, compras y gastos para obtener una vista financiera operativa del gimnasio.", "Consolidate fees, sales, purchases, and expenses to get an operational financial view of the gym.")}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <Button asChild variant="outline">
-                    <Link href="/dashboard/comercial">Comercial</Link>
+                    <Link href="/dashboard/comercial">{c("Comercial", "Commercial")}</Link>
                   </Button>
                   <Button asChild variant="outline">
-                    <Link href="/dashboard/pagos">Pagos</Link>
+                    <Link href="/dashboard/pagos">{c("Pagos", "Payments")}</Link>
                   </Button>
                   <Button asChild variant="outline">
-                    <Link href="/dashboard/otros-gastos">Gastos</Link>
+                    <Link href="/dashboard/otros-gastos">{c("Gastos", "Expenses")}</Link>
                   </Button>
                 </div>
               </div>
             </section>
 
-            <Card className="bg-white dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100">
+            <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
               <CardContent className="flex flex-col gap-4 p-4 lg:flex-row lg:items-end lg:justify-between">
                 <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-2 lg:max-w-xl">
                   <div className="space-y-2">
-                    <Label htmlFor="fecha-desde">Fecha desde</Label>
+                    <Label htmlFor="fecha-desde">{c("Fecha desde", "Date from")}</Label>
                     <Input
                       id="fecha-desde"
                       type="date"
@@ -436,7 +492,7 @@ export default function FinanzasIngresosEgresosBiPage() {
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="fecha-hasta">Fecha hasta</Label>
+                    <Label htmlFor="fecha-hasta">{c("Fecha hasta", "Date to")}</Label>
                     <Input
                       id="fecha-hasta"
                       type="date"
@@ -453,7 +509,7 @@ export default function FinanzasIngresosEgresosBiPage() {
                     className="bg-[#02a8e1] hover:bg-[#0288b1]"
                   >
                     <RefreshCcw className="mr-2 h-4 w-4" />
-                    {loading ? "Actualizando..." : "Actualizar"}
+                    {loading ? c("Actualizando...", "Refreshing...") : c("Actualizar", "Refresh")}
                   </Button>
                   <Button
                     type="button"
@@ -463,7 +519,7 @@ export default function FinanzasIngresosEgresosBiPage() {
                     className="border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <FileText className="mr-2 h-4 w-4" />
-                    Descargar PDF
+                    {c("Descargar PDF", "Download PDF")}
                   </Button>
                   <Button
                     type="button"
@@ -473,7 +529,7 @@ export default function FinanzasIngresosEgresosBiPage() {
                     className="border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <FileSpreadsheet className="mr-2 h-4 w-4" />
-                    Exportar
+                    {c("Exportar", "Export")}
                   </Button>
                 </div>
               </CardContent>
@@ -481,46 +537,46 @@ export default function FinanzasIngresosEgresosBiPage() {
 
             <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
               <MetricCard
-                title="Ingresos totales"
+                title={c("Ingresos totales", "Total income")}
                 value={
                   loading || !metricas
                     ? "..."
                     : formatCurrencyARS(metricas.ingresos_total)
                 }
-                description="Cuotas, ventas y servicios vendidos."
+                description={c("Cuotas, ventas y servicios vendidos.", "Fees, sales, and services sold.")}
                 icon={ArrowUpCircle}
                 tone="income"
               />
               <MetricCard
-                title="Egresos totales"
+                title={c("Egresos totales", "Total outflows")}
                 value={
                   loading || !metricas
                     ? "..."
                     : formatCurrencyARS(metricas.egresos_total)
                 }
-                description="Compras pagadas y gastos pagados."
+                description={c("Compras pagadas y gastos pagados.", "Paid purchases and paid expenses.")}
                 icon={ArrowDownCircle}
                 tone="expense"
               />
               <MetricCard
-                title="Resultado neto"
+                title={c("Resultado neto", "Net result")}
                 value={
                   loading || !metricas
                     ? "..."
                     : formatCurrencyARS(metricas.resultado_neto)
                 }
-                description={`Margen operativo: ${metricas ? formatPercent(metricas.margen_resultado_porcentaje) : "-"}`}
+                description={`${c("Margen operativo", "Operating margin")}: ${metricas ? formatPercent(metricas.margen_resultado_porcentaje) : "-"}`}
                 icon={TrendingUp}
                 tone="result"
               />
               <MetricCard
-                title="Compromisos pendientes"
+                title={c("Compromisos pendientes", "Pending commitments")}
                 value={
                   loading || !metricas
                     ? "..."
                     : formatCurrencyARS(metricas.compromisos_pendientes)
                 }
-                description="Compras pendientes y gastos pendientes/vencidos."
+                description={c("Compras pendientes y gastos pendientes/vencidos.", "Pending purchases and pending/overdue expenses.")}
                 icon={AlertTriangle}
                 tone="warning"
               />
@@ -532,7 +588,7 @@ export default function FinanzasIngresosEgresosBiPage() {
                   <div className="flex items-start justify-between gap-4">
                     <div>
                       <p className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-200">
-                        Lectura ejecutiva financiera
+                        {c("Lectura ejecutiva financiera", "Financial executive summary")}
                       </p>
                       <h2 className="mt-2 text-xl font-bold">
                         {financialSignal.label}
@@ -546,35 +602,35 @@ export default function FinanzasIngresosEgresosBiPage() {
                     >
                       {metricas
                         ? formatPercent(metricas.margen_resultado_porcentaje)
-                        : "Sin margen"}
+                        : c("Sin margen", "No margin")}
                     </div>
                   </div>
                   <div className="grid gap-3 sm:grid-cols-3">
                     <div className="rounded-2xl border border-white/10 bg-white/10 p-4">
                       <p className="text-xs uppercase tracking-wide text-cyan-100/70">
-                        Ventas registradas
+                        {c("Ventas registradas", "Registered sales")}
                       </p>
                       <p className="mt-2 text-lg font-bold">
                         {metricas ? metricas.cantidad_ventas : 0}
                       </p>
                       <p className="mt-1 text-xs text-cyan-50/70">
-                        Operaciones comerciales del período.
+                        {c("Operaciones comerciales del período.", "Commercial operations in the period.")}
                       </p>
                     </div>
                     <div className="rounded-2xl border border-white/10 bg-white/10 p-4">
                       <p className="text-xs uppercase tracking-wide text-cyan-100/70">
-                        Pagos de cuotas
+                        {c("Pagos de cuotas", "Fee payments")}
                       </p>
                       <p className="mt-2 text-lg font-bold">
                         {metricas ? metricas.cantidad_pagos : 0}
                       </p>
                       <p className="mt-1 text-xs text-cyan-50/70">
-                        Base recurrente del gimnasio.
+                        {c("Base recurrente del gimnasio.", "Recurring base of the gym.")}
                       </p>
                     </div>
                     <div className="rounded-2xl border border-white/10 bg-white/10 p-4">
                       <p className="text-xs uppercase tracking-wide text-cyan-100/70">
-                        Compras/Gastos
+                        {c("Compras/Gastos", "Purchases/Expenses")}
                       </p>
                       <p className="mt-2 text-lg font-bold">
                         {metricas
@@ -582,41 +638,39 @@ export default function FinanzasIngresosEgresosBiPage() {
                           : 0}
                       </p>
                       <p className="mt-1 text-xs text-cyan-50/70">
-                        Salidas operativas registradas.
+                        {c("Salidas operativas registradas.", "Registered operating outflows.")}
                       </p>
                     </div>
                   </div>
                 </CardContent>
               </Card>
 
-              <Card className="border-emerald-200 bg-emerald-50/60 dark:border-emerald-900 dark:bg-emerald-950/20">
+              <Card className="border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/70 dark:bg-emerald-950/25 dark:text-neutral-100">
                 <CardContent className="space-y-3 p-5">
                   <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:text-emerald-300">
-                    Decisión sugerida
+                    {c("Decisión sugerida", "Suggested decision")}
                   </p>
                   <h3 className="text-lg font-bold">
-                    Conectar reportes con caja, stock y comercial
+                    {c("Conectar reportes con caja, stock y comercial", "Connect reports with cash, stock, and commercial")}
                   </h3>
                   <p className="text-sm leading-relaxed text-muted-foreground">
-                    Usá este panel para validar si el crecimiento de ventas
-                    acompaña el margen neto y si los compromisos pendientes no
-                    comprometen reposición o sueldos.
+                    {c("Usá este panel para validar si el crecimiento de ventas acompaña el margen neto y si los compromisos pendientes no comprometen reposición o sueldos.", "Use this panel to validate whether sales growth supports net margin and whether pending commitments affect replenishment or salaries.")}
                   </p>
                   <div className="grid gap-2 text-sm sm:grid-cols-3">
                     <div className="rounded-xl border bg-background p-3">
-                      Ingresos:{" "}
+                      {c("Ingresos", "Income")}:{" "}
                       {metricas
                         ? formatCurrencyARS(metricas.ingresos_total)
                         : "-"}
                     </div>
                     <div className="rounded-xl border bg-background p-3">
-                      Egresos:{" "}
+                      {c("Egresos", "Outflows")}:{" "}
                       {metricas
                         ? formatCurrencyARS(metricas.egresos_total)
                         : "-"}
                     </div>
                     <div className="rounded-xl border bg-background p-3">
-                      Pendientes:{" "}
+                      {c("Pendientes", "Pending")}:{" "}
                       {metricas
                         ? formatCurrencyARS(metricas.compromisos_pendientes)
                         : "-"}
@@ -627,17 +681,17 @@ export default function FinanzasIngresosEgresosBiPage() {
             </section>
 
             <section className="grid grid-cols-1 gap-4 xl:grid-cols-3">
-              <Card className="xl:col-span-2">
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100 xl:col-span-2">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2 text-lg">
-                    <WalletCards className="h-5 w-5 text-sky-600" />
-                    Evolución mensual
+                    <WalletCards className="h-5 w-5 text-sky-600 dark:text-cyan-300" />
+                    {c("Evolución mensual", "Monthly evolution")}
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="h-[360px]">
                   {chartData.length === 0 ? (
                     <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                      No hay datos financieros para el período seleccionado.
+                      {c("No hay datos financieros para el período seleccionado.", "No financial data for the selected period.")}
                     </div>
                   ) : (
                     <ResponsiveContainer width="100%" height="100%">
@@ -655,13 +709,13 @@ export default function FinanzasIngresosEgresosBiPage() {
                         <Legend />
                         <Bar
                           dataKey="ingresos_total"
-                          name="Ingresos"
+                          name={c("Ingresos", "Income")}
                           fill="#16a34a"
                           radius={[6, 6, 0, 0]}
                         />
                         <Bar
                           dataKey="egresos_total"
-                          name="Egresos"
+                          name={c("Egresos", "Outflows")}
                           fill="#dc2626"
                           radius={[6, 6, 0, 0]}
                         />
@@ -671,17 +725,17 @@ export default function FinanzasIngresosEgresosBiPage() {
                 </CardContent>
               </Card>
 
-              <Card>
+              <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2 text-lg">
-                    <CalendarDays className="h-5 w-5 text-sky-600" />
-                    Resultado neto
+                    <CalendarDays className="h-5 w-5 text-sky-600 dark:text-cyan-300" />
+                    {c("Resultado neto", "Net result")}
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="h-[360px]">
                   {chartData.length === 0 ? (
                     <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                      Sin resultados para graficar.
+                      {c("Sin resultados para graficar.", "No results to chart.")}
                     </div>
                   ) : (
                     <ResponsiveContainer width="100%" height="100%">
@@ -699,7 +753,7 @@ export default function FinanzasIngresosEgresosBiPage() {
                         <Area
                           type="monotone"
                           dataKey="resultado_neto"
-                          name="Resultado"
+                          name={c("Resultado", "Result")}
                           stroke="#0284c7"
                           fill="#e0f2fe"
                         />
@@ -712,41 +766,44 @@ export default function FinanzasIngresosEgresosBiPage() {
 
             <section className="grid grid-cols-1 gap-4 lg:grid-cols-3">
               <CategoryList
-                title="Ingresos por categoría"
+                title={c("Ingresos por categoría", "Income by category")}
                 items={data?.ingresos_por_categoria ?? []}
-                emptyLabel="No hay ingresos para el período."
+                emptyLabel={c("No hay ingresos para el período.", "No income for the selected period.")}
+                locale={locale}
               />
               <CategoryList
-                title="Egresos por categoría"
+                title={c("Egresos por categoría", "Outflows by category")}
                 items={data?.egresos_por_categoria ?? []}
-                emptyLabel="No hay egresos para el período."
+                emptyLabel={c("No hay egresos para el período.", "No outflows for the selected period.")}
+                locale={locale}
               />
               <CategoryList
-                title="Pendientes y vencidos"
+                title={c("Pendientes y vencidos", "Pending and overdue")}
                 items={data?.compromisos_por_categoria ?? []}
-                emptyLabel="No hay compromisos pendientes para el período."
+                emptyLabel={c("No hay compromisos pendientes para el período.", "No pending commitments for the selected period.")}
+                locale={locale}
               />
             </section>
 
-            <Card>
+            <Card className="bg-white dark:border-neutral-800 dark:bg-neutral-950/90 dark:text-neutral-100">
               <CardHeader>
                 <CardTitle className="text-lg">
-                  Resumen mensual detallado
+                  {c("Resumen mensual detallado", "Detailed monthly summary")}
                 </CardTitle>
               </CardHeader>
               <CardContent className="overflow-x-auto">
                 <table className="w-full min-w-[980px] text-sm">
                   <thead>
-                    <tr className="border-b bg-slate-50 text-left">
-                      <th className="p-3">Período</th>
-                      <th className="p-3 text-right">Cuotas</th>
-                      <th className="p-3 text-right">Ventas</th>
-                      <th className="p-3 text-right">Servicios</th>
-                      <th className="p-3 text-right">Ingresos</th>
-                      <th className="p-3 text-right">Compras</th>
-                      <th className="p-3 text-right">Gastos</th>
-                      <th className="p-3 text-right">Egresos</th>
-                      <th className="p-3 text-right">Resultado</th>
+                    <tr className="border-b bg-slate-50 text-left dark:border-neutral-800 dark:bg-neutral-900">
+                      <th className="p-3">{c("Período", "Period")}</th>
+                      <th className="p-3 text-right">{c("Cuotas", "Fees")}</th>
+                      <th className="p-3 text-right">{c("Ventas", "Sales")}</th>
+                      <th className="p-3 text-right">{c("Servicios", "Services")}</th>
+                      <th className="p-3 text-right">{c("Ingresos", "Income")}</th>
+                      <th className="p-3 text-right">{c("Compras", "Purchases")}</th>
+                      <th className="p-3 text-right">{c("Gastos", "Expenses")}</th>
+                      <th className="p-3 text-right">{c("Egresos", "Outflows")}</th>
+                      <th className="p-3 text-right">{c("Resultado", "Result")}</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -756,12 +813,12 @@ export default function FinanzasIngresosEgresosBiPage() {
                           colSpan={9}
                           className="p-6 text-center text-muted-foreground"
                         >
-                          No hay registros para el período seleccionado.
+                          {c("No hay registros para el período seleccionado.", "No records for the selected period.")}
                         </td>
                       </tr>
                     ) : (
                       chartData.map((item) => (
-                        <tr key={item.periodo} className="border-b">
+                        <tr key={item.periodo} className="border-b dark:border-neutral-800">
                           <td className="p-3 font-medium">
                             {item.periodo_label}
                           </td>

--- a/src/app/dashboard/notificaciones/page.tsx
+++ b/src/app/dashboard/notificaciones/page.tsx
@@ -47,6 +47,8 @@ import {
   getNotificaciones,
 } from '@/services/apiClient';
 import { useAuthStore } from '@/stores/authStore';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import { downloadCommercialReportPdf } from '@/utils/commercialReportPdf';
 import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
@@ -54,6 +56,45 @@ import { formatFrontendDateTime } from '@/utils/dateFormat';
 const PAGE_SIZE = 10;
 type EstadoFilter = 'todos' | NotificacionEstado;
 type TipoFilter = 'todos' | NotificacionTipo;
+
+
+function notificationTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function notificationStatusLabel(locale: GymMasterLocale, value?: string | null) {
+  const labels: Record<string, { es: string; en: string }> = {
+    todos: { es: 'Todos', en: 'All' },
+    borrador: { es: 'Borrador', en: 'Draft' },
+    programada: { es: 'Programada', en: 'Scheduled' },
+    enviada: { es: 'Enviada', en: 'Sent' },
+    cancelada: { es: 'Cancelada', en: 'Cancelled' },
+    error: { es: 'Error', en: 'Error' },
+  };
+  const key = String(value ?? '').toLowerCase();
+  const match = labels[key];
+  if (match) return notificationTx(locale, match.es, match.en);
+  return normalizeLabel(value);
+}
+
+function notificationTypeLabel(locale: GymMasterLocale, value?: string | null) {
+  const labels: Record<string, { es: string; en: string }> = {
+    todos: { es: 'Todos', en: 'All' },
+    general: { es: 'General', en: 'General' },
+    feriado: { es: 'Feriado', en: 'Holiday' },
+    promocion: { es: 'Promoción', en: 'Promotion' },
+    stock: { es: 'Stock', en: 'Stock' },
+    cumpleanos: { es: 'Cumpleaños', en: 'Birthday' },
+    cuota: { es: 'Cuota', en: 'Fee' },
+    recordatorio: { es: 'Recordatorio', en: 'Reminder' },
+    sistema: { es: 'Sistema', en: 'System' },
+    otro: { es: 'Otro', en: 'Other' },
+  };
+  const key = String(value ?? '').toLowerCase();
+  const match = labels[key];
+  if (match) return notificationTx(locale, match.es, match.en);
+  return normalizeLabel(value);
+}
 
 const estados: Array<{ value: EstadoFilter; label: string }> = [
   { value: 'todos', label: 'Todos' },
@@ -77,14 +118,12 @@ const tipos: Array<{ value: TipoFilter; label: string }> = [
   { value: 'otro', label: 'Otro' },
 ];
 
-function estadoLabel(value: EstadoFilter) {
-  const match = estados.find((estado) => estado.value === value);
-  return match?.label ?? value;
+function estadoLabel(locale: GymMasterLocale, value: EstadoFilter) {
+  return notificationStatusLabel(locale, value);
 }
 
-function tipoLabel(value: TipoFilter) {
-  const match = tipos.find((tipo) => tipo.value === value);
-  return match?.label ?? value;
+function tipoLabel(locale: GymMasterLocale, value: TipoFilter) {
+  return notificationTypeLabel(locale, value);
 }
 
 function dateInRange(value: string | null | undefined, desde: string, hasta: string) {
@@ -117,6 +156,8 @@ function normalizeLabel(value?: string | null) {
 
 export default function NotificacionesPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => notificationTx(locale, es, en);
   const router = useRouter();
   const [notificaciones, setNotificaciones] = useState<Notificacion[]>([]);
   const [plantillas, setPlantillas] = useState<NotificacionPlantilla[]>([]);
@@ -148,15 +189,15 @@ export default function NotificacionesPage() {
         getNotificacionPlantillas(),
       ]);
 
-      if (!notificacionesResponse.ok) throw new Error(notificacionesResponse.error || 'Error al cargar notificaciones');
-      if (!plantillasResponse.ok) throw new Error(plantillasResponse.error || 'Error al cargar plantillas');
+      if (!notificacionesResponse.ok) throw new Error(notificacionesResponse.error || c('Error al cargar notificaciones', 'Could not load notifications'));
+      if (!plantillasResponse.ok) throw new Error(plantillasResponse.error || c('Error al cargar plantillas', 'Could not load templates'));
 
       setNotificaciones((notificacionesResponse.data || []) as Notificacion[]);
       setPlantillas((plantillasResponse.data || []) as NotificacionPlantilla[]);
     } catch (error) {
       setNotificaciones([]);
       setPlantillas([]);
-      toast.error(error instanceof Error ? error.message : 'Error al cargar notificaciones');
+      toast.error(error instanceof Error ? error.message : c('Error al cargar notificaciones', 'Could not load notifications'));
     } finally {
       setLoading(false);
     }
@@ -250,7 +291,7 @@ export default function NotificacionesPage() {
     const response = await getNotificacion(notificacion.id);
 
     if (!response.ok) {
-      toast.error(response.error || 'No se pudo cargar el detalle');
+      toast.error(response.error || c('No se pudo cargar el detalle', 'Could not load the detail'));
       return;
     }
 
@@ -259,66 +300,66 @@ export default function NotificacionesPage() {
   };
 
   const handleSend = async (notificacion: Notificacion) => {
-    if (!confirm(`¿Preparar/enviar la notificación “${notificacion.titulo}” a los socios del segmento seleccionado?`)) return;
+    if (!confirm(c(`¿Preparar/enviar la notificación “${notificacion.titulo}” a los socios del segmento seleccionado?`, `Prepare/send the notification “${notificacion.titulo}” to members in the selected segment?`))) return;
 
     const response = await enviarNotificacion(notificacion.id);
 
     if (!response.ok) {
-      toast.error(response.error || 'No se pudo enviar la notificación');
+      toast.error(response.error || c('No se pudo enviar la notificación', 'Could not send the notification'));
       return;
     }
 
-    toast.success('Notificación registrada como enviada');
+    toast.success(c('Notificación registrada como enviada', 'Notification marked as sent'));
     setOpenViewModal(false);
     setNotificacionVer(null);
     await loadData();
   };
 
   const handleCancel = async (notificacion: Notificacion) => {
-    if (!confirm(`¿Cancelar la notificación “${notificacion.titulo}”?`)) return;
+    if (!confirm(c(`¿Cancelar la notificación “${notificacion.titulo}”?`, `Cancel the notification “${notificacion.titulo}”?`))) return;
 
     const response = await cancelarNotificacion(notificacion.id);
 
     if (!response.ok) {
-      toast.error(response.error || 'No se pudo cancelar la notificación');
+      toast.error(response.error || c('No se pudo cancelar la notificación', 'Could not cancel the notification'));
       return;
     }
 
-    toast.success('Notificación cancelada');
+    toast.success(c('Notificación cancelada', 'Notification cancelled'));
     await loadData();
   };
 
   const exportExcel = async () => {
     const workbook = new ExcelJS.Workbook();
-    const sheet = workbook.addWorksheet('Notificaciones');
+    const sheet = workbook.addWorksheet(c('Notificaciones', 'Notifications'));
 
     sheet.columns = [
-      { header: 'Título', key: 'titulo', width: 28 },
-      { header: 'Asunto', key: 'asunto', width: 36 },
-      { header: 'Tipo', key: 'tipo', width: 16 },
-      { header: 'Canal', key: 'canal', width: 16 },
-      { header: 'Estado', key: 'estado', width: 16 },
-      { header: 'Destinatarios', key: 'destinatarios', width: 16 },
-      { header: 'Enviados', key: 'enviados', width: 14 },
-      { header: 'Errores', key: 'errores', width: 14 },
-      { header: 'Programada', key: 'programada', width: 22 },
-      { header: 'Visible hasta', key: 'vigencia_hasta', width: 22 },
-      { header: 'Terminal', key: 'terminal', width: 14 },
+      { header: c('Título', 'Title'), key: 'titulo', width: 28 },
+      { header: c('Asunto', 'Subject'), key: 'asunto', width: 36 },
+      { header: c('Tipo', 'Type'), key: 'tipo', width: 16 },
+      { header: c('Canal', 'Channel'), key: 'canal', width: 16 },
+      { header: c('Estado', 'Status'), key: 'estado', width: 16 },
+      { header: c('Destinatarios', 'Recipients'), key: 'destinatarios', width: 16 },
+      { header: c('Enviados', 'Sent'), key: 'enviados', width: 14 },
+      { header: c('Errores', 'Errors'), key: 'errores', width: 14 },
+      { header: c('Programada', 'Scheduled'), key: 'programada', width: 22 },
+      { header: c('Visible hasta', 'Visible until'), key: 'vigencia_hasta', width: 22 },
+      { header: c('Terminal', 'Terminal'), key: 'terminal', width: 14 },
     ];
 
     filteredNotificaciones.forEach((notificacion) => {
       sheet.addRow({
         titulo: notificacion.titulo,
         asunto: notificacion.asunto,
-        tipo: notificacion.tipo,
-        canal: notificacion.canal,
-        estado: notificacion.estado,
+        tipo: notificationTypeLabel(locale, notificacion.tipo),
+        canal: normalizeLabel(notificacion.canal),
+        estado: notificationStatusLabel(locale, notificacion.estado),
         destinatarios: notificacion.total_destinatarios,
         enviados: notificacion.total_enviados,
         errores: notificacion.total_errores,
         programada: formatFrontendDateTime(notificacion.fecha_programada),
         vigencia_hasta: formatFrontendDateTime(notificacion.fecha_vigencia_hasta),
-        terminal: notificacion.mostrar_terminal ? 'Sí' : 'No',
+        terminal: notificacion.mostrar_terminal ? c('Sí', 'Yes') : c('No', 'No'),
       });
     });
 
@@ -336,31 +377,31 @@ export default function NotificacionesPage() {
 
   const downloadPdf = async () => {
     await downloadCommercialReportPdf({
-      title: 'Centro de notificaciones',
-      subtitle: 'Avisos administrativos, campañas, terminal, emails y seguimiento de envíos.',
+      title: c('Centro de notificaciones', 'Notifications center'),
+      subtitle: c('Avisos administrativos, campañas, terminal, emails y seguimiento de envíos.', 'Administrative alerts, campaigns, terminal messages, emails and delivery tracking.'),
       fileName: buildTimestampedDownloadFileName('listado-notificaciones', 'pdf'),
       rows: filteredNotificaciones,
       metrics: [
-        { label: 'Registros', value: totals.total },
-        { label: 'Enviadas', value: totals.enviadas },
-        { label: 'Programadas', value: totals.programadas },
-        { label: 'Errores', value: totals.errores },
-        { label: 'Terminal visibles', value: totals.terminal },
+        { label: c('Registros', 'Records'), value: totals.total },
+        { label: c('Enviadas', 'Sent'), value: totals.enviadas },
+        { label: c('Programadas', 'Scheduled'), value: totals.programadas },
+        { label: c('Errores', 'Errors'), value: totals.errores },
+        { label: c('Terminal visibles', 'Visible in terminal'), value: totals.terminal },
       ],
-      filtersLabel: `Estado: ${estadoLabel(estadoFilter)} · Tipo: ${tipoLabel(tipoFilter)} · Desde: ${fechaDesde || 'sin filtro'} · Hasta: ${fechaHasta || 'sin filtro'} · Búsqueda: ${searchTerm || 'sin búsqueda'}`,
+      filtersLabel: `${c('Estado', 'Status')}: ${estadoLabel(locale, estadoFilter)} · ${c('Tipo', 'Type')}: ${tipoLabel(locale, tipoFilter)} · ${c('Desde', 'From')}: ${fechaDesde || c('sin filtro', 'no filter')} · ${c('Hasta', 'To')}: ${fechaHasta || c('sin filtro', 'no filter')} · ${c('Búsqueda', 'Search')}: ${searchTerm || c('sin búsqueda', 'no search')}`,
       columns: [
-        { header: 'Título', width: 36, getValue: (row) => row.titulo },
-        { header: 'Tipo', width: 22, getValue: (row) => row.tipo },
-        { header: 'Canal', width: 24, getValue: (row) => row.canal },
-        { header: 'Estado', width: 24, getValue: (row) => row.estado },
-        { header: 'Programada', width: 28, getValue: (row) => formatFrontendDateTime(row.fecha_programada) },
-        { header: 'Hasta', width: 28, getValue: (row) => formatFrontendDateTime(row.fecha_vigencia_hasta) },
-        { header: 'Envíos', width: 20, getValue: (row) => `${row.total_enviados}/${row.total_destinatarios}` },
+        { header: c('Título', 'Title'), width: 36, getValue: (row) => row.titulo },
+        { header: c('Tipo', 'Type'), width: 22, getValue: (row) => notificationTypeLabel(locale, row.tipo) },
+        { header: c('Canal', 'Channel'), width: 24, getValue: (row) => normalizeLabel(row.canal) },
+        { header: c('Estado', 'Status'), width: 24, getValue: (row) => notificationStatusLabel(locale, row.estado) },
+        { header: c('Programada', 'Scheduled'), width: 28, getValue: (row) => formatFrontendDateTime(row.fecha_programada) },
+        { header: c('Hasta', 'Until'), width: 28, getValue: (row) => formatFrontendDateTime(row.fecha_vigencia_hasta) },
+        { header: c('Envíos', 'Deliveries'), width: 20, getValue: (row) => `${row.total_enviados}/${row.total_destinatarios}` },
       ],
     });
   };
 
-  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isInitialized) return <div>{c('Cargando...', 'Loading...')}</div>;
   if (!isAuthenticated) return null;
 
   return (
@@ -368,7 +409,7 @@ export default function NotificacionesPage() {
       <div className='flex h-[100dvh] max-h-[100dvh] w-full overflow-hidden'>
         <AppSidebar />
         <SidebarInset className='!grid !min-h-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden'>
-          <AppHeader title='Notificaciones' />
+          <AppHeader title={c('Notificaciones', 'Notifications')} />
           <section className='min-h-0 overflow-y-auto bg-gradient-to-b from-sky-50/70 via-background to-background px-4 py-4 sm:px-6 md:p-6 dark:from-sky-950/10'>
             <div className='mx-auto w-full max-w-7xl space-y-5 md:space-y-6'>
               <section className='overflow-hidden rounded-[2rem] border border-sky-100 bg-white shadow-sm dark:border-sky-900/60 dark:bg-slate-950/80'>
@@ -376,19 +417,19 @@ export default function NotificacionesPage() {
                   <div className='min-w-0'>
                     <p className='inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-sky-700 ring-1 ring-sky-100 dark:bg-sky-950/40 dark:text-sky-200 dark:ring-sky-900/70'>
                       <BellRing className='h-3.5 w-3.5' />
-                      Centro administrativo
+                      {c('Centro administrativo', 'Administrative center')}
                     </p>
                     <h1 className='mt-3 text-2xl font-black leading-tight text-slate-950 sm:text-3xl dark:text-white'>
-                      Centro de notificaciones
+                      {c('Centro de notificaciones', 'Notifications center')}
                     </h1>
                     <p className='mt-2 max-w-3xl text-sm leading-6 text-muted-foreground'>
-                      Controlá campañas, avisos programados, mensajes de sistema, alertas para Terminal y envíos a socios desde una vista operativa.
+                      {c('Controlá campañas, avisos programados, mensajes de sistema, alertas para Terminal y envíos a socios desde una vista operativa.', 'Control campaigns, scheduled alerts, system messages, terminal alerts and member deliveries from one operational view.')}
                     </p>
                   </div>
                   <div className='grid gap-2 sm:grid-cols-2 lg:min-w-[360px]'>
                     <Button type='button' variant='outline' onClick={loadData} disabled={loading} className='w-full'>
                       <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-                      Actualizar
+                      {c('Actualizar', 'Refresh')}
                     </Button>
                     <Button
                       type='button'
@@ -398,7 +439,7 @@ export default function NotificacionesPage() {
                       }}
                       className='w-full'
                     >
-                      <Plus className='mr-2 h-4 w-4' /> Nueva notificación
+                      <Plus className='mr-2 h-4 w-4' /> {c('Nueva notificación', 'New notification')}
                     </Button>
                   </div>
                 </div>
@@ -409,7 +450,7 @@ export default function NotificacionesPage() {
                   <CardContent className='flex items-center gap-3 p-4'>
                     <BellRing className='h-8 w-8 text-sky-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Registros</p>
+                      <p className='text-sm text-muted-foreground'>{c('Registros', 'Records')}</p>
                       <p className='text-2xl font-bold'>{totals.total}</p>
                     </div>
                   </CardContent>
@@ -418,7 +459,7 @@ export default function NotificacionesPage() {
                   <CardContent className='flex items-center gap-3 p-4'>
                     <Send className='h-8 w-8 text-emerald-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Enviadas</p>
+                      <p className='text-sm text-muted-foreground'>{c('Enviadas', 'Sent')}</p>
                       <p className='text-2xl font-bold'>{totals.enviadas}</p>
                     </div>
                   </CardContent>
@@ -427,7 +468,7 @@ export default function NotificacionesPage() {
                   <CardContent className='flex items-center gap-3 p-4'>
                     <CalendarClock className='h-8 w-8 text-amber-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Programadas</p>
+                      <p className='text-sm text-muted-foreground'>{c('Programadas', 'Scheduled')}</p>
                       <p className='text-2xl font-bold'>{totals.programadas}</p>
                     </div>
                   </CardContent>
@@ -436,7 +477,7 @@ export default function NotificacionesPage() {
                   <CardContent className='flex items-center gap-3 p-4'>
                     <AlertTriangle className='h-8 w-8 text-red-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Con error</p>
+                      <p className='text-sm text-muted-foreground'>{c('Con error', 'With errors')}</p>
                       <p className='text-2xl font-bold'>{totals.errores}</p>
                     </div>
                   </CardContent>
@@ -454,7 +495,7 @@ export default function NotificacionesPage() {
                   <CardContent className='flex items-center gap-3 p-4'>
                     <Mail className='h-8 w-8 text-cyan-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Entrega</p>
+                      <p className='text-sm text-muted-foreground'>{c('Entrega', 'Delivery')}</p>
                       <p className='text-2xl font-bold'>{formatPercent(deliveryRate)}</p>
                     </div>
                   </CardContent>
@@ -469,26 +510,26 @@ export default function NotificacionesPage() {
                         <ShieldCheck className='h-5 w-5' />
                       </span>
                       <div>
-                        <h2 className='text-lg font-black'>Salud del centro de avisos</h2>
-                        <p className='text-sm text-muted-foreground'>Lectura rápida para detectar campañas trabadas o envíos que necesitan intervención.</p>
+                        <h2 className='text-lg font-black'>{c('Salud del centro de avisos', 'Notification center health')}</h2>
+                        <p className='text-sm text-muted-foreground'>{c('Lectura rápida para detectar campañas trabadas o envíos que necesitan intervención.', 'Quick reading to detect stuck campaigns or deliveries that need attention.')}</p>
                       </div>
                     </div>
                   </CardHeader>
                   <CardContent className='grid gap-3 p-4 md:grid-cols-3'>
                     <div className='rounded-2xl border border-border/70 bg-muted/20 p-4'>
-                      <p className='text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>Próximas 48 h</p>
+                      <p className='text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>{c('Próximas 48 h', 'Next 48 h')}</p>
                       <p className='mt-2 text-2xl font-black'>{totals.proximas48}</p>
-                      <p className='mt-1 text-xs text-muted-foreground'>Programaciones próximas a ejecutarse.</p>
+                      <p className='mt-1 text-xs text-muted-foreground'>{c('Programaciones próximas a ejecutarse.', 'Scheduled messages about to run.')}</p>
                     </div>
                     <div className='rounded-2xl border border-border/70 bg-muted/20 p-4'>
-                      <p className='text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>Borradores</p>
+                      <p className='text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>{c('Borradores', 'Drafts')}</p>
                       <p className='mt-2 text-2xl font-black'>{totals.borradores}</p>
-                      <p className='mt-1 text-xs text-muted-foreground'>Avisos pendientes de preparación o envío.</p>
+                      <p className='mt-1 text-xs text-muted-foreground'>{c('Avisos pendientes de preparación o envío.', 'Messages pending preparation or delivery.')}</p>
                     </div>
                     <div className='rounded-2xl border border-border/70 bg-muted/20 p-4'>
-                      <p className='text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>Sin destinatarios</p>
+                      <p className='text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>{c('Sin destinatarios', 'Without recipients')}</p>
                       <p className='mt-2 text-2xl font-black'>{totals.sinDestinatarios}</p>
-                      <p className='mt-1 text-xs text-muted-foreground'>Revisar segmento antes de enviar.</p>
+                      <p className='mt-1 text-xs text-muted-foreground'>{c('Revisar segmento antes de enviar.', 'Review the segment before sending.')}</p>
                     </div>
                   </CardContent>
                 </Card>
@@ -500,8 +541,8 @@ export default function NotificacionesPage() {
                         <Inbox className='h-5 w-5' />
                       </span>
                       <div>
-                        <h2 className='text-lg font-black'>Prioridades</h2>
-                        <p className='text-sm text-muted-foreground'>Errores o envíos próximos.</p>
+                        <h2 className='text-lg font-black'>{c('Prioridades', 'Priorities')}</h2>
+                        <p className='text-sm text-muted-foreground'>{c('Errores o envíos próximos.', 'Errors or upcoming deliveries.')}</p>
                       </div>
                     </div>
                   </CardHeader>
@@ -510,7 +551,7 @@ export default function NotificacionesPage() {
                       <div className='rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/30 dark:text-emerald-100'>
                         <div className='flex items-start gap-2'>
                           <CheckCircle2 className='mt-0.5 h-4 w-4 shrink-0' />
-                          No hay alertas críticas para los filtros actuales.
+                          {c('No hay alertas críticas para los filtros actuales.', 'No critical alerts for the current filters.')}
                         </div>
                       </div>
                     ) : (
@@ -526,7 +567,7 @@ export default function NotificacionesPage() {
                             <div className='min-w-0'>
                               <p className='truncate text-sm font-bold'>{item.titulo}</p>
                               <p className='text-xs text-muted-foreground'>
-                                {normalizeLabel(item.estado)} · {formatFrontendDateTime(item.fecha_programada ?? item.creado_en)}
+                                {notificationStatusLabel(locale, item.estado)} · {formatFrontendDateTime(item.fecha_programada ?? item.creado_en)}
                               </p>
                             </div>
                           </div>
@@ -540,15 +581,15 @@ export default function NotificacionesPage() {
               <Card className='overflow-hidden rounded-[2rem] border-border bg-white shadow-sm dark:bg-slate-950/80'>
                 <CardHeader className='flex flex-col items-start justify-between gap-4 border-b p-4 xl:flex-row xl:items-center'>
                   <div>
-                    <h2 className='text-xl font-bold'>Listado operativo</h2>
-                    <p className='text-sm text-muted-foreground'>Filtrá, exportá, revisá detalle y ejecutá acciones sobre las notificaciones.</p>
+                    <h2 className='text-xl font-bold'>{c('Listado operativo', 'Operational list')}</h2>
+                    <p className='text-sm text-muted-foreground'>{c('Filtrá, exportá, revisá detalle y ejecutá acciones sobre las notificaciones.', 'Filter, export, review details and run actions on notifications.')}</p>
                   </div>
                   <div className='grid w-full grid-cols-1 gap-2 sm:grid-cols-2 xl:w-auto xl:grid-cols-3'>
                     <Button type='button' variant='outline' onClick={exportExcel}>
                       <FileSpreadsheet className='mr-2 h-4 w-4' /> Excel
                     </Button>
                     <Button type='button' variant='outline' onClick={downloadPdf}>
-                      <FileText className='mr-2 h-4 w-4' /> Descargar PDF
+                      <FileText className='mr-2 h-4 w-4' /> {c('Descargar PDF', 'Download PDF')}
                     </Button>
                     <Button
                       type='button'
@@ -557,7 +598,7 @@ export default function NotificacionesPage() {
                         setOpenModal(true);
                       }}
                     >
-                      <Plus className='mr-2 h-4 w-4' /> Nueva notificación
+                      <Plus className='mr-2 h-4 w-4' /> {c('Nueva notificación', 'New notification')}
                     </Button>
                   </div>
                 </CardHeader>
@@ -566,11 +607,11 @@ export default function NotificacionesPage() {
                     <div className='mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
                       <div className='flex items-center gap-2 text-sm font-bold'>
                         <Filter className='h-4 w-4 text-sky-600' />
-                        Filtros de búsqueda
+                        {c('Filtros de búsqueda', 'Search filters')}
                       </div>
                       {hasActiveFilters ? (
                         <Button type='button' variant='ghost' size='sm' onClick={clearFilters}>
-                          Limpiar filtros
+                          {c('Limpiar filtros', 'Clear filters')}
                         </Button>
                       ) : null}
                     </div>
@@ -579,7 +620,7 @@ export default function NotificacionesPage() {
                         <Search className='absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground' />
                         <Input
                           type='search'
-                          placeholder='Buscar por título, asunto, tipo, canal o mensaje...'
+                          placeholder={c('Buscar por título, asunto, tipo, canal o mensaje...', 'Search by title, subject, type, channel or message...')}
                           className='pl-8'
                           value={searchTerm}
                           onChange={(event) => setSearchTerm(event.target.value)}
@@ -592,7 +633,7 @@ export default function NotificacionesPage() {
                       >
                         {estados.map((estado) => (
                           <option key={estado.value} value={estado.value}>
-                            {estado.label}
+                            {notificationStatusLabel(locale, estado.value)}
                           </option>
                         ))}
                       </select>
@@ -603,7 +644,7 @@ export default function NotificacionesPage() {
                       >
                         {tipos.map((tipo) => (
                           <option key={tipo.value} value={tipo.value}>
-                            {tipo.label}
+                            {notificationTypeLabel(locale, tipo.value)}
                           </option>
                         ))}
                       </select>
@@ -615,7 +656,7 @@ export default function NotificacionesPage() {
                   </div>
 
                   {loading ? (
-                    <div className='py-10 text-center text-muted-foreground'>Cargando notificaciones...</div>
+                    <div className='py-10 text-center text-muted-foreground'>{c('Cargando notificaciones...', 'Loading notifications...')}</div>
                   ) : (
                     <NotificacionTable
                       notificaciones={paginatedNotificaciones}
@@ -634,7 +675,7 @@ export default function NotificacionesPage() {
                     totalItems={filteredNotificaciones.length}
                     pageSize={PAGE_SIZE}
                     onPageChange={setCurrentPage}
-                    itemLabel='notificaciones'
+                    itemLabel={c('notificaciones', 'notifications')}
                   />
                 </CardContent>
               </Card>

--- a/src/app/dashboard/otros-gastos/page.tsx
+++ b/src/app/dashboard/otros-gastos/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import ExcelJS from "exceljs";
 import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
 import { toast } from "sonner";
-import { FileSpreadsheet, FileText, Plus, ReceiptText, Search } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Clock3, DollarSign, FileSpreadsheet, FileText, Plus, ReceiptText, Search } from "lucide-react";
 import { useAuthStore } from "@/stores/authStore";
 import { AppHeader } from "@/components/header/AppHeader";
 import { AppFooter } from "@/components/footer/AppFooter";
@@ -26,17 +26,26 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { formatCurrencyARS } from "@/lib/comercial/productos";
 import { formatFrontendDate } from "@/utils/dateFormat";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
+import {
+  getOtrosGastosEstadoLabel,
+  getOtrosGastosMedioPagoLabel,
+  getOtrosGastosTipoLabel,
+  translateOtrosGastosDescription,
+  translateOtrosGastosUi,
+ } from "@/utils/otrosGastosI18n";
 
 const PAGE_SIZE = 10;
 type EstadoFilter = "todos" | OtrosGastosEstado;
 
-function estadoLabel(estado: EstadoFilter) {
-  if (estado === "todos") return "Todos";
-  return estado.charAt(0).toUpperCase() + estado.slice(1);
+function estadoLabel(estado: EstadoFilter, locale: GymMasterLocale) {
+  if (estado === "todos") return translateOtrosGastosUi(locale, "Todos");
+  return getOtrosGastosEstadoLabel(locale, estado);
 }
 
-function getTipoNombre(gasto: OtrosGastos) {
-  return gasto.tipo_gasto?.nombre ?? "Sin clasificar";
+function getTipoNombre(gasto: OtrosGastos, locale: GymMasterLocale) {
+  return getOtrosGastosTipoLabel(locale, gasto.tipo_gasto?.nombre);
 }
 
 function getDateOnlyTime(value?: string | null) {
@@ -51,6 +60,8 @@ function getDateOnlyTime(value?: string | null) {
 
 export default function OtrosGastosPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
+  const c = (text: string) => translateOtrosGastosUi(locale, text);
   const router = useRouter();
   const [gastos, setGastos] = useState<OtrosGastos[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -102,7 +113,7 @@ export default function OtrosGastosPage() {
       const matchesFechaHasta = !hastaTime || (gastoTime !== null && gastoTime <= hastaTime);
       const searchable = [
         gasto.descripcion,
-        getTipoNombre(gasto),
+        getTipoNombre(gasto, locale),
         gasto.proveedor_nombre,
         gasto.entidad,
         gasto.numero_comprobante,
@@ -122,7 +133,7 @@ export default function OtrosGastosPage() {
         (!lowercaseSearch || searchable.includes(lowercaseSearch))
       );
     });
-  }, [estadoFilter, fechaDesde, fechaHasta, gastos, searchTerm]);
+  }, [estadoFilter, fechaDesde, fechaHasta, gastos, locale, searchTerm]);
 
   useEffect(() => {
     setCurrentPage(1);
@@ -150,41 +161,41 @@ export default function OtrosGastosPage() {
   }, [gastos]);
 
   const filtersLabel = [
-    `Estado: ${estadoLabel(estadoFilter)}`,
-    fechaDesde ? `Desde: ${formatFrontendDate(fechaDesde)}` : null,
-    fechaHasta ? `Hasta: ${formatFrontendDate(fechaHasta)}` : null,
-    searchTerm ? `Búsqueda: ${searchTerm}` : null,
+    `${c("Estado:")} ${estadoLabel(estadoFilter, locale)}`,
+    fechaDesde ? `${c("Desde:")} ${formatFrontendDate(fechaDesde)}` : null,
+    fechaHasta ? `${c("Hasta:")} ${formatFrontendDate(fechaHasta)}` : null,
+    searchTerm ? `${c("Búsqueda:")} ${searchTerm}` : null,
   ]
     .filter(Boolean)
     .join(" | ");
 
   const handleExportExcel = async () => {
     const workbook = new ExcelJS.Workbook();
-    const worksheet = workbook.addWorksheet("Gastos");
+    const worksheet = workbook.addWorksheet(c("Gastos / Egresos"));
 
     worksheet.columns = [
-      { header: "Descripción", key: "descripcion", width: 38 },
-      { header: "Tipo", key: "tipo", width: 22 },
-      { header: "Entidad", key: "entidad", width: 24 },
-      { header: "Estado", key: "estado", width: 14 },
-      { header: "Medio de pago", key: "medio_pago", width: 18 },
-      { header: "Monto", key: "monto", width: 16 },
-      { header: "Fecha", key: "fecha", width: 14 },
-      { header: "Vencimiento", key: "fecha_vencimiento", width: 14 },
-      { header: "Fecha pago", key: "fecha_pago", width: 14 },
-      { header: "Período desde", key: "periodo_desde", width: 14 },
-      { header: "Período hasta", key: "periodo_hasta", width: 14 },
-      { header: "Comprobante", key: "comprobante", width: 35 },
-      { header: "Observaciones", key: "observaciones", width: 35 },
+      { header: c("Descripción"), key: "descripcion", width: 38 },
+      { header: c("Tipo"), key: "tipo", width: 22 },
+      { header: c("Entidad"), key: "entidad", width: 24 },
+      { header: c("Estado"), key: "estado", width: 14 },
+      { header: c("Medio de pago"), key: "medio_pago", width: 18 },
+      { header: c("Monto"), key: "monto", width: 16 },
+      { header: c("Fecha"), key: "fecha", width: 14 },
+      { header: c("Vencimiento"), key: "fecha_vencimiento", width: 14 },
+      { header: c("Fecha pago"), key: "fecha_pago", width: 14 },
+      { header: c("Período desde"), key: "periodo_desde", width: 14 },
+      { header: c("Período hasta"), key: "periodo_hasta", width: 14 },
+      { header: c("Comprobante"), key: "comprobante", width: 35 },
+      { header: c("Observaciones"), key: "observaciones", width: 35 },
     ];
 
     filteredGastos.forEach((g) => {
       worksheet.addRow({
-        descripcion: g.descripcion,
-        tipo: getTipoNombre(g),
+        descripcion: translateOtrosGastosDescription(locale, g.descripcion),
+        tipo: getTipoNombre(g, locale),
         entidad: g.proveedor_nombre || g.entidad || "-",
-        estado: g.estado ?? "-",
-        medio_pago: g.medio_pago?.replace(/_/g, " ") ?? "-",
+        estado: getOtrosGastosEstadoLabel(locale, g.estado),
+        medio_pago: getOtrosGastosMedioPagoLabel(locale, g.medio_pago),
         monto: Number(g.monto ?? 0),
         fecha: formatFrontendDate(g.fecha),
         fecha_vencimiento: g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-",
@@ -192,7 +203,7 @@ export default function OtrosGastosPage() {
         periodo_desde: g.periodo_desde ? formatFrontendDate(g.periodo_desde) : "-",
         periodo_hasta: g.periodo_hasta ? formatFrontendDate(g.periodo_hasta) : "-",
         comprobante: g.comprobante_url ?? "-",
-        observaciones: g.observaciones ?? "-",
+        observaciones: translateOtrosGastosDescription(locale, g.observaciones),
       });
     });
 
@@ -210,34 +221,34 @@ export default function OtrosGastosPage() {
 
   const handleDownloadPdf = async () => {
     await downloadCommercialReportPdf<OtrosGastos>({
-      title: "Listado de Gastos / Egresos",
-      subtitle: "Control operativo de egresos del gimnasio",
+      title: c("Listado de Gastos / Egresos"),
+      subtitle: c("Control operativo de egresos del gimnasio"),
       fileName: "listado-gastos-egresos",
       rows: filteredGastos,
       filtersLabel,
       metrics: [
-        { label: "Total", value: metrics.total },
-        { label: "Activos", value: metrics.activos },
-        { label: "Pendientes", value: metrics.pendientes },
-        { label: "Vencidos", value: metrics.vencidos },
-        { label: "Con comprobante", value: metrics.conComprobante },
+        { label: c("Total"), value: metrics.total },
+        { label: c("Activos"), value: metrics.activos },
+        { label: c("Pendientes"), value: metrics.pendientes },
+        { label: c("Vencidos"), value: metrics.vencidos },
+        { label: c("Con comprobante"), value: metrics.conComprobante },
       ],
       columns: [
-        { header: "Descripción", width: 34, getValue: (g) => g.descripcion },
-        { header: "Tipo", width: 22, getValue: (g) => getTipoNombre(g) },
-        { header: "Entidad", width: 24, getValue: (g) => g.proveedor_nombre || g.entidad || "-" },
-        { header: "Estado", width: 16, getValue: (g) => g.estado ?? "-" },
-        { header: "Medio", width: 18, getValue: (g) => g.medio_pago?.replace(/_/g, " ") ?? "-" },
-        { header: "Monto", width: 20, align: "right", getValue: (g) => formatCurrencyARS(Number(g.monto ?? 0)) },
-        { header: "Fecha", width: 16, getValue: (g) => formatFrontendDate(g.fecha) },
-        { header: "Venc.", width: 16, getValue: (g) => g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-" },
-        { header: "Comp.", width: 18, getValue: (g) => g.numero_comprobante ?? "-" },
+        { header: c("Descripción"), width: 34, getValue: (g) => translateOtrosGastosDescription(locale, g.descripcion) },
+        { header: c("Tipo"), width: 22, getValue: (g) => getTipoNombre(g, locale) },
+        { header: c("Entidad"), width: 24, getValue: (g) => translateOtrosGastosDescription(locale, g.proveedor_nombre || g.entidad || "-") },
+        { header: c("Estado"), width: 16, getValue: (g) => getOtrosGastosEstadoLabel(locale, g.estado) },
+        { header: c("Medio"), width: 18, getValue: (g) => getOtrosGastosMedioPagoLabel(locale, g.medio_pago) },
+        { header: c("Monto"), width: 20, align: "right", getValue: (g) => formatCurrencyARS(Number(g.monto ?? 0)) },
+        { header: c("Fecha"), width: 16, getValue: (g) => formatFrontendDate(g.fecha) },
+        { header: c("Vencimiento"), width: 16, getValue: (g) => g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-" },
+        { header: c("Comp."), width: 18, getValue: (g) => g.numero_comprobante ?? "-" },
       ],
     });
   };
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{c("Cargando...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -249,47 +260,82 @@ export default function OtrosGastosPage() {
       <div className="flex min-h-screen w-full">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Gastos / Egresos" />
+          <AppHeader title={c("Gastos / Egresos")} />
           <main className="flex-1 space-y-6 p-6">
             <section className="grid grid-cols-1 gap-4 md:grid-cols-5">
-              <Card>
+              <Card className="border-emerald-100 bg-white dark:border-emerald-900/60 dark:bg-neutral-950/80">
                 <CardContent className="p-5">
-                  <p className="text-sm text-muted-foreground">Total egresos</p>
-                  <p className="text-2xl font-bold">{metrics.total}</p>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm text-muted-foreground dark:text-neutral-400">{c("Total egresos")}</p>
+                      <p className="text-2xl font-bold text-foreground dark:text-white">{metrics.total}</p>
+                    </div>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-300">
+                      <DollarSign className="h-5 w-5" />
+                    </span>
+                  </div>
                 </CardContent>
               </Card>
-              <Card>
+              <Card className="border-sky-100 bg-white dark:border-sky-900/60 dark:bg-neutral-950/80">
                 <CardContent className="p-5">
-                  <p className="text-sm text-muted-foreground">Activos</p>
-                  <p className="text-2xl font-bold">{metrics.activos}</p>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm text-muted-foreground dark:text-neutral-400">{c("Activos")}</p>
+                      <p className="text-2xl font-bold text-foreground dark:text-white">{metrics.activos}</p>
+                    </div>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-300">
+                      <CheckCircle2 className="h-5 w-5" />
+                    </span>
+                  </div>
                 </CardContent>
               </Card>
-              <Card>
+              <Card className="border-amber-100 bg-white dark:border-amber-900/60 dark:bg-neutral-950/80">
                 <CardContent className="p-5">
-                  <p className="text-sm text-muted-foreground">Pendientes</p>
-                  <p className="text-2xl font-bold text-amber-600">{metrics.pendientes}</p>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm text-muted-foreground dark:text-neutral-400">{c("Pendientes")}</p>
+                      <p className="text-2xl font-bold text-amber-600 dark:text-amber-300">{metrics.pendientes}</p>
+                    </div>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-300">
+                      <Clock3 className="h-5 w-5" />
+                    </span>
+                  </div>
                 </CardContent>
               </Card>
-              <Card>
+              <Card className="border-red-100 bg-white dark:border-red-900/60 dark:bg-neutral-950/80">
                 <CardContent className="p-5">
-                  <p className="text-sm text-muted-foreground">Vencidos</p>
-                  <p className="text-2xl font-bold text-red-600">{metrics.vencidos}</p>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm text-muted-foreground dark:text-neutral-400">{c("Vencidos")}</p>
+                      <p className="text-2xl font-bold text-red-600 dark:text-red-300">{metrics.vencidos}</p>
+                    </div>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-red-200 bg-red-50 text-red-700 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-300">
+                      <AlertTriangle className="h-5 w-5" />
+                    </span>
+                  </div>
                 </CardContent>
               </Card>
-              <Card>
+              <Card className="border-cyan-100 bg-white dark:border-cyan-900/60 dark:bg-neutral-950/80">
                 <CardContent className="p-5">
-                  <p className="text-sm text-muted-foreground">Comprobantes</p>
-                  <p className="text-2xl font-bold text-sky-600">{metrics.conComprobante}</p>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm text-muted-foreground dark:text-neutral-400">{c("Comprobantes")}</p>
+                      <p className="text-2xl font-bold text-sky-600 dark:text-cyan-300">{metrics.conComprobante}</p>
+                    </div>
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl border border-cyan-200 bg-cyan-50 text-cyan-700 dark:border-cyan-900/70 dark:bg-cyan-950/40 dark:text-cyan-300">
+                      <ReceiptText className="h-5 w-5" />
+                    </span>
+                  </div>
                 </CardContent>
               </Card>
             </section>
 
-            <Card className="w-full">
+            <Card className="w-full dark:border-neutral-800 dark:bg-neutral-950/80">
               <CardHeader className="flex flex-wrap items-center justify-between gap-4 border-b p-4 md:flex-nowrap">
                 <div>
-                  <h2 className="text-xl font-bold">Listado de Gastos / Egresos</h2>
+                  <h2 className="text-xl font-bold">{c("Listado de Gastos / Egresos")}</h2>
                   <p className="text-sm text-muted-foreground">
-                    Registrá gastos operativos, vencimientos, medios de pago y comprobantes.
+                    {c("Registrá gastos operativos, vencimientos, medios de pago y comprobantes.")}
                   </p>
                 </div>
                 <div className="flex w-full flex-wrap items-center gap-2 md:w-auto">
@@ -298,25 +344,25 @@ export default function OtrosGastosPage() {
                     onChange={(event) => setEstadoFilter(event.target.value as EstadoFilter)}
                     className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
                   >
-                    <option value="todos">Todos</option>
-                    <option value="pagado">Pagados</option>
-                    <option value="pendiente">Pendientes</option>
-                    <option value="vencido">Vencidos</option>
-                    <option value="anulado">Anulados</option>
+                    <option value="todos">{c("Todos")}</option>
+                    <option value="pagado">{c("Pagados")}</option>
+                    <option value="pendiente">{c("Pendientes")}</option>
+                    <option value="vencido">{c("Vencidos")}</option>
+                    <option value="anulado">{c("Anulados")}</option>
                   </select>
                   <div className="flex items-center gap-2">
                     <Input
                       type="date"
-                      aria-label="Fecha desde"
-                      title="Fecha desde"
+                      aria-label={c("Fecha desde")}
+                      title={c("Fecha desde")}
                       value={fechaDesde}
                       onChange={(event) => setFechaDesde(event.target.value)}
                       className="w-[150px]"
                     />
                     <Input
                       type="date"
-                      aria-label="Fecha hasta"
-                      title="Fecha hasta"
+                      aria-label={c("Fecha hasta")}
+                      title={c("Fecha hasta")}
                       value={fechaHasta}
                       onChange={(event) => setFechaHasta(event.target.value)}
                       className="w-[150px]"
@@ -331,7 +377,7 @@ export default function OtrosGastosPage() {
                         }}
                         className="h-10 px-2 text-xs"
                       >
-                        Limpiar
+                        {c("Limpiar")}
                       </Button>
                     )}
                   </div>
@@ -339,7 +385,7 @@ export default function OtrosGastosPage() {
                     <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
                       type="search"
-                      placeholder="Buscar gasto, tipo, entidad, comprobante..."
+                      placeholder={c("Buscar gasto, tipo, entidad, comprobante...")}
                       className="w-full pl-8 sm:w-[320px]"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
@@ -348,33 +394,32 @@ export default function OtrosGastosPage() {
                   <Button
                     onClick={handleDownloadPdf}
                     variant="outline"
-                    className="flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd] dark:bg-neutral-950 dark:hover:bg-neutral-900"
                   >
                     <FileText className="h-4 w-4" />
-                    <span className="hidden sm:inline">Descargar PDF</span>
+                    <span className="hidden sm:inline">{c("Descargar PDF")}</span>
                   </Button>
                   <Button
                     variant="outline"
                     onClick={handleExportExcel}
-                    className="flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 border-[#02a8e1] bg-white text-[#02a8e1] hover:bg-[#e6f7fd] dark:bg-neutral-950 dark:hover:bg-neutral-900"
                   >
                     <FileSpreadsheet className="h-4 w-4" />
-                    <span className="hidden sm:inline">Exportar</span>
+                    <span className="hidden sm:inline">{c("Exportar")}</span>
                   </Button>
                   <Button onClick={() => setOpenModal(true)} className="bg-[#02a8e1] hover:bg-[#0288b1]">
                     <Plus className="mr-2 h-4 w-4" />
-                    <span className="hidden sm:inline">Añadir Gasto</span>
-                    <span className="sm:hidden">Añadir</span>
+                    <span className="hidden sm:inline">{c("Añadir Gasto")}</span>
+                    <span className="sm:hidden">{c("Añadir")}</span>
                   </Button>
                 </div>
               </CardHeader>
               <CardContent className="space-y-4 p-4">
-                <div className="rounded-xl border bg-sky-50/60 p-4 text-sm text-sky-900">
+                <div className="rounded-xl border bg-sky-50/60 p-4 text-sm text-sky-900 dark:border-sky-900/60 dark:bg-sky-950/30 dark:text-sky-200">
                   <div className="flex items-start gap-2">
                     <ReceiptText className="mt-0.5 h-4 w-4" />
                     <p>
-                      Los comprobantes pueden guardarse como URL o subirse a Cloudinary en formato PDF o imagen.
-                      Los gastos anulados quedan fuera del total operativo.
+                      {c("Los comprobantes pueden guardarse como URL o subirse a Cloudinary en formato PDF o imagen. Los gastos anulados quedan fuera del total operativo.")}
                     </p>
                   </div>
                 </div>
@@ -391,15 +436,15 @@ export default function OtrosGastosPage() {
                       setOpenModal(true);
                     }}
                     onDelete={async (gasto) => {
-                      const confirmar = window.confirm("¿Está seguro de anular el gasto?");
+                      const confirmar = window.confirm(c("¿Está seguro de anular el gasto?"));
                       if (!confirmar) return;
 
                       try {
                         await deleteOtrosGastos(gasto.id);
-                        toast.success("Gasto anulado correctamente");
+                        toast.success(c("Gasto anulado correctamente"));
                         await loadGastos();
                       } catch (err: any) {
-                        toast.error(err?.message || "Error al anular gasto");
+                        toast.error(err?.message || c("Error al anular gasto"));
                       }
                     }}
                   />
@@ -409,7 +454,7 @@ export default function OtrosGastosPage() {
                   totalItems={filteredGastos.length}
                   pageSize={PAGE_SIZE}
                   onPageChange={setCurrentPage}
-                  itemLabel="gastos"
+                  itemLabel={c("gastos")}
                 />
               </CardContent>
             </Card>

--- a/src/app/dashboard/pagos/page.tsx
+++ b/src/app/dashboard/pagos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStore } from "@/stores/authStore";
 import { AppHeader } from "@/components/header/AppHeader";
@@ -9,10 +9,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, FileText, FileSpreadsheet } from "lucide-react";
-import {
-  deletePagoApi,
-  fetchPagosApi,
-} from "@/services/browser/pagoApiClient";
+import { deletePagoApi, fetchPagosApi } from "@/services/browser/pagoApiClient";
 import PagoModal from "@/components/modal/PagoModal";
 import PagoViewModal from "@/components/modal/PagoViewModal";
 import PagoTable from "@/components/tables/PagoTable";
@@ -21,10 +18,11 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import ExcelJS from "exceljs";
-import { buildTimestampedDownloadFileName } from '@/utils/downloadFileName';
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { descargarPagoReciboPdf } from "@/utils/pagoReciboPdf";
 import { PaginationControls } from "@/components/ui/PaginationControls";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
+import { useI18n } from "@/i18n/I18nProvider";
 
 const PAGOS_PAGE_SIZE = 10;
 
@@ -36,6 +34,12 @@ function numberOrZero(value: unknown) {
 export default function PagosPage() {
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = useCallback(
+    (es: string, en: string) => (isEnglish ? en : es),
+    [isEnglish],
+  );
   const [pagos, setPagos] = useState<ResponsePago[]>([]);
   const [filteredPagos, setFilteredPagos] = useState<ResponsePago[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -66,7 +70,9 @@ export default function PagosPage() {
       setPagos(data ?? []);
       setFilteredPagos(data ?? []);
     } catch (error: any) {
-      toast.error(error.message || "Error al cargar pagos");
+      toast.error(
+        error.message || tx("Error al cargar pagos", "Error loading payments"),
+      );
     } finally {
       setLoading(false);
     }
@@ -75,49 +81,126 @@ export default function PagosPage() {
   const handleDownloadPdf = async () => {
     try {
       await downloadCommercialReportPdf({
-        title: "Listado de Pagos",
-        subtitle: "Reporte de pagos manuales, Stripe, períodos y estados.",
+        title: tx("Listado de pagos", "Payments list"),
+        subtitle: tx(
+          "Reporte de pagos manuales, Stripe, períodos y estados.",
+          "Report of manual payments, Stripe payments, covered periods, and statuses.",
+        ),
         fileName: "listado-pagos-gym-master",
         rows: filteredPagos,
         metrics: [
-          { label: "Pagos filtrados", value: filteredPagos.length },
-          { label: "Total efectivo", value: `$${totalEfectivo.toLocaleString("es-AR")}` },
+          {
+            label: tx("Pagos filtrados", "Filtered payments"),
+            value: filteredPagos.length,
+          },
+          {
+            label: tx("Total efectivo", "Cash total"),
+            value: `$${totalEfectivo.toLocaleString("es-AR")}`,
+          },
         ],
-        filtersLabel: `Período: ${periodFilter}${fechaDesde ? ` · Desde: ${fechaDesde}` : ""}${fechaHasta ? ` · Hasta: ${fechaHasta}` : ""}${searchTerm.trim() ? ` · Búsqueda: ${searchTerm.trim()}` : ""}`,
+        filtersLabel: `${tx("Período", "Period")}: ${periodFilter}${fechaDesde ? ` · ${tx("Desde", "From")}: ${fechaDesde}` : ""}${fechaHasta ? ` · ${tx("Hasta", "To")}: ${fechaHasta}` : ""}${searchTerm.trim() ? ` · ${tx("Búsqueda", "Search")}: ${searchTerm.trim()}` : ""}`,
         columns: [
-          { header: "Socio", width: 42, getValue: (p) => p.socio?.nombre_completo || "-" },
-          { header: "Cuota", width: 36, getValue: (p) => p.cuota?.descripcion || "-" },
-          { header: "Fecha pago", width: 24, getValue: (p) => p.fecha_pago },
-          { header: "Período", width: 36, getValue: (p) => `${p.periodo_desde || p.fecha_pago} / ${p.periodo_hasta || p.fecha_vencimiento}` },
-          { header: "Método", width: 22, getValue: (p) => p.metodo_pago || "-" },
-          { header: "Estado", width: 22, getValue: (p) => p.estado || "-" },
-          { header: "Monto", width: 24, getValue: (p) => `$${numberOrZero(p.monto_pagado).toLocaleString("es-AR")}`, align: "right" },
-          { header: "Registrado por", width: 34, getValue: (p) => p.registrado_por?.nombre || "-" },
+          {
+            header: tx("Socio", "Member"),
+            width: 42,
+            getValue: (p) => p.socio?.nombre_completo || "-",
+          },
+          {
+            header: tx("Cuota", "Fee"),
+            width: 36,
+            getValue: (p) => p.cuota?.descripcion || "-",
+          },
+          {
+            header: tx("Fecha pago", "Payment date"),
+            width: 24,
+            getValue: (p) => p.fecha_pago,
+          },
+          {
+            header: tx("Período", "Period"),
+            width: 36,
+            getValue: (p) =>
+              `${p.periodo_desde || p.fecha_pago} / ${p.periodo_hasta || p.fecha_vencimiento}`,
+          },
+          {
+            header: tx("Método", "Method"),
+            width: 22,
+            getValue: (p) => p.metodo_pago || "-",
+          },
+          {
+            header: tx("Estado", "Status"),
+            width: 22,
+            getValue: (p) => p.estado || "-",
+          },
+          {
+            header: tx("Monto", "Amount"),
+            width: 24,
+            getValue: (p) =>
+              `$${numberOrZero(p.monto_pagado).toLocaleString("es-AR")}`,
+            align: "right",
+          },
+          {
+            header: tx("Registrado por", "Registered by"),
+            width: 34,
+            getValue: (p) => p.registrado_por?.nombre || "-",
+          },
         ],
       });
     } catch {
-      toast.error("No se pudo generar el PDF de pagos");
+      toast.error(
+        tx(
+          "No se pudo generar el PDF de pagos",
+          "Could not generate the payments PDF",
+        ),
+      );
     }
   };
 
   const handleExportExcel = async () => {
     const workbook = new ExcelJS.Workbook();
-    const worksheet = workbook.addWorksheet("Pagos");
+    const worksheet = workbook.addWorksheet(tx("Pagos", "Payments"));
 
     worksheet.columns = [
-      { header: "Socio", key: "socio", width: 28 },
-      { header: "Cuota", key: "cuota", width: 24 },
-      { header: "Fecha Pago", key: "fecha_pago", width: 16 },
-      { header: "Periodo Desde", key: "periodo_desde", width: 16 },
-      { header: "Periodo Hasta", key: "periodo_hasta", width: 16 },
-      { header: "Meses", key: "meses", width: 10 },
-      { header: "Método", key: "metodo", width: 14 },
-      { header: "Estado", key: "estado", width: 14 },
-      { header: "Subtotal", key: "subtotal", width: 15 },
-      { header: "Descuento %", key: "descuento_porcentaje", width: 14 },
-      { header: "Descuento Monto", key: "descuento_monto", width: 18 },
-      { header: "Monto Pagado", key: "monto_pagado", width: 15 },
-      { header: "Registrado Por", key: "registrado_por", width: 20 },
+      { header: tx("Socio", "Member"), key: "socio", width: 28 },
+      { header: tx("Cuota", "Fee"), key: "cuota", width: 24 },
+      {
+        header: tx("Fecha Pago", "Payment Date"),
+        key: "fecha_pago",
+        width: 16,
+      },
+      {
+        header: tx("Periodo Desde", "Period From"),
+        key: "periodo_desde",
+        width: 16,
+      },
+      {
+        header: tx("Periodo Hasta", "Period To"),
+        key: "periodo_hasta",
+        width: 16,
+      },
+      { header: tx("Meses", "Months"), key: "meses", width: 10 },
+      { header: tx("Método", "Method"), key: "metodo", width: 14 },
+      { header: tx("Estado", "Status"), key: "estado", width: 14 },
+      { header: tx("Subtotal", "Subtotal"), key: "subtotal", width: 15 },
+      {
+        header: tx("Descuento %", "Discount %"),
+        key: "descuento_porcentaje",
+        width: 14,
+      },
+      {
+        header: tx("Descuento Monto", "Discount Amount"),
+        key: "descuento_monto",
+        width: 18,
+      },
+      {
+        header: tx("Monto Pagado", "Amount Paid"),
+        key: "monto_pagado",
+        width: 15,
+      },
+      {
+        header: tx("Registrado Por", "Registered By"),
+        key: "registrado_por",
+        width: 20,
+      },
     ];
 
     filteredPagos.forEach((p) => {
@@ -150,16 +233,25 @@ export default function PagosPage() {
     window.URL.revokeObjectURL(url);
   };
 
-
   const handleDownloadReceipt = async (pago: ResponsePago) => {
     try {
       await descargarPagoReciboPdf(pago);
-      toast.success("Recibo PDF generado correctamente");
+      toast.success(
+        tx(
+          "Recibo PDF generado correctamente",
+          "PDF receipt generated successfully",
+        ),
+      );
     } catch (error: any) {
-      toast.error(error?.message || "Error al generar el recibo PDF");
+      toast.error(
+        error?.message ||
+          tx(
+            "Error al generar el recibo PDF",
+            "Error generating the PDF receipt",
+          ),
+      );
     }
   };
-
 
   useEffect(() => {
     if (isInitialized && isAuthenticated) {
@@ -174,16 +266,24 @@ export default function PagosPage() {
     const startOfWeekDate = new Date(today);
     startOfWeekDate.setDate(today.getDate() - 6);
     const startOfWeek = startOfWeekDate.toISOString().slice(0, 10);
-    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1).toISOString().slice(0, 10);
-    const startOfYear = new Date(today.getFullYear(), 0, 1).toISOString().slice(0, 10);
+    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1)
+      .toISOString()
+      .slice(0, 10);
+    const startOfYear = new Date(today.getFullYear(), 0, 1)
+      .toISOString()
+      .slice(0, 10);
 
     const filtered = pagos.filter((p) => {
       const fecha = p.fecha_pago || "";
       const matchesSearch =
         lowercaseSearch === "" ||
-        (p.socio?.nombre_completo || "").toLowerCase().includes(lowercaseSearch) ||
+        (p.socio?.nombre_completo || "")
+          .toLowerCase()
+          .includes(lowercaseSearch) ||
         (p.cuota?.descripcion || "").toLowerCase().includes(lowercaseSearch) ||
-        (p.registrado_por?.nombre || "").toLowerCase().includes(lowercaseSearch) ||
+        (p.registrado_por?.nombre || "")
+          .toLowerCase()
+          .includes(lowercaseSearch) ||
         (p.metodo_pago || "").toLowerCase().includes(lowercaseSearch) ||
         (p.estado || "").toLowerCase().includes(lowercaseSearch);
 
@@ -210,7 +310,7 @@ export default function PagosPage() {
   const safeCurrentPage = Math.min(currentPage, totalPages);
   const paginatedPagos = filteredPagos.slice(
     (safeCurrentPage - 1) * PAGOS_PAGE_SIZE,
-    safeCurrentPage * PAGOS_PAGE_SIZE
+    safeCurrentPage * PAGOS_PAGE_SIZE,
   );
 
   useEffect(() => {
@@ -224,7 +324,7 @@ export default function PagosPage() {
     .reduce((acc, pago) => acc + numberOrZero(pago.monto_pagado), 0);
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{tx("Cargando...", "Loading...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -236,14 +336,17 @@ export default function PagosPage() {
       <div className="flex w-full min-h-screen">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Pagos" />
-          <main className="flex-1 p-6 space-y-6">
-            <Card className="w-full">
+          <AppHeader title={tx("Pagos", "Payments")} />
+          <main className="flex-1 p-6 space-y-6 dark:bg-black">
+            <Card className="w-full dark:border-neutral-800 dark:bg-neutral-950/80">
               <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
                 <div>
-                  <h2 className="text-xl font-bold">Listado de Pagos</h2>
+                  <h2 className="text-xl font-bold">
+                    {tx("Listado de pagos", "Payments list")}
+                  </h2>
                   <p className="text-sm text-muted-foreground">
-                    Total efectivo filtrado: ${totalEfectivo.toLocaleString("es-AR")}
+                    {tx("Total efectivo filtrado", "Filtered cash total")}: $
+                    {totalEfectivo.toLocaleString("es-AR")}
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center w-full gap-2 md:w-auto">
@@ -251,7 +354,10 @@ export default function PagosPage() {
                     <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
                       type="search"
-                      placeholder="Buscar por socio, cuota, método..."
+                      placeholder={tx(
+                        "Buscar por socio, cuota, método...",
+                        "Search by member, fee, method...",
+                      )}
                       className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
@@ -262,48 +368,62 @@ export default function PagosPage() {
                     onChange={(e) => setPeriodFilter(e.target.value)}
                     className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
                   >
-                    <option value="todos">Todos los períodos</option>
-                    <option value="dia">Hoy</option>
-                    <option value="semana">Últimos 7 días</option>
-                    <option value="mes">Mes actual</option>
-                    <option value="anio">Año actual</option>
+                    <option value="todos">
+                      {tx("Todos los períodos", "All periods")}
+                    </option>
+                    <option value="dia">{tx("Hoy", "Today")}</option>
+                    <option value="semana">
+                      {tx("Últimos 7 días", "Last 7 days")}
+                    </option>
+                    <option value="mes">
+                      {tx("Mes actual", "Current month")}
+                    </option>
+                    <option value="anio">
+                      {tx("Año actual", "Current year")}
+                    </option>
                   </select>
                   <Input
                     type="date"
                     value={fechaDesde}
                     onChange={(e) => setFechaDesde(e.target.value)}
                     className="w-[150px]"
-                    title="Fecha desde"
+                    title={tx("Fecha desde", "Date from")}
                   />
                   <Input
                     type="date"
                     value={fechaHasta}
                     onChange={(e) => setFechaHasta(e.target.value)}
                     className="w-[150px]"
-                    title="Fecha hasta"
+                    title={tx("Fecha hasta", "Date to")}
                   />
                   <Button
                     onClick={handleDownloadPdf}
                     variant="outline"
-                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd] dark:bg-neutral-950 dark:text-cyan-300 dark:border-cyan-800 dark:hover:bg-neutral-900"
                   >
                     <FileText className="w-4 h-4" />
-                    <span className="hidden sm:inline">Descargar PDF</span>
+                    <span className="hidden sm:inline">
+                      {tx("Descargar PDF", "Download PDF")}
+                    </span>
                   </Button>
                   <Button
                     variant="outline"
                     onClick={handleExportExcel}
-                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                    className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd] dark:bg-neutral-950 dark:text-cyan-300 dark:border-cyan-800 dark:hover:bg-neutral-900"
                   >
                     <FileSpreadsheet className="w-4 h-4" />
-                    <span className="hidden sm:inline">Exportar</span>
+                    <span className="hidden sm:inline">
+                      {tx("Exportar", "Export")}
+                    </span>
                   </Button>
                   <Button
                     onClick={() => setOpenModal(true)}
                     className="bg-[#02a8e1] hover:bg-[#0288b1]"
                   >
-                    <span className="hidden sm:inline">Registrar Pago Manual</span>
-                    <span className="sm:hidden">Añadir</span>
+                    <span className="hidden sm:inline">
+                      {tx("Registrar pago manual", "Register manual payment")}
+                    </span>
+                    <span className="sm:hidden">{tx("Añadir", "Add")}</span>
                   </Button>
                 </div>
               </CardHeader>
@@ -323,16 +443,30 @@ export default function PagosPage() {
                     onReceipt={handleDownloadReceipt}
                     onDelete={async (pago) => {
                       const confirmar = window.confirm(
-                        "¿Está seguro de eliminar el pago?"
+                        tx(
+                          "¿Está seguro de eliminar el pago?",
+                          "Are you sure you want to delete this payment?",
+                        ),
                       );
                       if (!confirmar) return;
 
                       try {
                         await deletePagoApi(pago.id);
-                        toast.success("Pago eliminado correctamente");
+                        toast.success(
+                          tx(
+                            "Pago eliminado correctamente",
+                            "Payment deleted successfully",
+                          ),
+                        );
                         await loadPagos();
                       } catch (err: any) {
-                        toast.error(err.message || "Error al eliminar pago");
+                        toast.error(
+                          err.message ||
+                            tx(
+                              "Error al eliminar pago",
+                              "Error deleting payment",
+                            ),
+                        );
                       }
                     }}
                   />
@@ -342,7 +476,7 @@ export default function PagosPage() {
                   totalItems={totalPagos}
                   pageSize={PAGOS_PAGE_SIZE}
                   onPageChange={setCurrentPage}
-                  itemLabel="pagos"
+                  itemLabel={tx("pagos", "payments")}
                 />
               </CardContent>
             </Card>

--- a/src/app/dashboard/rag-corpus/page.tsx
+++ b/src/app/dashboard/rag-corpus/page.tsx
@@ -1,7 +1,21 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { Activity, Database, Loader2, Play, RefreshCw, ShieldAlert } from 'lucide-react';
+import {
+  Activity,
+  CheckCircle2,
+  Clock,
+  Database,
+  Dumbbell,
+  FileText,
+  Globe2,
+  Layers,
+  Loader2,
+  Play,
+  RefreshCw,
+  ShieldAlert,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 import { AppFooter } from '@/components/footer/AppFooter';
 import { AppHeader } from '@/components/header/AppHeader';
@@ -9,32 +23,107 @@ import { AppSidebar } from '@/components/sidebar/AppSidebar';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import type { RagCorpusBatchAction, RagCorpusBatchResponse, RagCorpusStatusResponse } from '@/interfaces/ragCorpus.interface';
 import { getRagCorpusStatusClient, runRagCorpusBatchClient } from '@/services/ragCorpusAdminClient';
 
-const actionLabels: Record<RagCorpusBatchAction, string> = {
-  ingest_exercises: 'Ingestar ejercicios',
-  ingest_diet_rules: 'Ingestar dietas',
-  vectorize_pending: 'Vectorizar pendientes',
-  all: 'Tanda completa',
+function ragTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+const ACTION_LABELS: Record<RagCorpusBatchAction, { es: string; en: string }> = {
+  ingest_exercises: { es: 'Ingestar ejercicios', en: 'Ingest exercises' },
+  ingest_diet_rules: { es: 'Ingestar dietas', en: 'Ingest diets' },
+  vectorize_pending: { es: 'Vectorizar pendientes', en: 'Vectorize pending' },
+  all: { es: 'Tanda completa', en: 'Full batch' },
 };
+
+const DOMAIN_LABELS: Record<string, { es: string; en: string }> = {
+  exercise: { es: 'Ejercicios', en: 'Exercises' },
+  diet_rule: { es: 'Reglas de dieta', en: 'Diet rules' },
+  routine_rule: { es: 'Reglas de rutina', en: 'Routine rules' },
+  safety: { es: 'Seguridad', en: 'Safety' },
+  evolution: { es: 'Evolución', en: 'Evolution' },
+  business: { es: 'Negocio', en: 'Business' },
+  general: { es: 'General', en: 'General' },
+};
+
+function translateActionLabel(locale: GymMasterLocale, action: RagCorpusBatchAction) {
+  const label = ACTION_LABELS[action];
+  return locale === 'en' ? label.en : label.es;
+}
+
+function translateDomain(locale: GymMasterLocale, domain: string) {
+  const label = DOMAIN_LABELS[domain];
+  if (!label) return domain;
+  return locale === 'en' ? label.en : label.es;
+}
+
+function normalizeCorpusText(value?: string | null) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+function translateRecommendation(locale: GymMasterLocale, value: string) {
+  if (locale !== 'en') return value;
+
+  const normalized = normalizeCorpusText(value);
+  if (normalized.includes('corpus base') && normalized.includes('ejercicios') && normalized.includes('dietas')) {
+    return 'The base exercise and diet corpus does not show major pending items. Keep monitoring by domain.';
+  }
+
+  return value;
+}
+
+function formatCoverageText(locale: GymMasterLocale, indexed: number, total: number, esNoun: string, enNoun: string) {
+  if (locale === 'en') {
+    return `${indexed} of ${total} active ${enNoun} indexed.`;
+  }
+
+  return `${indexed} de ${total} ${esNoun} activos indexados.`;
+}
 
 function progressPercent(indexed: number, total: number) {
   if (!total) return 0;
   return Math.round((indexed / total) * 100);
 }
 
-function StatusCard({ title, value, hint }: { title: string; value: number | string; hint?: string }) {
+function StatusCard({
+  title,
+  value,
+  hint,
+  icon: Icon,
+}: {
+  title: string;
+  value: number | string;
+  hint?: string;
+  icon: LucideIcon;
+}) {
   return (
-    <Card className="p-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{title}</p>
-      <p className="mt-2 text-3xl font-bold text-slate-950">{value}</p>
-      {hint ? <p className="mt-1 text-xs text-muted-foreground">{hint}</p> : null}
+    <Card className="border-slate-200 bg-white p-4 shadow-sm dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground dark:text-zinc-400">{title}</p>
+          <p className="mt-2 text-3xl font-bold text-slate-950 dark:text-zinc-50">{value}</p>
+          {hint ? <p className="mt-1 text-xs text-muted-foreground dark:text-zinc-400">{hint}</p> : null}
+        </div>
+        <span className="rounded-full bg-cyan-50 p-2 text-cyan-600 dark:bg-cyan-950/40 dark:text-cyan-300">
+          <Icon className="h-4 w-4" />
+        </span>
+      </div>
     </Card>
   );
 }
 
 export default function RagCorpusPage() {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => ragTx(locale, es, en);
+
   const [status, setStatus] = useState<RagCorpusStatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [runningAction, setRunningAction] = useState<RagCorpusBatchAction | null>(null);
@@ -42,6 +131,9 @@ export default function RagCorpusPage() {
   const [error, setError] = useState<string | null>(null);
   const [limit, setLimit] = useState(10);
   const [delayMs, setDelayMs] = useState(1000);
+
+  const inputClassName =
+    'w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-slate-950 outline-none transition focus:border-cyan-500 focus:ring-2 focus:ring-cyan-500/20 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50 dark:placeholder:text-zinc-500';
 
   const exercisesPercent = useMemo(
     () => progressPercent(status?.sources.indexedExercises ?? 0, status?.sources.activeExercises ?? 0),
@@ -60,7 +152,7 @@ export default function RagCorpusPage() {
       const data = await getRagCorpusStatusClient();
       setStatus(data);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'No se pudo consultar estado del corpus.');
+      setError(err instanceof Error ? err.message : c('No se pudo consultar estado del corpus.', 'Could not fetch corpus status.'));
     } finally {
       setLoading(false);
     }
@@ -68,6 +160,7 @@ export default function RagCorpusPage() {
 
   useEffect(() => {
     loadStatus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const runAction = async (action: RagCorpusBatchAction) => {
@@ -85,7 +178,7 @@ export default function RagCorpusPage() {
       if (result.status) setStatus(result.status);
       else await loadStatus();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'No se pudo ejecutar la tanda RAG.');
+      setError(err instanceof Error ? err.message : c('No se pudo ejecutar la tanda RAG.', 'Could not run the RAG batch.'));
     } finally {
       setRunningAction(null);
     }
@@ -96,29 +189,40 @@ export default function RagCorpusPage() {
       <div className="flex min-h-screen w-full">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="RAG Corpus" />
-          <main className="flex-1 space-y-6 p-6">
-            <Card className="border-cyan-100 bg-white p-6 shadow-sm">
+          <AppHeader title={c('Corpus RAG', 'RAG Corpus')} />
+          <main className="flex-1 space-y-6 bg-slate-50/40 p-6 text-slate-950 dark:bg-black dark:text-zinc-100">
+            <Card className="border-cyan-100 bg-white p-6 shadow-sm dark:border-cyan-900/50 dark:bg-zinc-950/80 dark:text-zinc-100">
               <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
                 <div>
                   <div className="flex items-center gap-2">
-                    <Database className="h-6 w-6 text-cyan-600" />
-                    <h1 className="text-2xl font-bold text-slate-950">Estado del corpus RAG</h1>
+                    <Database className="h-6 w-6 text-cyan-600 dark:text-cyan-300" />
+                    <h1 className="text-2xl font-bold text-slate-950 dark:text-zinc-50">
+                      {c('Estado del corpus RAG', 'RAG corpus status')}
+                    </h1>
                   </div>
-                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-                    Panel administrativo para continuar la ingesta real del corpus del Coach IA por tandas controladas, con delay, pendientes y manejo seguro de límites 429.
+                  <p className="mt-2 max-w-3xl text-sm text-muted-foreground dark:text-zinc-400">
+                    {c(
+                      'Panel administrativo para continuar la ingesta real del corpus del Coach IA por tandas controladas, con delay, pendientes y manejo seguro de límites 429.',
+                      'Administrative panel to continue the real AI Coach corpus ingestion through controlled batches, with delay, pending items, and safe handling of 429 limits.',
+                    )}
                   </p>
                 </div>
 
-                <Button type="button" variant="outline" onClick={loadStatus} disabled={loading || Boolean(runningAction)}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={loadStatus}
+                  disabled={loading || Boolean(runningAction)}
+                  className="dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800"
+                >
                   {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
-                  Actualizar
+                  {c('Actualizar', 'Refresh')}
                 </Button>
               </div>
             </Card>
 
             {error ? (
-              <Card className="border-red-200 bg-red-50 p-4 text-sm text-red-800">
+              <Card className="border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200">
                 <div className="flex items-center gap-2 font-semibold">
                   <ShieldAlert className="h-4 w-4" />
                   {error}
@@ -129,57 +233,75 @@ export default function RagCorpusPage() {
             {status ? (
               <>
                 <div className="grid gap-4 md:grid-cols-5">
-                  <StatusCard title="Documentos" value={status.totals.documents} />
-                  <StatusCard title="Chunks" value={status.totals.chunks} />
-                  <StatusCard title="Vectorizados" value={status.totals.embeddedChunks} />
-                  <StatusCard title="Pendientes" value={status.totals.pendingChunks} />
-                  <StatusCard title="Dominios" value={status.domains.filter((domain) => domain.documents > 0).length} />
+                  <StatusCard title={c('Documentos', 'Documents')} value={status.totals.documents} icon={FileText} />
+                  <StatusCard title="Chunks" value={status.totals.chunks} icon={Layers} />
+                  <StatusCard title={c('Vectorizados', 'Vectorized')} value={status.totals.embeddedChunks} icon={CheckCircle2} />
+                  <StatusCard title={c('Pendientes', 'Pending')} value={status.totals.pendingChunks} icon={Clock} />
+                  <StatusCard
+                    title={c('Dominios', 'Domains')}
+                    value={status.domains.filter((domain) => domain.documents > 0).length}
+                    icon={Globe2}
+                  />
                 </div>
 
                 <div className="grid gap-4 md:grid-cols-2">
-                  <Card className="p-5">
-                    <h2 className="font-semibold text-slate-950">Cobertura ejercicios</h2>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      {status.sources.indexedExercises} de {status.sources.activeExercises} ejercicios activos indexados.
+                  <Card className="border-slate-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                    <h2 className="flex items-center gap-2 font-semibold text-slate-950 dark:text-zinc-50">
+                      <Dumbbell className="h-5 w-5 text-cyan-600 dark:text-cyan-300" />
+                      {c('Cobertura ejercicios', 'Exercise coverage')}
+                    </h2>
+                    <p className="mt-2 text-sm text-muted-foreground dark:text-zinc-400">
+                      {formatCoverageText(
+                        locale,
+                        status.sources.indexedExercises,
+                        status.sources.activeExercises,
+                        'ejercicios',
+                        'exercises',
+                      )}
                     </p>
-                    <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-100">
-                      <div className="h-full bg-cyan-600" style={{ width: `${exercisesPercent}%` }} />
+                    <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-zinc-900">
+                      <div className="h-full bg-cyan-600 dark:bg-cyan-400" style={{ width: `${exercisesPercent}%` }} />
                     </div>
-                    <p className="mt-1 text-xs text-muted-foreground">{exercisesPercent}%</p>
+                    <p className="mt-1 text-xs text-muted-foreground dark:text-zinc-400">{exercisesPercent}%</p>
                   </Card>
 
-                  <Card className="p-5">
-                    <h2 className="font-semibold text-slate-950">Cobertura dietas</h2>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      {status.sources.indexedDietRules} de {status.sources.dietRules} reglas nutricionales indexadas.
+                  <Card className="border-slate-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                    <h2 className="flex items-center gap-2 font-semibold text-slate-950 dark:text-zinc-50">
+                      <Activity className="h-5 w-5 text-lime-600 dark:text-lime-300" />
+                      {c('Cobertura dietas', 'Diet coverage')}
+                    </h2>
+                    <p className="mt-2 text-sm text-muted-foreground dark:text-zinc-400">
+                      {locale === 'en'
+                        ? `${status.sources.indexedDietRules} of ${status.sources.dietRules} nutrition rules indexed.`
+                        : `${status.sources.indexedDietRules} de ${status.sources.dietRules} reglas nutricionales indexadas.`}
                     </p>
-                    <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-100">
-                      <div className="h-full bg-lime-600" style={{ width: `${dietPercent}%` }} />
+                    <div className="mt-3 h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-zinc-900">
+                      <div className="h-full bg-lime-600 dark:bg-lime-400" style={{ width: `${dietPercent}%` }} />
                     </div>
-                    <p className="mt-1 text-xs text-muted-foreground">{dietPercent}%</p>
+                    <p className="mt-1 text-xs text-muted-foreground dark:text-zinc-400">{dietPercent}%</p>
                   </Card>
                 </div>
 
-                <Card className="p-5">
-                  <h2 className="mb-3 flex items-center gap-2 font-semibold text-slate-950">
-                    <Activity className="h-5 w-5 text-cyan-600" />
-                    Ejecutar tandas controladas
+                <Card className="border-slate-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                  <h2 className="mb-3 flex items-center gap-2 font-semibold text-slate-950 dark:text-zinc-50">
+                    <Activity className="h-5 w-5 text-cyan-600 dark:text-cyan-300" />
+                    {c('Ejecutar tandas controladas', 'Run controlled batches')}
                   </h2>
 
                   <div className="grid gap-3 md:grid-cols-4">
                     <label className="text-sm">
-                      <span className="mb-1 block font-medium">Límite</span>
+                      <span className="mb-1 block font-medium text-slate-950 dark:text-zinc-100">{c('Límite', 'Limit')}</span>
                       <input
                         type="number"
                         min={1}
                         max={100}
                         value={limit}
                         onChange={(event) => setLimit(Number(event.target.value))}
-                        className="w-full rounded-md border px-3 py-2"
+                        className={inputClassName}
                       />
                     </label>
                     <label className="text-sm">
-                      <span className="mb-1 block font-medium">Delay ms</span>
+                      <span className="mb-1 block font-medium text-slate-950 dark:text-zinc-100">{c('Delay ms', 'Delay (ms)')}</span>
                       <input
                         type="number"
                         min={0}
@@ -187,42 +309,47 @@ export default function RagCorpusPage() {
                         step={250}
                         value={delayMs}
                         onChange={(event) => setDelayMs(Number(event.target.value))}
-                        className="w-full rounded-md border px-3 py-2"
+                        className={inputClassName}
                       />
                     </label>
                   </div>
 
                   <div className="mt-4 flex flex-wrap gap-2">
-                    {(Object.keys(actionLabels) as RagCorpusBatchAction[]).map((action) => (
+                    {(Object.keys(ACTION_LABELS) as RagCorpusBatchAction[]).map((action) => (
                       <Button key={action} type="button" onClick={() => runAction(action)} disabled={Boolean(runningAction)}>
                         {runningAction === action ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Play className="mr-2 h-4 w-4" />}
-                        {actionLabels[action]}
+                        {translateActionLabel(locale, action)}
                       </Button>
                     ))}
                   </div>
 
-                  <p className="mt-3 text-xs text-muted-foreground">
-                    Recomendado: usar tandas controladas según el provider activo. Con OpenAI podés aumentar el límite progresivamente; si aparecen errores parciales, continuar luego con “Vectorizar pendientes”.
+                  <p className="mt-3 text-xs text-muted-foreground dark:text-zinc-400">
+                    {c(
+                      'Recomendado: usar tandas controladas según el proveedor activo. Con OpenAI podés aumentar el límite progresivamente; si aparecen errores parciales, continuar luego con “Vectorizar pendientes”.',
+                      'Recommended: use controlled batches according to the active provider. With OpenAI, you can progressively increase the limit; if partial errors appear, continue later with “Vectorize pending”.',
+                    )}
                   </p>
                 </Card>
 
-                <Card className="p-5">
-                  <h2 className="mb-3 font-semibold text-slate-950">Dominios del corpus</h2>
+                <Card className="border-slate-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                  <h2 className="mb-3 font-semibold text-slate-950 dark:text-zinc-50">{c('Dominios del corpus', 'Corpus domains')}</h2>
                   <div className="overflow-x-auto">
                     <table className="w-full min-w-[720px] text-left text-sm">
-                      <thead className="bg-slate-50 text-xs uppercase text-muted-foreground">
+                      <thead className="bg-slate-50 text-xs uppercase text-muted-foreground dark:bg-zinc-900/80 dark:text-zinc-400">
                         <tr>
-                          <th className="px-3 py-2">Dominio</th>
-                          <th className="px-3 py-2">Documentos</th>
+                          <th className="px-3 py-2">{c('Dominio', 'Domain')}</th>
+                          <th className="px-3 py-2">{c('Documentos', 'Documents')}</th>
                           <th className="px-3 py-2">Chunks</th>
-                          <th className="px-3 py-2">Vectorizados</th>
-                          <th className="px-3 py-2">Pendientes</th>
+                          <th className="px-3 py-2">{c('Vectorizados', 'Vectorized')}</th>
+                          <th className="px-3 py-2">{c('Pendientes', 'Pending')}</th>
                         </tr>
                       </thead>
                       <tbody>
                         {status.domains.map((domain) => (
-                          <tr key={domain.domain} className="border-b">
-                            <td className="px-3 py-2 font-medium">{domain.domain}</td>
+                          <tr key={domain.domain} className="border-b border-slate-200 dark:border-zinc-800">
+                            <td className="px-3 py-2 font-medium text-slate-950 dark:text-zinc-100">
+                              {translateDomain(locale, domain.domain)}
+                            </td>
                             <td className="px-3 py-2">{domain.documents}</td>
                             <td className="px-3 py-2">{domain.chunks}</td>
                             <td className="px-3 py-2">{domain.embeddedChunks}</td>
@@ -235,24 +362,26 @@ export default function RagCorpusPage() {
                 </Card>
 
                 {status.recommendations.length > 0 ? (
-                  <Card className="p-5">
-                    <h2 className="mb-2 font-semibold text-slate-950">Recomendaciones</h2>
-                    <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                  <Card className="border-slate-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                    <h2 className="mb-2 font-semibold text-slate-950 dark:text-zinc-50">{c('Recomendaciones', 'Recommendations')}</h2>
+                    <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground dark:text-zinc-400">
                       {status.recommendations.map((item) => (
-                        <li key={item}>{item}</li>
+                        <li key={item}>{translateRecommendation(locale, item)}</li>
                       ))}
                     </ul>
                   </Card>
                 ) : null}
               </>
             ) : loading ? (
-              <Card className="p-6 text-sm text-muted-foreground">Cargando estado del corpus...</Card>
+              <Card className="border-slate-200 bg-white p-6 text-sm text-muted-foreground dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-400">
+                {c('Cargando estado del corpus...', 'Loading corpus status...')}
+              </Card>
             ) : null}
 
             {lastRun ? (
-              <Card className="p-5">
-                <h2 className="mb-2 font-semibold text-slate-950">Última ejecución</h2>
-                <pre className="max-h-80 overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-50">
+              <Card className="border-slate-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                <h2 className="mb-2 font-semibold text-slate-950 dark:text-zinc-50">{c('Última ejecución', 'Last run')}</h2>
+                <pre className="max-h-80 overflow-auto rounded-xl bg-slate-950 p-4 text-xs text-slate-50 dark:bg-black">
                   {JSON.stringify(lastRun, null, 2)}
                 </pre>
               </Card>

--- a/src/app/dashboard/socios-ranking-bonificacion/page.tsx
+++ b/src/app/dashboard/socios-ranking-bonificacion/page.tsx
@@ -19,9 +19,19 @@ import {
   XCircle,
 } from "lucide-react";
 import { toast } from "sonner";
-import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 import { AppFooter } from "@/components/footer/AppFooter";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 import { AppHeader } from "@/components/header/AppHeader";
 import { QaFileNameBadge } from "@/components/qa/QaFileNameBadge";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
@@ -39,7 +49,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import type { SocioRankingBonificacionItem, SociosRankingBonificacionResponse } from "@/interfaces/sociosRankingBonificacion.interface";
+import type {
+  SocioRankingBonificacionItem,
+  SociosRankingBonificacionResponse,
+} from "@/interfaces/sociosRankingBonificacion.interface";
 import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
 import { useAuthStore } from "@/stores/authStore";
@@ -56,46 +69,175 @@ function currentYearMonth() {
 }
 
 function formatNumber(value?: number | null) {
-  return new Intl.NumberFormat("es-AR", { maximumFractionDigits: 0 }).format(Number(value ?? 0));
+  return new Intl.NumberFormat("es-AR", { maximumFractionDigits: 0 }).format(
+    Number(value ?? 0),
+  );
 }
 
 function formatPercent(value?: number | null) {
   return `${Number(value ?? 0).toFixed(0)}%`;
 }
 
-function monthName(anio: number, mes: number) {
-  return new Intl.DateTimeFormat("es-AR", { month: "long", year: "numeric" }).format(new Date(anio, mes - 1, 1));
+function rbTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
 }
 
-function Badge({ children, tone = "slate" }: { children: ReactNode; tone?: "slate" | "green" | "red" | "blue" | "amber" | "violet" }) {
+function monthName(anio: number, mes: number, locale: GymMasterLocale = "es") {
+  return new Intl.DateTimeFormat(locale === "en" ? "en-US" : "es-AR", {
+    month: "long",
+    year: "numeric",
+  }).format(new Date(anio, mes - 1, 1));
+}
+
+function yesNo(locale: GymMasterLocale, value: boolean) {
+  return value ? rbTx(locale, "Sí", "Yes") : rbTx(locale, "No", "No");
+}
+
+function normalizeRankingText(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function translateRankingRule(locale: GymMasterLocale, value: string) {
+  if (locale !== "en") return value;
+
+  const normalized = normalizeRankingText(value);
+  const rules: Record<string, string> = {
+    "mayor cantidad de dias asistidos en el mes.":
+      "Highest number of attended days in the month.",
+    "primer desempate: cuota al dia al cierre del periodo.":
+      "First tiebreaker: fee up to date at period close.",
+    "segundo desempate: score operativo.":
+      "Second tiebreaker: operational score.",
+    "ultimo desempate: orden alfabetico.":
+      "Final tiebreaker: alphabetical order.",
+  };
+
+  return rules[normalized] ?? value;
+}
+
+function translateRankingWarning(locale: GymMasterLocale, value: string) {
+  if (locale !== "en") return value;
+
+  const normalized = normalizeRankingText(value);
+  if (
+    normalized.includes("tabla socio_ranking_bonificacion_mensual") &&
+    normalized.includes("todavia no esta disponible")
+  ) {
+    return "The monthly bonus ranking table is not available yet. Apply the migration to save bonuses.";
+  }
+  if (normalized.includes("no se pudo leer bonificaciones guardadas")) {
+    return value.replace(
+      /^No se pudo leer bonificaciones guardadas:/i,
+      "Could not read saved bonuses:",
+    );
+  }
+  return value;
+}
+
+function translateBonusReason(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const normalized = normalizeRankingText(raw);
+  if (normalized === "bonificacion mensual por ranking")
+    return "Monthly ranking bonus";
+  if (normalized === "bonificacion removida") return "Bonus removed";
+  if (normalized.includes("socio bonificado desde ranking")) {
+    return raw.replace(
+      /^Socio bonificado desde ranking/i,
+      "Member bonused from ranking",
+    );
+  }
+  return raw;
+}
+
+function translateBlockReason(locale: GymMasterLocale, value?: string | null) {
+  const raw = String(value ?? "").trim();
+  if (!raw || locale !== "en") return raw;
+
+  const normalized = normalizeRankingText(raw);
+  if (
+    normalized.includes("ya existe un pago registrado") &&
+    normalized.includes("snapshot comercial")
+  ) {
+    return "A payment already exists for this member and month. The bonus is locked to preserve the commercial snapshot of the payment.";
+  }
+  if (normalized.includes("bonificacion bloqueada por pago registrado")) {
+    return "Bonus locked by registered payment";
+  }
+  return raw;
+}
+
+function Badge({
+  children,
+  tone = "slate",
+}: {
+  children: ReactNode;
+  tone?: "slate" | "green" | "red" | "blue" | "amber" | "violet";
+}) {
   const classes = {
-    slate: "bg-slate-100 text-slate-700",
-    green: "bg-emerald-100 text-emerald-700",
-    red: "bg-red-100 text-red-700",
-    blue: "bg-sky-100 text-sky-700",
-    amber: "bg-amber-100 text-amber-700",
-    violet: "bg-violet-100 text-violet-700",
-  }[tone];
-
-  return <span className={`rounded-full px-2 py-1 text-xs font-semibold ${classes}`}>{children}</span>;
-}
-
-function MetricCard({ title, value, helper, icon: Icon, tone = "blue" }: { title: string; value: string; helper: string; icon: ElementType; tone?: "blue" | "green" | "amber" | "violet" | "slate" }) {
-  const toneClass = {
-    blue: "bg-sky-50 text-sky-700",
-    green: "bg-emerald-50 text-emerald-700",
-    amber: "bg-amber-50 text-amber-700",
-    violet: "bg-violet-50 text-violet-700",
-    slate: "bg-slate-100 text-slate-700",
+    slate: "bg-slate-100 text-slate-700 dark:bg-zinc-800 dark:text-zinc-200",
+    green:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-200",
+    red: "bg-red-100 text-red-700 dark:bg-red-950/70 dark:text-red-200",
+    blue: "bg-sky-100 text-sky-700 dark:bg-sky-950/70 dark:text-sky-200",
+    amber:
+      "bg-amber-100 text-amber-700 dark:bg-amber-950/70 dark:text-amber-200",
+    violet:
+      "bg-violet-100 text-violet-700 dark:bg-violet-950/70 dark:text-violet-200",
   }[tone];
 
   return (
-    <Card>
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${classes}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function MetricCard({
+  title,
+  value,
+  helper,
+  icon: Icon,
+  tone = "blue",
+}: {
+  title: string;
+  value: string;
+  helper: string;
+  icon: ElementType;
+  tone?: "blue" | "green" | "amber" | "violet" | "slate";
+}) {
+  const toneClass = {
+    blue: "bg-sky-50 text-sky-700 dark:bg-sky-950/70 dark:text-sky-200",
+    green:
+      "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-200",
+    amber:
+      "bg-amber-50 text-amber-700 dark:bg-amber-950/70 dark:text-amber-200",
+    violet:
+      "bg-violet-50 text-violet-700 dark:bg-violet-950/70 dark:text-violet-200",
+    slate: "bg-slate-100 text-slate-700 dark:bg-zinc-800 dark:text-zinc-200",
+  }[tone];
+
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
       <CardContent className="flex items-center justify-between gap-4 p-5">
         <div>
-          <p className="text-sm text-muted-foreground">{title}</p>
-          <p className="text-2xl font-bold text-slate-950">{value}</p>
-          <p className="text-xs text-muted-foreground">{helper}</p>
+          <p className="text-sm text-muted-foreground dark:text-zinc-400">
+            {title}
+          </p>
+          <p className="text-2xl font-bold text-slate-950 dark:text-white">
+            {value}
+          </p>
+          <p className="text-xs text-muted-foreground dark:text-zinc-400">
+            {helper}
+          </p>
         </div>
         <div className={`rounded-full p-3 ${toneClass}`}>
           <Icon className="h-5 w-5" />
@@ -106,10 +248,16 @@ function MetricCard({ title, value, helper, icon: Icon, tone = "blue" }: { title
 }
 
 function EmptyChart({ label }: { label: string }) {
-  return <div className="flex h-[260px] items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground">{label}</div>;
+  return (
+    <div className="flex h-[260px] items-center justify-center rounded-xl border border-dashed border-slate-300 text-sm text-muted-foreground dark:border-zinc-800 dark:text-zinc-400">
+      {label}
+    </div>
+  );
 }
 
-function resolvePositionTone(position: number): "slate" | "green" | "red" | "blue" | "amber" | "violet" {
+function resolvePositionTone(
+  position: number,
+): "slate" | "green" | "red" | "blue" | "amber" | "violet" {
   if (position === 1) return "amber";
   if (position === 2) return "slate";
   if (position === 3) return "violet";
@@ -118,11 +266,14 @@ function resolvePositionTone(position: number): "slate" | "green" | "red" | "blu
 
 export default function SociosRankingBonificacionPage() {
   const { anio: defaultAnio, mes: defaultMes } = currentYearMonth();
+  const { locale } = useI18n();
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
   const [anio, setAnio] = useState(defaultAnio);
   const [mes, setMes] = useState(defaultMes);
-  const [data, setData] = useState<SociosRankingBonificacionResponse | null>(null);
+  const [data, setData] = useState<SociosRankingBonificacionResponse | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [soloConAsistencia, setSoloConAsistencia] = useState(false);
@@ -146,12 +297,19 @@ export default function SociosRankingBonificacionPage() {
       const response = await fetchSociosRankingBonificacion(anio, mes);
       setData(response);
     } catch (error: any) {
-      toast.error(error?.message || "No se pudo cargar el ranking mensual");
+      toast.error(
+        error?.message ||
+          rbTx(
+            locale,
+            "No se pudo cargar el ranking mensual",
+            "Could not load the monthly ranking",
+          ),
+      );
       setData(null);
     } finally {
       setLoading(false);
     }
-  }, [anio, isAuthenticated, mes]);
+  }, [anio, isAuthenticated, locale, mes]);
 
   useEffect(() => {
     if (isInitialized && isAuthenticated) loadData();
@@ -159,13 +317,23 @@ export default function SociosRankingBonificacionPage() {
 
   useEffect(() => {
     setPage(1);
-  }, [searchTerm, soloConAsistencia, soloCuotaAlDia, soloBonificados, anio, mes]);
+  }, [
+    searchTerm,
+    soloConAsistencia,
+    soloCuotaAlDia,
+    soloBonificados,
+    anio,
+    mes,
+  ]);
 
   const filteredRanking = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
     return (data?.ranking ?? []).filter((item) => {
       if (term) {
-        const haystack = [item.nombre_completo, item.dni, item.email].filter(Boolean).join(" ").toLowerCase();
+        const haystack = [item.nombre_completo, item.dni, item.email]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
         if (!haystack.includes(term)) return false;
       }
       if (soloConAsistencia && item.asistencias <= 0) return false;
@@ -175,29 +343,63 @@ export default function SociosRankingBonificacionPage() {
     });
   }, [data, searchTerm, soloBonificados, soloConAsistencia, soloCuotaAlDia]);
 
-  const topSocios = useMemo(() => filteredRanking.slice(0, 10), [filteredRanking]);
+  const topSocios = useMemo(
+    () => filteredRanking.slice(0, 10),
+    [filteredRanking],
+  );
   const totalPages = Math.max(1, Math.ceil(filteredRanking.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages);
-  const paginatedRanking = filteredRanking.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+  const paginatedRanking = filteredRanking.slice(
+    (safePage - 1) * PAGE_SIZE,
+    safePage * PAGE_SIZE,
+  );
 
-  const handleToggleBonificacion = async (item: SocioRankingBonificacionItem) => {
+  const handleToggleBonificacion = async (
+    item: SocioRankingBonificacionItem,
+  ) => {
     if (!data?.schema_ready) {
-      toast.error("Aplicá la migración para guardar bonificaciones mensuales.");
+      toast.error(
+        rbTx(
+          locale,
+          "Aplicá la migración para guardar bonificaciones mensuales.",
+          "Apply the migration to save monthly bonuses.",
+        ),
+      );
       return;
     }
 
     if (item.bonificacion_bloqueada) {
       toast.error(
-        item.bloqueo_motivo ||
-          "No se puede modificar la bonificación porque ya existe un pago registrado para ese mes.",
+        translateBlockReason(locale, item.bloqueo_motivo) ||
+          rbTx(
+            locale,
+            "No se puede modificar la bonificación porque ya existe un pago registrado para ese mes.",
+            "This bonus cannot be changed because a payment already exists for that month.",
+          ),
       );
       return;
     }
 
     const nextValue = !item.bonificado;
-    const descuento = nextValue ? Number(window.prompt("Porcentaje de bonificación", String(item.descuento_porcentaje || 10)) || 0) : 0;
-    if (nextValue && (Number.isNaN(descuento) || descuento < 0 || descuento > 100)) {
-      toast.error("El descuento debe estar entre 0 y 100.");
+    const descuento = nextValue
+      ? Number(
+          window.prompt(
+            rbTx(locale, "Porcentaje de bonificación", "Bonus percentage"),
+            String(item.descuento_porcentaje || 10),
+          ) || 0,
+        )
+      : 0;
+    if (
+      nextValue &&
+      (Number.isNaN(descuento) || descuento < 0 || descuento > 100)
+    ) {
+      toast.error(
+        rbTx(
+          locale,
+          "El descuento debe estar entre 0 y 100.",
+          "The discount must be between 0 and 100.",
+        ),
+      );
       return;
     }
 
@@ -209,13 +411,32 @@ export default function SociosRankingBonificacionPage() {
         mes,
         bonificado: nextValue,
         descuento_porcentaje: descuento,
-        motivo: nextValue ? "Bonificación mensual por ranking" : "Bonificación removida",
-        observaciones: nextValue ? `Socio bonificado desde ranking ${monthName(anio, mes)}` : null,
+        motivo: nextValue
+          ? "Bonificación mensual por ranking"
+          : "Bonificación removida",
+        observaciones: nextValue
+          ? `Socio bonificado desde ranking ${monthName(anio, mes, "es")}`
+          : null,
       });
       setData(response);
-      toast.success(nextValue ? "Socio bonificado correctamente" : "Bonificación removida");
+      toast.success(
+        nextValue
+          ? rbTx(
+              locale,
+              "Socio bonificado correctamente",
+              "Member bonused successfully",
+            )
+          : rbTx(locale, "Bonificación removida", "Bonus removed"),
+      );
     } catch (error: any) {
-      toast.error(error?.message || "No se pudo actualizar la bonificación");
+      toast.error(
+        error?.message ||
+          rbTx(
+            locale,
+            "No se pudo actualizar la bonificación",
+            "Could not update the bonus",
+          ),
+      );
     } finally {
       setSavingId(null);
     }
@@ -224,47 +445,100 @@ export default function SociosRankingBonificacionPage() {
   const handleExportExcel = async () => {
     if (!data) return;
     const workbook = new ExcelJS.Workbook();
-    const resumen = workbook.addWorksheet("Resumen");
+    const resumen = workbook.addWorksheet(rbTx(locale, "Resumen", "Summary"));
     resumen.columns = [
-      { header: "Métrica", key: "metrica", width: 32 },
-      { header: "Valor", key: "valor", width: 18 },
+      { header: rbTx(locale, "Métrica", "Metric"), key: "metrica", width: 32 },
+      { header: rbTx(locale, "Valor", "Value"), key: "valor", width: 18 },
     ];
     resumen.addRows([
-      { metrica: "Período", valor: monthName(anio, mes) },
-      { metrica: "Socios activos", valor: data.kpis.socios_activos },
-      { metrica: "Socios con asistencia", valor: data.kpis.socios_con_asistencia },
-      { metrica: "Socios cuota al día", valor: data.kpis.socios_cuota_al_dia },
-      { metrica: "Bonificados", valor: data.kpis.bonificados },
-      { metrica: "Asistencias totales", valor: data.kpis.asistencia_total },
-      { metrica: "Asistencia promedio", valor: data.kpis.asistencia_promedio },
+      {
+        metrica: rbTx(locale, "Período", "Period"),
+        valor: monthName(anio, mes, locale),
+      },
+      {
+        metrica: rbTx(locale, "Socios activos", "Active members"),
+        valor: data.kpis.socios_activos,
+      },
+      {
+        metrica: rbTx(
+          locale,
+          "Socios con asistencia",
+          "Members with attendance",
+        ),
+        valor: data.kpis.socios_con_asistencia,
+      },
+      {
+        metrica: rbTx(locale, "Socios cuota al día", "Members up to date"),
+        valor: data.kpis.socios_cuota_al_dia,
+      },
+      {
+        metrica: rbTx(locale, "Bonificados", "Bonused members"),
+        valor: data.kpis.bonificados,
+      },
+      {
+        metrica: rbTx(locale, "Asistencias totales", "Total attendance"),
+        valor: data.kpis.asistencia_total,
+      },
+      {
+        metrica: rbTx(locale, "Asistencia promedio", "Average attendance"),
+        valor: data.kpis.asistencia_promedio,
+      },
     ]);
 
-    const rankingSheet = workbook.addWorksheet("Ranking mensual");
+    const rankingSheet = workbook.addWorksheet(
+      rbTx(locale, "Ranking mensual", "Monthly ranking"),
+    );
     rankingSheet.columns = [
       { header: "Ranking", key: "ranking", width: 10 },
-      { header: "Socio", key: "nombre_completo", width: 34 },
-      { header: "DNI", key: "dni", width: 16 },
-      { header: "Asistencias", key: "asistencias", width: 14 },
-      { header: "Cuota al día", key: "cuota_al_dia", width: 14 },
+      {
+        header: rbTx(locale, "Socio", "Member"),
+        key: "nombre_completo",
+        width: 34,
+      },
+      { header: rbTx(locale, "DNI", "ID"), key: "dni", width: 16 },
+      {
+        header: rbTx(locale, "Asistencias", "Attendance"),
+        key: "asistencias",
+        width: 14,
+      },
+      {
+        header: rbTx(locale, "Cuota al día", "Fee up to date"),
+        key: "cuota_al_dia",
+        width: 14,
+      },
       { header: "Score", key: "score", width: 12 },
-      { header: "Bonificado", key: "bonificado", width: 14 },
-      { header: "Descuento", key: "descuento_porcentaje", width: 14 },
-      { header: "Motivo", key: "motivo", width: 36 },
+      {
+        header: rbTx(locale, "Bonificado", "Bonused"),
+        key: "bonificado",
+        width: 14,
+      },
+      {
+        header: rbTx(locale, "Descuento", "Discount"),
+        key: "descuento_porcentaje",
+        width: 14,
+      },
+      { header: rbTx(locale, "Motivo", "Reason"), key: "motivo", width: 36 },
     ];
     filteredRanking.forEach((item) => {
       rankingSheet.addRow({
         ...item,
-        cuota_al_dia: item.cuota_al_dia ? "Sí" : "No",
-        bonificado: item.bonificado ? "Sí" : "No",
+        cuota_al_dia: yesNo(locale, item.cuota_al_dia),
+        bonificado: yesNo(locale, item.bonificado),
+        motivo: translateBonusReason(locale, item.motivo),
       });
     });
 
     const buffer = await workbook.xlsx.writeBuffer();
-    const blob = new Blob([buffer], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+    const blob = new Blob([buffer], {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
     const url = window.URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = buildTimestampedDownloadFileName("ranking-bonificacion-socios", "xlsx");
+    link.download = buildTimestampedDownloadFileName(
+      "ranking-bonificacion-socios",
+      "xlsx",
+    );
     link.click();
     window.URL.revokeObjectURL(url);
   };
@@ -273,42 +547,123 @@ export default function SociosRankingBonificacionPage() {
     if (!data) return;
 
     await downloadCommercialReportPdf({
-      title: "Ranking mensual de socios",
-      subtitle: monthName(anio, mes),
-      fileName: buildTimestampedDownloadFileName("ranking-bonificacion-socios", "pdf"),
+      title: rbTx(
+        locale,
+        "Ranking mensual de socios",
+        "Monthly member ranking",
+      ),
+      subtitle: monthName(anio, mes, locale),
+      fileName: buildTimestampedDownloadFileName(
+        "ranking-bonificacion-socios",
+        "pdf",
+      ),
       pageOrientation: "landscape",
       metrics: [
-        { label: "Socios activos", value: data.kpis.socios_activos },
-        { label: "Con asistencia", value: data.kpis.socios_con_asistencia },
-        { label: "Cuota al día", value: data.kpis.socios_cuota_al_dia },
-        { label: "Bonificados", value: data.kpis.bonificados },
-        { label: "Asistencias", value: data.kpis.asistencia_total },
+        {
+          label: rbTx(locale, "Socios activos", "Active members"),
+          value: data.kpis.socios_activos,
+        },
+        {
+          label: rbTx(locale, "Con asistencia", "With attendance"),
+          value: data.kpis.socios_con_asistencia,
+        },
+        {
+          label: rbTx(locale, "Cuota al día", "Fee up to date"),
+          value: data.kpis.socios_cuota_al_dia,
+        },
+        {
+          label: rbTx(locale, "Bonificados", "Bonused"),
+          value: data.kpis.bonificados,
+        },
+        {
+          label: rbTx(locale, "Asistencias", "Attendance"),
+          value: data.kpis.asistencia_total,
+        },
       ],
-      filtersLabel: `Período: ${data.periodo_desde} a ${data.periodo_hasta}. Filtro: ${searchTerm || "sin búsqueda"}`,
+      filtersLabel: rbTx(
+        locale,
+        `Período: ${data.periodo_desde} a ${data.periodo_hasta}. Filtro: ${searchTerm || "sin búsqueda"}`,
+        `Period: ${data.periodo_desde} to ${data.periodo_hasta}. Filter: ${searchTerm || "no search"}`,
+      ),
       charts: [
         {
-          title: "Top socios por asistencia",
+          title: rbTx(
+            locale,
+            "Top socios por asistencia",
+            "Top members by attendance",
+          ),
           kind: "bars",
-          data: topSocios.map((item) => ({ socio: item.nombre_completo.slice(0, 18), asistencias: item.asistencias })),
-          labelKey: "socio",
-          series: [{ key: "asistencias", label: "Asistencias", color: [2, 168, 225] }],
+          data: topSocios.map((item) => ({
+            member: item.nombre_completo.slice(0, 18),
+            attendance: item.asistencias,
+          })),
+          labelKey: "member",
+          series: [
+            {
+              key: "attendance",
+              label: rbTx(locale, "Asistencias", "Attendance"),
+              color: [2, 168, 225],
+            },
+          ],
         },
       ],
       rows: filteredRanking.slice(0, 40),
       columns: [
-        { header: "#", width: 12, getValue: (row) => row.ranking, align: "center" },
-        { header: "Socio", width: 52, getValue: (row) => row.nombre_completo },
-        { header: "Asist.", width: 18, getValue: (row) => row.asistencias, align: "center" },
-        { header: "Cuota", width: 24, getValue: (row) => (row.cuota_al_dia ? "Al día" : "Pendiente") },
-        { header: "Score", width: 18, getValue: (row) => row.score, align: "center" },
-        { header: "Bonificado", width: 28, getValue: (row) => (row.bonificado ? `Sí ${row.descuento_porcentaje}%` : "No") },
-        { header: "Motivo", width: 70, getValue: (row) => row.motivo || "-" },
+        {
+          header: "#",
+          width: 12,
+          getValue: (row) => row.ranking,
+          align: "center",
+        },
+        {
+          header: rbTx(locale, "Socio", "Member"),
+          width: 52,
+          getValue: (row) => row.nombre_completo,
+        },
+        {
+          header: rbTx(locale, "Asist.", "Att."),
+          width: 18,
+          getValue: (row) => row.asistencias,
+          align: "center",
+        },
+        {
+          header: rbTx(locale, "Cuota", "Fee"),
+          width: 24,
+          getValue: (row) =>
+            row.cuota_al_dia
+              ? rbTx(locale, "Al día", "Up to date")
+              : rbTx(locale, "Pendiente", "Pending"),
+        },
+        {
+          header: "Score",
+          width: 18,
+          getValue: (row) => row.score,
+          align: "center",
+        },
+        {
+          header: rbTx(locale, "Bonificado", "Bonused"),
+          width: 28,
+          getValue: (row) =>
+            row.bonificado
+              ? `${yesNo(locale, true)} ${row.descuento_porcentaje}%`
+              : yesNo(locale, false),
+        },
+        {
+          header: rbTx(locale, "Motivo", "Reason"),
+          width: 70,
+          getValue: (row) => translateBonusReason(locale, row.motivo) || "-",
+        },
       ],
-      footerText: "Gym Master · Ranking y bonificación mensual de socios",
+      footerText: rbTx(
+        locale,
+        "Gym Master · Ranking y bonificación mensual de socios",
+        "Gym Master · Monthly member ranking and bonus",
+      ),
     });
   };
 
-  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isInitialized)
+    return <div>{rbTx(locale, "Cargando...", "Loading...")}</div>;
   if (!isAuthenticated) return null;
 
   return (
@@ -316,180 +671,454 @@ export default function SociosRankingBonificacionPage() {
       <div className="flex min-h-screen w-full">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Ranking y bonificación mensual" />
-          <main className="flex-1 space-y-6 p-6">
+          <AppHeader
+            title={rbTx(
+              locale,
+              "Ranking y bonificación mensual",
+              "Monthly ranking and bonus",
+            )}
+          />
+          <main className="flex-1 space-y-6 bg-slate-50/40 p-6 text-slate-950 dark:bg-black dark:text-zinc-100">
             <section className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <h1 className="text-2xl font-bold text-slate-950">Ranking y bonificación mensual de socios</h1>
-                <p className="text-sm text-muted-foreground">
-                  Reconocimiento comercial para premiar constancia, cuota al día y fidelización.
+                <h1 className="text-2xl font-bold text-slate-950 dark:text-white">
+                  {rbTx(
+                    locale,
+                    "Ranking y bonificación mensual de socios",
+                    "Monthly member ranking and bonus",
+                  )}
+                </h1>
+                <p className="text-sm text-muted-foreground dark:text-zinc-400">
+                  {rbTx(
+                    locale,
+                    "Reconocimiento comercial para premiar constancia, cuota al día y fidelización.",
+                    "Commercial recognition to reward consistency, up-to-date fees, and loyalty.",
+                  )}
                 </p>
               </div>
               <QaFileNameBadge file="src/app/dashboard/socios-ranking-bonificacion/page.tsx" />
             </section>
 
             {data?.warnings?.length ? (
-              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200">
                 {data.warnings.map((warning) => (
-                  <p key={warning}>{warning}</p>
+                  <p key={warning}>
+                    {translateRankingWarning(locale, warning)}
+                  </p>
                 ))}
               </div>
             ) : null}
 
             <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-              <MetricCard title="Socios activos" value={formatNumber(data?.kpis.socios_activos)} helper="Base activa" icon={Users} tone="blue" />
-              <MetricCard title="Con asistencia" value={formatNumber(data?.kpis.socios_con_asistencia)} helper="Participaron este mes" icon={CheckCircle2} tone="green" />
-              <MetricCard title="Cuota al día" value={formatNumber(data?.kpis.socios_cuota_al_dia)} helper="Al cierre del período" icon={Star} tone="amber" />
-              <MetricCard title="Bonificados" value={formatNumber(data?.kpis.bonificados)} helper="Premios activos" icon={Award} tone="violet" />
-              <MetricCard title="Promedio asistencia" value={formatNumber(data?.kpis.asistencia_promedio)} helper="Por socio" icon={Trophy} tone="slate" />
+              <MetricCard
+                title={rbTx(locale, "Socios activos", "Active members")}
+                value={formatNumber(data?.kpis.socios_activos)}
+                helper={rbTx(locale, "Base activa", "Active base")}
+                icon={Users}
+                tone="blue"
+              />
+              <MetricCard
+                title={rbTx(locale, "Con asistencia", "With attendance")}
+                value={formatNumber(data?.kpis.socios_con_asistencia)}
+                helper={rbTx(
+                  locale,
+                  "Participaron este mes",
+                  "Participated this month",
+                )}
+                icon={CheckCircle2}
+                tone="green"
+              />
+              <MetricCard
+                title={rbTx(locale, "Cuota al día", "Fee up to date")}
+                value={formatNumber(data?.kpis.socios_cuota_al_dia)}
+                helper={rbTx(
+                  locale,
+                  "Al cierre del período",
+                  "At period close",
+                )}
+                icon={Star}
+                tone="amber"
+              />
+              <MetricCard
+                title={rbTx(locale, "Bonificados", "Bonused")}
+                value={formatNumber(data?.kpis.bonificados)}
+                helper={rbTx(locale, "Premios activos", "Active rewards")}
+                icon={Award}
+                tone="violet"
+              />
+              <MetricCard
+                title={rbTx(
+                  locale,
+                  "Promedio asistencia",
+                  "Average attendance",
+                )}
+                value={formatNumber(data?.kpis.asistencia_promedio)}
+                helper={rbTx(locale, "Por socio", "Per member")}
+                icon={Trophy}
+                tone="slate"
+              />
             </section>
 
             <section className="grid gap-4 xl:grid-cols-[0.7fr_1.3fr]">
-              <Card>
-                <CardHeader className="border-b p-4">
-                  <h2 className="text-xl font-bold">Período y filtros</h2>
-                  <p className="text-sm text-muted-foreground">Seleccioná mes, año y criterios del ranking.</p>
+              <Card className="border-slate-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                <CardHeader className="border-b border-slate-200 p-4 dark:border-zinc-800">
+                  <h2 className="text-xl font-bold text-slate-950 dark:text-white">
+                    {rbTx(locale, "Período y filtros", "Period and filters")}
+                  </h2>
+                  <p className="text-sm text-muted-foreground dark:text-zinc-400">
+                    {rbTx(
+                      locale,
+                      "Seleccioná mes, año y criterios del ranking.",
+                      "Select month, year, and ranking criteria.",
+                    )}
+                  </p>
                 </CardHeader>
                 <CardContent className="space-y-4 p-4">
                   <div className="grid gap-3 sm:grid-cols-2">
                     <div className="space-y-2">
-                      <Label>Año</Label>
-                      <Input type="number" min={2020} max={2100} value={anio} onChange={(event) => setAnio(Number(event.target.value))} />
+                      <Label>{rbTx(locale, "Año", "Year")}</Label>
+                      <Input
+                        type="number"
+                        min={2020}
+                        max={2100}
+                        value={anio}
+                        onChange={(event) =>
+                          setAnio(Number(event.target.value))
+                        }
+                      />
                     </div>
                     <div className="space-y-2">
-                      <Label>Mes</Label>
-                      <Input type="number" min={1} max={12} value={mes} onChange={(event) => setMes(Number(event.target.value))} />
+                      <Label>{rbTx(locale, "Mes", "Month")}</Label>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={12}
+                        value={mes}
+                        onChange={(event) => setMes(Number(event.target.value))}
+                      />
                     </div>
                   </div>
 
                   <div className="space-y-2">
-                    <Label>Buscar socio</Label>
-                    <Input placeholder="Nombre, DNI o email..." value={searchTerm} onChange={(event) => setSearchTerm(event.target.value)} />
+                    <Label>
+                      {rbTx(locale, "Buscar socio", "Search member")}
+                    </Label>
+                    <Input
+                      placeholder={rbTx(
+                        locale,
+                        "Nombre, DNI o email...",
+                        "Name, ID, or email...",
+                      )}
+                      value={searchTerm}
+                      onChange={(event) => setSearchTerm(event.target.value)}
+                    />
                   </div>
 
-                  <div className="space-y-3 rounded-xl border p-3">
+                  <div className="space-y-3 rounded-xl border border-slate-200 p-3 dark:border-zinc-800 dark:bg-zinc-900/40">
                     <label className="flex items-center gap-2 text-sm">
-                      <Checkbox checked={soloConAsistencia} onCheckedChange={(value) => setSoloConAsistencia(Boolean(value))} />
-                      Solo socios con asistencia
+                      <Checkbox
+                        checked={soloConAsistencia}
+                        onCheckedChange={(value) =>
+                          setSoloConAsistencia(Boolean(value))
+                        }
+                      />
+                      {rbTx(
+                        locale,
+                        "Solo socios con asistencia",
+                        "Only members with attendance",
+                      )}
                     </label>
                     <label className="flex items-center gap-2 text-sm">
-                      <Checkbox checked={soloCuotaAlDia} onCheckedChange={(value) => setSoloCuotaAlDia(Boolean(value))} />
-                      Solo cuota al día
+                      <Checkbox
+                        checked={soloCuotaAlDia}
+                        onCheckedChange={(value) =>
+                          setSoloCuotaAlDia(Boolean(value))
+                        }
+                      />
+                      {rbTx(
+                        locale,
+                        "Solo cuota al día",
+                        "Only up-to-date fees",
+                      )}
                     </label>
                     <label className="flex items-center gap-2 text-sm">
-                      <Checkbox checked={soloBonificados} onCheckedChange={(value) => setSoloBonificados(Boolean(value))} />
-                      Solo bonificados
+                      <Checkbox
+                        checked={soloBonificados}
+                        onCheckedChange={(value) =>
+                          setSoloBonificados(Boolean(value))
+                        }
+                      />
+                      {rbTx(locale, "Solo bonificados", "Only bonused members")}
                     </label>
                   </div>
 
                   <div className="flex flex-wrap gap-2">
-                    <Button onClick={loadData} disabled={loading} className="bg-[#02a8e1] hover:bg-[#0288b1]">
-                      <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
-                      Actualizar
+                    <Button
+                      onClick={loadData}
+                      disabled={loading}
+                      className="bg-[#02a8e1] hover:bg-[#0288b1]"
+                    >
+                      <RefreshCw
+                        className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`}
+                      />
+                      {rbTx(locale, "Actualizar", "Refresh")}
                     </Button>
-                    <Button variant="outline" onClick={handleDownloadPdf} disabled={!data}>
+                    <Button
+                      variant="outline"
+                      onClick={handleDownloadPdf}
+                      disabled={!data}
+                    >
                       <FileText className="mr-2 h-4 w-4" /> PDF
                     </Button>
-                    <Button variant="outline" onClick={handleExportExcel} disabled={!data}>
+                    <Button
+                      variant="outline"
+                      onClick={handleExportExcel}
+                      disabled={!data}
+                    >
                       <FileSpreadsheet className="mr-2 h-4 w-4" /> Excel
                     </Button>
                   </div>
                 </CardContent>
               </Card>
 
-              <Card>
-                <CardHeader className="border-b p-4">
-                  <h2 className="text-xl font-bold">Top socios del mes</h2>
-                  <p className="text-sm text-muted-foreground">{monthName(anio, mes)} · ranking por asistencia y cuota al día.</p>
+              <Card className="border-slate-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+                <CardHeader className="border-b border-slate-200 p-4 dark:border-zinc-800">
+                  <h2 className="text-xl font-bold text-slate-950 dark:text-white">
+                    {rbTx(
+                      locale,
+                      "Top socios del mes",
+                      "Top members of the month",
+                    )}
+                  </h2>
+                  <p className="text-sm text-muted-foreground dark:text-zinc-400">
+                    {monthName(anio, mes, locale)} ·{" "}
+                    {rbTx(
+                      locale,
+                      "ranking por asistencia y cuota al día.",
+                      "ranking by attendance and up-to-date fees.",
+                    )}
+                  </p>
                 </CardHeader>
                 <CardContent className="p-4">
                   {topSocios.length ? (
                     <ResponsiveContainer width="100%" height={300}>
-                      <BarChart data={topSocios.map((item) => ({ socio: item.nombre_completo.split(" ").slice(0, 2).join(" "), asistencias: item.asistencias }))}>
-                        <CartesianGrid strokeDasharray="3 3" />
-                        <XAxis dataKey="socio" />
-                        <YAxis allowDecimals={false} />
-                        <Tooltip />
-                        <Bar dataKey="asistencias" name="Asistencias" fill="#02a8e1" />
+                      <BarChart
+                        data={topSocios.map((item) => ({
+                          member: item.nombre_completo
+                            .split(" ")
+                            .slice(0, 2)
+                            .join(" "),
+                          attendance: item.asistencias,
+                        }))}
+                      >
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          className="stroke-slate-200 dark:stroke-zinc-800"
+                        />
+                        <XAxis
+                          dataKey="member"
+                          tick={{ fill: "currentColor", fontSize: 12 }}
+                          className="text-slate-500 dark:text-zinc-400"
+                        />
+                        <YAxis
+                          allowDecimals={false}
+                          tick={{ fill: "currentColor", fontSize: 12 }}
+                          className="text-slate-500 dark:text-zinc-400"
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: "#111827",
+                            border: "1px solid #27272a",
+                            borderRadius: 12,
+                            color: "#f9fafb",
+                          }}
+                        />
+                        <Bar
+                          dataKey="attendance"
+                          name={rbTx(locale, "Asistencias", "Attendance")}
+                          fill="#02a8e1"
+                        />
                       </BarChart>
                     </ResponsiveContainer>
                   ) : (
-                    <EmptyChart label={loading ? "Cargando ranking..." : "Sin datos para graficar."} />
+                    <EmptyChart
+                      label={
+                        loading
+                          ? rbTx(
+                              locale,
+                              "Cargando ranking...",
+                              "Loading ranking...",
+                            )
+                          : rbTx(
+                              locale,
+                              "Sin datos para graficar.",
+                              "No data to chart.",
+                            )
+                      }
+                    />
                   )}
                 </CardContent>
               </Card>
             </section>
 
-            <Card>
-              <CardHeader className="border-b p-4">
+            <Card className="border-slate-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+              <CardHeader className="border-b border-slate-200 p-4 dark:border-zinc-800">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
-                    <h2 className="text-xl font-bold">Ranking mensual</h2>
-                    <p className="text-sm text-muted-foreground">
-                      {filteredRanking.length} resultado{filteredRanking.length === 1 ? "" : "s"} filtrado{filteredRanking.length === 1 ? "" : "s"} de {data?.ranking.length ?? 0} socios.
+                    <h2 className="text-xl font-bold text-slate-950 dark:text-white">
+                      {rbTx(locale, "Ranking mensual", "Monthly ranking")}
+                    </h2>
+                    <p className="text-sm text-muted-foreground dark:text-zinc-400">
+                      {locale === "en"
+                        ? `${filteredRanking.length} filtered result${filteredRanking.length === 1 ? "" : "s"} out of ${data?.ranking.length ?? 0} members.`
+                        : `${filteredRanking.length} resultado${filteredRanking.length === 1 ? "" : "s"} filtrado${filteredRanking.length === 1 ? "" : "s"} de ${data?.ranking.length ?? 0} socios.`}
                     </p>
                   </div>
-                  <div className="text-xs text-muted-foreground">Página {safePage} de {totalPages}</div>
+                  <div className="text-xs text-muted-foreground dark:text-zinc-400">
+                    {rbTx(locale, "Página", "Page")} {safePage}{" "}
+                    {rbTx(locale, "de", "of")} {totalPages}
+                  </div>
                 </div>
               </CardHeader>
               <CardContent className="p-4">
-                <div className="overflow-x-auto rounded-xl border">
+                <div className="overflow-x-auto rounded-xl border border-slate-200 dark:border-zinc-800">
                   <Table>
-                    <TableHeader>
+                    <TableHeader className="bg-slate-50 dark:bg-zinc-900/80">
                       <TableRow>
                         <TableHead className="w-[70px]">Ranking</TableHead>
-                        <TableHead>Socio</TableHead>
-                        <TableHead>Asistencias</TableHead>
-                        <TableHead>Cuota</TableHead>
+                        <TableHead>{rbTx(locale, "Socio", "Member")}</TableHead>
+                        <TableHead>
+                          {rbTx(locale, "Asistencias", "Attendance")}
+                        </TableHead>
+                        <TableHead>{rbTx(locale, "Cuota", "Fee")}</TableHead>
                         <TableHead>Score</TableHead>
-                        <TableHead>Bonificación</TableHead>
-                        <TableHead className="text-right">Acciones</TableHead>
+                        <TableHead>
+                          {rbTx(locale, "Bonificación", "Bonus")}
+                        </TableHead>
+                        <TableHead className="text-right">
+                          {rbTx(locale, "Acciones", "Actions")}
+                        </TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
                       {paginatedRanking.map((item) => (
-                        <TableRow key={item.socio_id}>
+                        <TableRow
+                          key={item.socio_id}
+                          className="dark:border-zinc-800 dark:hover:!bg-zinc-800/80"
+                        >
                           <TableCell>
                             <Badge tone={resolvePositionTone(item.ranking)}>
-                              <Medal className="mr-1 inline h-3 w-3" /> #{item.ranking}
+                              <Medal className="mr-1 inline h-3 w-3" /> #
+                              {item.ranking}
                             </Badge>
                           </TableCell>
                           <TableCell>
-                            <div className="font-medium text-slate-950">{item.nombre_completo}</div>
-                            <div className="text-xs text-muted-foreground">DNI {item.dni || "-"} · {item.email || "sin email"}</div>
+                            <div className="font-medium text-slate-950 dark:text-white">
+                              {item.nombre_completo}
+                            </div>
+                            <div className="text-xs text-muted-foreground dark:text-zinc-400">
+                              {rbTx(locale, "DNI", "ID")} {item.dni || "-"} ·{" "}
+                              {item.email ||
+                                rbTx(locale, "sin email", "no email")}
+                            </div>
                           </TableCell>
-                          <TableCell>{formatNumber(item.asistencias)}</TableCell>
-                          <TableCell>{item.cuota_al_dia ? <Badge tone="green">Al día</Badge> : <Badge tone="red">Pendiente</Badge>}</TableCell>
+                          <TableCell>
+                            {formatNumber(item.asistencias)}
+                          </TableCell>
+                          <TableCell>
+                            {item.cuota_al_dia ? (
+                              <Badge tone="green">
+                                {rbTx(locale, "Al día", "Up to date")}
+                              </Badge>
+                            ) : (
+                              <Badge tone="red">
+                                {rbTx(locale, "Pendiente", "Pending")}
+                              </Badge>
+                            )}
+                          </TableCell>
                           <TableCell>{formatNumber(item.score)}</TableCell>
                           <TableCell>
                             <div className="flex flex-wrap gap-1">
                               {item.bonificado ? (
-                                <Badge tone="violet"><Percent className="mr-1 inline h-3 w-3" /> {formatPercent(item.descuento_porcentaje)}</Badge>
+                                <Badge tone="violet">
+                                  <Percent className="mr-1 inline h-3 w-3" />{" "}
+                                  {formatPercent(item.descuento_porcentaje)}
+                                </Badge>
                               ) : (
-                                <Badge>No bonificado</Badge>
+                                <Badge>
+                                  {rbTx(locale, "No bonificado", "No bonus")}
+                                </Badge>
                               )}
-                              {item.bonificacion_bloqueada ? <Badge tone="amber">Bloqueada por pago</Badge> : null}
+                              {item.bonificacion_bloqueada ? (
+                                <Badge tone="amber">
+                                  {rbTx(
+                                    locale,
+                                    "Bloqueada por pago",
+                                    "Blocked by payment",
+                                  )}
+                                </Badge>
+                              ) : null}
                             </div>
                           </TableCell>
                           <TableCell className="text-right">
                             <Button
                               size="sm"
                               variant={item.bonificado ? "outline" : "default"}
-                              disabled={savingId === item.socio_id || item.bonificacion_bloqueada}
-                              title={item.bonificacion_bloqueada ? item.bloqueo_motivo || "Bonificación bloqueada por pago registrado" : undefined}
+                              disabled={
+                                savingId === item.socio_id ||
+                                item.bonificacion_bloqueada
+                              }
+                              title={
+                                item.bonificacion_bloqueada
+                                  ? translateBlockReason(
+                                      locale,
+                                      item.bloqueo_motivo,
+                                    ) ||
+                                    rbTx(
+                                      locale,
+                                      "Bonificación bloqueada por pago registrado",
+                                      "Bonus locked by registered payment",
+                                    )
+                                  : undefined
+                              }
                               onClick={() => handleToggleBonificacion(item)}
-                              className={item.bonificado ? "" : "bg-[#02a8e1] hover:bg-[#0288b1]"}
+                              className={
+                                item.bonificado
+                                  ? ""
+                                  : "bg-[#02a8e1] hover:bg-[#0288b1]"
+                              }
                             >
-                              {item.bonificado ? <XCircle className="mr-2 h-4 w-4" /> : <Award className="mr-2 h-4 w-4" />}
-                              {item.bonificacion_bloqueada ? "Bloqueada" : item.bonificado ? "Quitar" : "Bonificar"}
+                              {item.bonificado ? (
+                                <XCircle className="mr-2 h-4 w-4" />
+                              ) : (
+                                <Award className="mr-2 h-4 w-4" />
+                              )}
+                              {item.bonificacion_bloqueada
+                                ? rbTx(locale, "Bloqueada", "Blocked")
+                                : item.bonificado
+                                  ? rbTx(locale, "Quitar", "Remove")
+                                  : rbTx(locale, "Bonificar", "Bonus")}
                             </Button>
                           </TableCell>
                         </TableRow>
                       ))}
                       {!paginatedRanking.length && (
                         <TableRow>
-                          <TableCell colSpan={7} className="py-10 text-center text-sm text-muted-foreground">
-                            {loading ? "Cargando ranking..." : "No hay socios para los filtros seleccionados."}
+                          <TableCell
+                            colSpan={7}
+                            className="py-10 text-center text-sm text-muted-foreground"
+                          >
+                            {loading
+                              ? rbTx(
+                                  locale,
+                                  "Cargando ranking...",
+                                  "Loading ranking...",
+                                )
+                              : rbTx(
+                                  locale,
+                                  "No hay socios para los filtros seleccionados.",
+                                  "No members match the selected filters.",
+                                )}
                           </TableCell>
                         </TableRow>
                       )}
@@ -498,23 +1127,55 @@ export default function SociosRankingBonificacionPage() {
                 </div>
 
                 <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
-                  <Button variant="outline" disabled={safePage <= 1} onClick={() => setPage((prev) => Math.max(1, prev - 1))}>Anterior</Button>
-                  <div className="text-sm text-muted-foreground">Mostrando {paginatedRanking.length} de {filteredRanking.length}</div>
-                  <Button variant="outline" disabled={safePage >= totalPages} onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}>Siguiente</Button>
+                  <Button
+                    variant="outline"
+                    disabled={safePage <= 1}
+                    onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+                  >
+                    {rbTx(locale, "Anterior", "Previous")}
+                  </Button>
+                  <div className="text-sm text-muted-foreground dark:text-zinc-400">
+                    {rbTx(locale, "Mostrando", "Showing")}{" "}
+                    {paginatedRanking.length} {rbTx(locale, "de", "of")}{" "}
+                    {filteredRanking.length}
+                  </div>
+                  <Button
+                    variant="outline"
+                    disabled={safePage >= totalPages}
+                    onClick={() =>
+                      setPage((prev) => Math.min(totalPages, prev + 1))
+                    }
+                  >
+                    {rbTx(locale, "Siguiente", "Next")}
+                  </Button>
                 </div>
               </CardContent>
             </Card>
 
-            <Card>
-              <CardHeader className="border-b p-4">
-                <h2 className="text-xl font-bold">Reglas comerciales</h2>
-                <p className="text-sm text-muted-foreground">Criterios usados para calcular el ranking mensual.</p>
+            <Card className="border-slate-200 bg-white dark:border-zinc-800 dark:bg-zinc-950/80 dark:text-zinc-100">
+              <CardHeader className="border-b border-slate-200 p-4 dark:border-zinc-800">
+                <h2 className="text-xl font-bold text-slate-950 dark:text-white">
+                  {rbTx(locale, "Reglas comerciales", "Commercial rules")}
+                </h2>
+                <p className="text-sm text-muted-foreground dark:text-zinc-400">
+                  {rbTx(
+                    locale,
+                    "Criterios usados para calcular el ranking mensual.",
+                    "Criteria used to calculate the monthly ranking.",
+                  )}
+                </p>
               </CardHeader>
               <CardContent className="grid gap-3 p-4 md:grid-cols-2">
                 {(data?.reglas ?? []).map((regla, index) => (
-                  <div key={regla} className="rounded-xl border bg-white p-4 text-sm">
+                  <div
+                    key={regla}
+                    className="rounded-xl border border-slate-200 bg-white p-4 text-sm dark:border-zinc-800 dark:bg-zinc-900/60"
+                  >
                     <CalendarDays className="mb-2 h-4 w-4 text-[#02a8e1]" />
-                    <span className="font-semibold">Regla {index + 1}: </span>{regla}
+                    <span className="font-semibold">
+                      {rbTx(locale, "Regla", "Rule")} {index + 1}:{" "}
+                    </span>
+                    {translateRankingRule(locale, regla)}
                   </div>
                 ))}
               </CardContent>

--- a/src/components/forms/CuotasForm.tsx
+++ b/src/components/forms/CuotasForm.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { createCuota, updateCuota } from "@/services/cuotaService";
 import { toast } from "sonner";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export interface CuotasFormProps {
   cuota?: {
@@ -29,6 +30,9 @@ const emptyForm = {
 };
 
 export default function CuotasForm({ cuota, onCreated }: CuotasFormProps) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
   const [form, setForm] = useState(emptyForm);
   const [loading, setLoading] = useState(false);
 
@@ -60,24 +64,28 @@ export default function CuotasForm({ cuota, onCreated }: CuotasFormProps) {
     try {
       if (cuota && cuota.id) {
         await updateCuota(cuota.id, { ...form, activo: true });
-        toast.success("Cuota actualizada");
+        toast.success(tx("Cuota actualizada", "Fee updated"));
       } else {
         await createCuota(form);
-        toast.success("Cuota creada");
+        toast.success(tx("Cuota creada", "Fee created"));
       }
       setForm(emptyForm);
       onCreated();
     } catch (error: any) {
-      let msg = error.message || "Error al guardar cuota";
+      let msg = error.message || tx("Error al guardar cuota", "Error saving fee");
       if (msg.includes("value too long")) {
-        msg =
-          "Uno de los campos excede la cantidad máxima de caracteres permitidos.";
+        msg = tx(
+          "Uno de los campos excede la cantidad máxima de caracteres permitidos.",
+          "One of the fields exceeds the maximum allowed number of characters.",
+        );
       }
       toast.error(msg);
     } finally {
       setLoading(false);
     }
   };
+
+  const inputClassName = "dark:border-neutral-800 dark:bg-black dark:text-neutral-100 dark:placeholder:text-neutral-500";
 
   return (
     <form
@@ -86,62 +94,67 @@ export default function CuotasForm({ cuota, onCreated }: CuotasFormProps) {
     >
       <QaFileNameBadge file="src/components/forms/CuotasForm.tsx" />
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="descripcion">Descripción</Label>
+        <Label htmlFor="descripcion">{tx("Descripción", "Description")}</Label>
         <Input
           id="descripcion"
           name="descripcion"
-          placeholder="Ingrese descripción"
+          placeholder={tx("Ingrese descripción", "Enter description")}
           value={form.descripcion}
           onChange={handleChange}
+          className={inputClassName}
           required
         />
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="monto">Monto</Label>
+        <Label htmlFor="monto">{tx("Monto", "Amount")}</Label>
         <Input
           id="monto"
           name="monto"
           type="number"
-          placeholder="Ingrese monto"
+          placeholder={tx("Ingrese monto", "Enter amount")}
           value={form.monto}
           onChange={handleChange}
+          className={inputClassName}
           required
         />
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="periodo">Período</Label>
+        <Label htmlFor="periodo">{tx("Período", "Period")}</Label>
         <Input
           id="periodo"
           name="periodo"
-          placeholder="Ingrese período"
+          placeholder={tx("Ingrese período", "Enter period")}
           value={form.periodo}
           onChange={handleChange}
+          className={inputClassName}
           required
         />
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha_inicio">Fecha de Inicio</Label>
+        <Label htmlFor="fecha_inicio">{tx("Fecha de Inicio", "Start date")}</Label>
         <Input
           id="fecha_inicio"
           name="fecha_inicio"
           type="date"
           value={form.fecha_inicio}
           onChange={handleChange}
+          className={inputClassName}
           required
         />
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha_fin">Fecha de Fin</Label>
+        <Label htmlFor="fecha_fin">{tx("Fecha de Fin", "End date")}</Label>
         <Input
           id="fecha_fin"
           name="fecha_fin"
           type="date"
           value={form.fecha_fin}
           onChange={handleChange}
+          className={inputClassName}
           required
         />
       </div>
@@ -151,7 +164,11 @@ export default function CuotasForm({ cuota, onCreated }: CuotasFormProps) {
         className="col-span-full justify-self-end"
         disabled={loading}
       >
-        {loading ? "Guardando..." : cuota ? "Actualizar Cuota" : "Crear Cuota"}
+        {loading
+          ? tx("Guardando...", "Saving...")
+          : cuota
+          ? tx("Actualizar Cuota", "Update fee")
+          : tx("Crear Cuota", "Create fee")}
       </Button>
     </form>
   );

--- a/src/components/forms/NotificacionForm.tsx
+++ b/src/components/forms/NotificacionForm.tsx
@@ -15,9 +15,50 @@ import {
 } from '@/interfaces/notificacion.interface';
 import { actualizarNotificacion, crearNotificacion } from '@/services/apiClient';
 import { useEffect, useMemo, useState } from 'react';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import { toast } from 'sonner';
 
 type FormState = CreateNotificacionDto;
+
+
+function notificationTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function optionLabel(locale: GymMasterLocale, label: string) {
+  const labels: Record<string, string> = {
+    'General': 'General',
+    'Feriado / horario especial': 'Holiday / special schedule',
+    'Promoción': 'Promotion',
+    'Stock crítico': 'Critical stock',
+    'Cumpleaños': 'Birthday',
+    'Cuotas / pagos': 'Fees / payments',
+    'Recordatorio': 'Reminder',
+    'Sistema': 'System',
+    'Otro': 'Other',
+    'Email': 'Email',
+    'Terminal': 'Terminal',
+    'Email + Terminal': 'Email + Terminal',
+    'Sistema interno': 'Internal system',
+    'Borrador': 'Draft',
+    'Programada / activa': 'Scheduled / active',
+    'Enviada': 'Sent',
+    'Cancelada': 'Cancelled',
+    'Error': 'Error',
+    'Todos los socios con email': 'All members with email',
+    'Socios activos con email': 'Active members with email',
+    'Socios con cuota al día (base futura)': 'Members with up-to-date fees (future base)',
+    'Manual / personalizado (base futura)': 'Manual / custom (future base)',
+    'Rosa neón': 'Neon pink',
+    'Verde flúor': 'Fluorescent green',
+    'Naranja flúor': 'Fluorescent orange',
+    'Amarillo flúor': 'Fluorescent yellow',
+    'Rojo flúor': 'Fluorescent red',
+  };
+  return locale === 'en' ? labels[label] ?? label : label;
+}
+
 
 const emptyForm: FormState = {
   titulo: '',
@@ -97,6 +138,8 @@ export default function NotificacionForm({
   plantillas: NotificacionPlantilla[];
   onCreated?: () => void;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => notificationTx(locale, es, en);
   const [form, setForm] = useState<FormState>(emptyForm);
   const [loading, setLoading] = useState(false);
 
@@ -172,11 +215,11 @@ export default function NotificacionForm({
     setLoading(false);
 
     if (!response.ok) {
-      toast.error(response.error || 'No se pudo guardar la notificación');
+      toast.error(response.error || c('No se pudo guardar la notificación', 'Could not save the notification'));
       return;
     }
 
-    toast.success(notificacion ? 'Notificación actualizada' : 'Notificación creada');
+    toast.success(notificacion ? c('Notificación actualizada', 'Notification updated') : c('Notificación creada', 'Notification created'));
     onCreated?.();
   };
 
@@ -185,14 +228,14 @@ export default function NotificacionForm({
       <QaFileNameBadge file='src/components/forms/NotificacionForm.tsx' />
 
       <div className='flex flex-col gap-1.5 md:col-span-2'>
-        <Label htmlFor='plantilla_id'>Plantilla base</Label>
+        <Label htmlFor='plantilla_id'>{c('Plantilla base', 'Base template')}</Label>
         <select
           id='plantilla_id'
           value={form.plantilla_id ?? ''}
           onChange={(event) => applyPlantilla(event.target.value)}
           className='h-10 rounded-md border border-input bg-background px-3 text-sm'
         >
-          <option value=''>Sin plantilla</option>
+          <option value=''>{c('Sin plantilla', 'No template')}</option>
           {plantillas.map((plantilla) => (
             <option key={plantilla.id} value={plantilla.id}>
               {plantilla.nombre}
@@ -201,13 +244,13 @@ export default function NotificacionForm({
         </select>
         {selectedPlantilla ? (
           <p className='text-xs text-muted-foreground'>
-            Se cargaron asunto, cuerpo, tipo y canal desde la plantilla seleccionada.
+            {c('Se cargaron asunto, cuerpo, tipo y canal desde la plantilla seleccionada.', 'Subject, body, type and channel were loaded from the selected template.')}
           </p>
         ) : null}
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='titulo'>Título interno</Label>
+        <Label htmlFor='titulo'>{c('Título interno', 'Internal title')}</Label>
         <Input
           id='titulo'
           value={form.titulo}
@@ -217,7 +260,7 @@ export default function NotificacionForm({
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='asunto'>Asunto / título visible</Label>
+        <Label htmlFor='asunto'>{c('Asunto / título visible', 'Subject / visible title')}</Label>
         <Input
           id='asunto'
           value={form.asunto}
@@ -227,7 +270,7 @@ export default function NotificacionForm({
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='tipo'>Tipo</Label>
+        <Label htmlFor='tipo'>{c('Tipo', 'Type')}</Label>
         <select
           id='tipo'
           value={form.tipo}
@@ -236,14 +279,14 @@ export default function NotificacionForm({
         >
           {tipos.map((tipo) => (
             <option key={tipo.value} value={tipo.value}>
-              {tipo.label}
+              {optionLabel(locale, tipo.label)}
             </option>
           ))}
         </select>
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='canal'>Canal</Label>
+        <Label htmlFor='canal'>{c('Canal', 'Channel')}</Label>
         <select
           id='canal'
           value={form.canal}
@@ -252,7 +295,7 @@ export default function NotificacionForm({
         >
           {canales.map((canal) => (
             <option key={canal.value} value={canal.value}>
-              {canal.label}
+              {optionLabel(locale, canal.label)}
             </option>
           ))}
         </select>
@@ -260,7 +303,7 @@ export default function NotificacionForm({
 
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='estado'>Estado</Label>
+        <Label htmlFor='estado'>{c('Estado', 'Status')}</Label>
         <select
           id='estado'
           value={form.estado ?? 'borrador'}
@@ -269,14 +312,14 @@ export default function NotificacionForm({
         >
           {estadosNotificacion.map((estado) => (
             <option key={estado.value} value={estado.value}>
-              {estado.label}
+              {optionLabel(locale, estado.label)}
             </option>
           ))}
         </select>
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='destinatario_segmento'>Destinatarios</Label>
+        <Label htmlFor='destinatario_segmento'>{c('Destinatarios', 'Recipients')}</Label>
         <select
           id='destinatario_segmento'
           value={form.destinatario_segmento}
@@ -285,14 +328,14 @@ export default function NotificacionForm({
         >
           {segmentos.map((segmento) => (
             <option key={segmento.value} value={segmento.value}>
-              {segmento.label}
+              {optionLabel(locale, segmento.label)}
             </option>
           ))}
         </select>
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='fecha_programada'>Visible desde / fecha programada</Label>
+        <Label htmlFor='fecha_programada'>{c('Visible desde / fecha programada', 'Visible from / scheduled date')}</Label>
         <Input
           id='fecha_programada'
           type='datetime-local'
@@ -303,18 +346,18 @@ export default function NotificacionForm({
 
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='fecha_vigencia_hasta'>Fecha/hora visible hasta</Label>
+        <Label htmlFor='fecha_vigencia_hasta'>{c('Fecha/hora visible hasta', 'Visible until date/time')}</Label>
         <Input
           id='fecha_vigencia_hasta'
           type='datetime-local'
           value={form.fecha_vigencia_hasta ?? ''}
           onChange={(event) => updateField('fecha_vigencia_hasta', event.target.value)}
         />
-        <p className='text-xs text-muted-foreground'>Usá este campo para que promociones vencidas no sigan apareciendo en Terminal.</p>
+        <p className='text-xs text-muted-foreground'>{c('Usá este campo para que promociones vencidas no sigan apareciendo en Terminal.', 'Use this field so expired promotions stop appearing in the terminal.')}</p>
       </div>
 
       <div className='flex flex-col gap-1.5 md:col-span-2'>
-        <Label htmlFor='cuerpo'>Mensaje</Label>
+        <Label htmlFor='cuerpo'>{c('Mensaje', 'Message')}</Label>
         <textarea
           id='cuerpo'
           value={form.cuerpo}
@@ -328,9 +371,9 @@ export default function NotificacionForm({
       <div className='rounded-xl border bg-muted/30 p-4 md:col-span-2'>
         <div className='mb-3 flex items-center justify-between gap-4'>
           <div>
-            <h3 className='font-semibold'>Salida en Terminal de asistencia</h3>
+            <h3 className='font-semibold'>{c('Salida en Terminal de asistencia', 'Attendance terminal output')}</h3>
             <p className='text-xs text-muted-foreground'>
-              Base para avisos/promociones en el panel derecho sin ocultar el QR.
+              {c('Base para avisos/promociones en el panel derecho sin ocultar el QR.', 'Base for alerts/promotions in the right panel without hiding the QR.')}
             </p>
           </div>
           <label className='flex items-center gap-2 text-sm font-medium'>
@@ -339,7 +382,7 @@ export default function NotificacionForm({
               checked={Boolean(form.mostrar_terminal)}
               onChange={(event) => updateField('mostrar_terminal', event.target.checked)}
             />
-            Mostrar en Terminal
+            {c('Mostrar en Terminal', 'Show in terminal')}
           </label>
         </div>
 
@@ -350,11 +393,11 @@ export default function NotificacionForm({
               checked={Boolean(form.terminal_visible)}
               onChange={(event) => updateField('terminal_visible', event.target.checked)}
             />
-            Visible/habilitada
+            {c('Visible/habilitada', 'Visible/enabled')}
           </label>
 
           <div className='flex flex-col gap-1.5'>
-            <Label htmlFor='terminal_color_neon'>Color neón</Label>
+            <Label htmlFor='terminal_color_neon'>{c('Color neón', 'Neon color')}</Label>
             <select
               id='terminal_color_neon'
               value={form.terminal_color_neon ?? 'verde_fluo'}
@@ -363,14 +406,14 @@ export default function NotificacionForm({
             >
               {coloresNeon.map((color) => (
                 <option key={color.value} value={color.value}>
-                  {color.label}
+                  {optionLabel(locale, color.label)}
                 </option>
               ))}
             </select>
           </div>
 
           <div className='flex flex-col gap-1.5'>
-            <Label htmlFor='terminal_duracion_segundos'>Duración en pantalla (segundos)</Label>
+            <Label htmlFor='terminal_duracion_segundos'>{c('Duración en pantalla (segundos)', 'On-screen duration (seconds)')}</Label>
             <Input
               id='terminal_duracion_segundos'
               type='number'
@@ -381,7 +424,7 @@ export default function NotificacionForm({
           </div>
 
           <div className='flex flex-col gap-1.5'>
-            <Label htmlFor='terminal_frecuencia_segundos'>Frecuencia de aparición (segundos)</Label>
+            <Label htmlFor='terminal_frecuencia_segundos'>{c('Frecuencia de aparición (segundos)', 'Appearance frequency (seconds)')}</Label>
             <Input
               id='terminal_frecuencia_segundos'
               type='number'
@@ -392,7 +435,7 @@ export default function NotificacionForm({
           </div>
 
           <div className='flex flex-col gap-1.5 md:col-span-2'>
-            <Label htmlFor='terminal_imagen_url'>URL de imagen/banner</Label>
+            <Label htmlFor='terminal_imagen_url'>{c('URL de imagen/banner', 'Image/banner URL')}</Label>
             <Input
               id='terminal_imagen_url'
               value={form.terminal_imagen_url ?? ''}
@@ -400,7 +443,7 @@ export default function NotificacionForm({
               placeholder='https://...'
             />
             <p className='text-xs text-muted-foreground'>
-              Recomendación visual: relación de aspecto 5:4. Si no hay imagen, se usará el logo del gimnasio y luego el logo de Gym Master como fallback.
+              {c('Recomendación visual: relación de aspecto 5:4. Si no hay imagen, se usará el logo del gimnasio y luego el logo de Gym Master como fallback.', 'Visual recommendation: 5:4 aspect ratio. If there is no image, the gym logo and then the Gym Master logo will be used as fallback.')}
             </p>
           </div>
         </div>
@@ -408,7 +451,7 @@ export default function NotificacionForm({
 
       <div className='flex justify-end md:col-span-2'>
         <Button type='submit' disabled={loading}>
-          {loading ? 'Guardando...' : notificacion ? 'Guardar cambios' : 'Crear notificación'}
+          {loading ? c('Guardando...', 'Saving...') : notificacion ? c('Guardar cambios', 'Save changes') : c('Crear notificación', 'Create notification')}
         </Button>
       </div>
     </form>

--- a/src/components/forms/OtrosGastosForm.tsx
+++ b/src/components/forms/OtrosGastosForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { QaFileNameBadge } from "@/components/qa/QaFileNameBadge";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -21,7 +21,7 @@ import {
 import { toast } from "sonner";
 import { FileUp, Link as LinkIcon } from "lucide-react";
 import { useI18n } from '@/i18n/I18nProvider';
-import { translateCommercialUi } from '@/i18n/commercialUi';
+import { getOtrosGastosTipoLabel, translateOtrosGastosUi } from '@/utils/otrosGastosI18n';
 
 export interface OtrosGastosFormProps {
   gasto?: OtrosGastos | null;
@@ -73,12 +73,13 @@ function normalizeNullable(value?: string | null) {
 
 export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormProps) {
   const { locale } = useI18n();
-  const c = (text: string) => translateCommercialUi(locale, text);
+  const c = (text: string) => translateOtrosGastosUi(locale, text);
 
   const [form, setForm] = useState<CreateOtrosGastosDto>(emptyForm);
   const [tiposGasto, setTiposGasto] = useState<TipoGastoLite[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const receiptFileInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     async function loadCatalogos() {
@@ -157,9 +158,9 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         comprobante_nombre: uploaded.originalName,
         comprobante_mime_type: uploaded.mimeType,
       }));
-      toast.success("Comprobante subido correctamente");
+      toast.success(c("Comprobante subido correctamente"));
     } catch (error: any) {
-      toast.error(error?.message || "Error al subir comprobante");
+      toast.error(error?.message || c("Error al subir comprobante"));
     } finally {
       setUploading(false);
       event.target.value = "";
@@ -193,15 +194,15 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
       const payload = buildPayload();
       if (gasto?.id) {
         await updateOtrosGastos(gasto.id, payload);
-        toast.success("Gasto actualizado");
+        toast.success(c("Gasto actualizado"));
       } else {
         await createOtrosGastos(payload);
-        toast.success("Gasto creado");
+        toast.success(c("Gasto creado"));
       }
       setForm(emptyForm);
       onCreated();
     } catch (error: any) {
-      toast.error(error?.message || "Error al guardar gasto");
+      toast.error(error?.message || c("Error al guardar gasto"));
     } finally {
       setLoading(false);
     }
@@ -213,7 +214,7 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
 
       <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="space-y-2 md:col-span-2">
-          <Label htmlFor="descripcion">Descripción *</Label>
+          <Label htmlFor="descripcion">{c("Descripción *")}</Label>
           <Input
             id="descripcion"
             name="descripcion"
@@ -225,28 +226,28 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="id_tipo_gasto">Tipo de gasto</Label>
+          <Label htmlFor="id_tipo_gasto">{c("Tipo de gasto")}</Label>
           <select
             id="id_tipo_gasto"
             name="id_tipo_gasto"
             value={form.id_tipo_gasto ?? ""}
             onChange={handleChange}
-            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-950"
           >
-            <option value="">Sin clasificar</option>
+            <option value="">{c("Sin clasificar")}</option>
             {tiposGasto.map((tipo) => (
               <option key={tipo.id} value={tipo.id}>
-                {tipo.nombre}
+                {getOtrosGastosTipoLabel(locale, tipo.nombre)}
               </option>
             ))}
           </select>
           {selectedTipo?.descripcion ? (
-            <p className="text-xs text-muted-foreground">{selectedTipo.descripcion}</p>
+            <p className="text-xs text-muted-foreground">{getOtrosGastosTipoLabel(locale, selectedTipo.descripcion)}</p>
           ) : null}
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="monto">Monto *</Label>
+          <Label htmlFor="monto">{c("Monto *")}</Label>
           <Input
             id="monto"
             name="monto"
@@ -260,12 +261,12 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="fecha">Fecha del gasto *</Label>
+          <Label htmlFor="fecha">{c("Fecha del gasto *")}</Label>
           <Input id="fecha" name="fecha" type="date" value={form.fecha} onChange={handleChange} required />
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="fecha_vencimiento">Fecha de vencimiento</Label>
+          <Label htmlFor="fecha_vencimiento">{c("Fecha de vencimiento")}</Label>
           <Input
             id="fecha_vencimiento"
             name="fecha_vencimiento"
@@ -276,7 +277,7 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="fecha_pago">Fecha de pago</Label>
+          <Label htmlFor="fecha_pago">{c("Fecha de pago")}</Label>
           <Input
             id="fecha_pago"
             name="fecha_pago"
@@ -287,41 +288,41 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="estado">Estado</Label>
+          <Label htmlFor="estado">{c("Estado")}</Label>
           <select
             id="estado"
             name="estado"
             value={form.estado ?? "pagado"}
             onChange={handleChange}
-            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-950"
           >
             {estados.map((estado) => (
               <option key={estado.value} value={estado.value}>
-                {estado.label}
+                {c(estado.label)}
               </option>
             ))}
           </select>
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="medio_pago">Medio de pago</Label>
+          <Label htmlFor="medio_pago">{c("Medio de pago")}</Label>
           <select
             id="medio_pago"
             name="medio_pago"
             value={form.medio_pago ?? "efectivo"}
             onChange={handleChange}
-            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            className="h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-950"
           >
             {mediosPago.map((medio) => (
               <option key={medio.value} value={medio.value}>
-                {medio.label}
+                {c(medio.label)}
               </option>
             ))}
           </select>
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="proveedor_nombre">Proveedor / entidad</Label>
+          <Label htmlFor="proveedor_nombre">{c("Proveedor / entidad")}</Label>
           <Input
             id="proveedor_nombre"
             name="proveedor_nombre"
@@ -332,18 +333,18 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="numero_comprobante">Nº comprobante / factura</Label>
+          <Label htmlFor="numero_comprobante">{c("Nº comprobante / factura")}</Label>
           <Input
             id="numero_comprobante"
             name="numero_comprobante"
             value={form.numero_comprobante ?? ""}
             onChange={handleChange}
-            placeholder="Factura, ticket, transferencia..."
+            placeholder={c("Factura, ticket, transferencia...")}
           />
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="periodo_desde">Período desde</Label>
+          <Label htmlFor="periodo_desde">{c("Período desde")}</Label>
           <Input
             id="periodo_desde"
             name="periodo_desde"
@@ -354,7 +355,7 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="periodo_hasta">Período hasta</Label>
+          <Label htmlFor="periodo_hasta">{c("Período hasta")}</Label>
           <Input
             id="periodo_hasta"
             name="periodo_hasta"
@@ -365,66 +366,83 @@ export default function OtrosGastosForm({ gasto, onCreated }: OtrosGastosFormPro
         </div>
       </section>
 
-      <section className="rounded-xl border bg-muted/20 p-4">
+      <section className="rounded-xl border bg-muted/20 p-4 dark:border-neutral-800 dark:bg-neutral-950/60">
         <div className="mb-3 flex items-center gap-2">
           <FileUp className="h-4 w-4 text-sky-600" />
-          <h3 className="font-semibold">Comprobante</h3>
+          <h3 className="font-semibold">{c("Comprobante")}</h3>
         </div>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="comprobante_file">Subir PDF o imagen</Label>
-            <Input
+            <Label htmlFor="comprobante_file">{c("Subir PDF o imagen")}</Label>
+            <input
+              ref={receiptFileInputRef}
               id="comprobante_file"
               type="file"
               accept="application/pdf,image/png,image/jpeg,image/webp,image/gif,image/heic,image/heif"
               onChange={handleFileChange}
               disabled={uploading}
+              className="sr-only"
             />
+            <div className="flex flex-col gap-2 rounded-md border border-input bg-background p-2 dark:border-neutral-800 dark:bg-neutral-950 sm:flex-row sm:items-center">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={uploading}
+                onClick={() => receiptFileInputRef.current?.click()}
+                className="justify-start sm:w-auto"
+              >
+                <FileUp className="mr-2 h-4 w-4" />
+                {uploading ? c("Subiendo...") : c("Seleccionar archivo")}
+              </Button>
+              <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground dark:text-neutral-400">
+                {form.comprobante_nombre || c("Sin archivo seleccionado")}
+              </span>
+            </div>
             <p className="text-xs text-muted-foreground">
-              Formatos permitidos: PDF, PNG, JPG, WEBP, GIF, HEIC/HEIF. Máximo 10MB.
+              {c("Formatos permitidos: PDF, PNG, JPG, WEBP, GIF, HEIC/HEIF. Máximo 10MB.")}
             </p>
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="comprobante_url">URL del comprobante</Label>
+            <Label htmlFor="comprobante_url">{c("URL del comprobante")}</Label>
             <div className="flex gap-2">
               <Input
                 id="comprobante_url"
                 name="comprobante_url"
                 value={form.comprobante_url ?? ""}
                 onChange={handleChange}
-                placeholder="URL de Cloudinary o comprobante externo"
+                placeholder={c("URL de Cloudinary o comprobante externo")}
               />
               {form.comprobante_url ? (
                 <Button type="button" variant="outline" asChild>
-                  <a href={form.comprobante_url} target="_blank" rel="noreferrer" title="Abrir comprobante">
+                  <a href={form.comprobante_url} target="_blank" rel="noreferrer" title={c("Abrir comprobante")}>
                     <LinkIcon className="h-4 w-4" />
                   </a>
                 </Button>
               ) : null}
             </div>
             {form.comprobante_nombre ? (
-              <p className="text-xs text-muted-foreground">Archivo: {form.comprobante_nombre}</p>
+              <p className="text-xs text-muted-foreground">{c("Archivo:")} {form.comprobante_nombre}</p>
             ) : null}
           </div>
         </div>
       </section>
 
       <div className="space-y-2">
-        <Label htmlFor="observaciones">Observaciones</Label>
+        <Label htmlFor="observaciones">{c("Observaciones")}</Label>
         <textarea
           id="observaciones"
           name="observaciones"
           value={form.observaciones ?? ""}
           onChange={handleChange}
           rows={3}
-          placeholder="Notas internas, detalle del gasto, condiciones de pago..."
-          className="min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm"
+          placeholder={c("Notas internas, detalle del gasto, condiciones de pago...")}
+          className="min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm dark:border-neutral-800 dark:bg-neutral-950"
         />
       </div>
 
       <Button type="submit" disabled={loading || uploading} className="w-full bg-[#02a8e1] hover:bg-[#0288b1]">
-        {loading ? c("Guardando...") : gasto ? "Actualizar Gasto" : "Crear Gasto"}
+        {loading ? c("Guardando...") : gasto ? c("Actualizar Gasto") : c("Crear Gasto")}
       </Button>
     </form>
   );

--- a/src/components/forms/PagoForm.tsx
+++ b/src/components/forms/PagoForm.tsx
@@ -13,23 +13,34 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Check, ChevronsUpDown } from "lucide-react";
 import {
   createPagoManualApi,
   fetchPagoFormOptionsApi,
   updatePagoApi,
 } from "@/services/browser/pagoApiClient";
-import { PagoManualFormOptions, ResponsePago } from "@/interfaces/pago.interface";
+import {
+  PagoManualFormOptions,
+  ResponsePago,
+} from "@/interfaces/pago.interface";
 import { CatalogoParametrizableItem } from "@/interfaces/parametrizacion.interface";
 import { useCatalogoParametrizable } from "@/hooks/useCatalogosParametrizables";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { calcularDescuentoPago, formatDiscountPercent } from "@/lib/cuotas/descuentoPago";
+import {
+  calcularDescuentoPago,
+  formatDiscountPercent,
+} from "@/lib/cuotas/descuentoPago";
 import {
   combinarDescuentosPago,
   resolveBonificacionMensualForPeriod,
 } from "@/lib/cuotas/descuentoPagoBonificacion";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export interface PagoFormProps {
   pago?: ResponsePago | null;
@@ -95,6 +106,64 @@ function normalizeMedioPagoIdForPayload(value?: string | null) {
   return value;
 }
 
+function normalizeLabel(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function getPaymentMethodLabel(
+  value: string | null | undefined,
+  isEnglish: boolean,
+) {
+  if (!isEnglish) return value ?? "-";
+  const normalized = normalizeLabel(value);
+  const labels: Record<string, string> = {
+    efectivo: "Cash",
+    transferencia: "Bank transfer",
+    stripe: "Stripe",
+    mercado_pago: "Mercado Pago",
+    "mercado pago": "Mercado Pago",
+    tarjeta: "Card",
+    debito: "Debit card",
+    débito: "Debit card",
+    credito: "Credit card",
+    crédito: "Credit card",
+    otro: "Other",
+  };
+  return labels[normalized] ?? value ?? "-";
+}
+
+function translatePaymentPreviewMessage(
+  message: string | null | undefined,
+  isEnglish: boolean,
+) {
+  if (!message) return null;
+  if (!isEnglish) return message;
+
+  const advanceDiscountMatch = message.match(
+    /Pagando\s+(\d+)\s+o\s+m[aá]s\s+cuotas(?:\s+por\s+adelantado)?\s+obten[eé]s\s+([\d.,]+)%\s+de\s+descuento\.?/i,
+  );
+  if (advanceDiscountMatch) {
+    return `Paying ${advanceDiscountMatch[1]} or more fees in advance gives you ${advanceDiscountMatch[2]}% discount.`;
+  }
+
+  const appliesDiscountMatch = message.match(
+    /Pagando\s+(\d+)\s+o\s+m[aá]s\s+cuotas\s+se\s+aplicar[aá]\s+([\d.,]+)%\s+de\s+descuento\.?/i,
+  );
+  if (appliesDiscountMatch) {
+    return `Paying ${appliesDiscountMatch[1]} or more fees applies ${appliesDiscountMatch[2]}% discount.`;
+  }
+
+  return message
+    .replace(/Pagando/gi, "Paying")
+    .replace(/o más cuotas por adelantado obtenés/gi, "or more fees in advance gives you")
+    .replace(/o mas cuotas por adelantado obtenes/gi, "or more fees in advance gives you")
+    .replace(/o más cuotas se aplicará/gi, "or more fees applies")
+    .replace(/de descuento/gi, "discount")
+    .replace(/Bonificación mensual activa para este socio/gi, "Active monthly bonus for this member");
+}
+
 const emptyForm = {
   socio_id: "",
   cuota_id: "",
@@ -113,6 +182,9 @@ const emptyForm = {
 };
 
 export default function PagoForm({ pago, onCreated }: PagoFormProps) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
   const [form, setForm] = useState(emptyForm);
   const [options, setOptions] = useState<PagoManualFormOptions>({
     socios: [],
@@ -124,7 +196,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
   const [socioComboboxOpen, setSocioComboboxOpen] = useState(false);
   const { items: mediosPago } = useCatalogoParametrizable(
     "medio_pago",
-    fallbackMediosPago
+    fallbackMediosPago,
   );
 
   useEffect(() => {
@@ -142,7 +214,13 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
           cuota_id: prev.cuota_id || defaultCuotaId,
         }));
       } catch (error: any) {
-        toast.error(error.message || "Error al cargar opciones de pago");
+        toast.error(
+          error.message ||
+            tx(
+              "Error al cargar opciones de pago",
+              "Error loading payment options",
+            ),
+        );
       } finally {
         if (mounted) setLoadingOptions(false);
       }
@@ -158,7 +236,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
     if (pago) {
       const metodoPago = pago.metodo_pago ?? "efectivo";
       const medioPago = mediosPago.find(
-        (item) => item.codigo === metodoPago || item.id === pago.id_medio_pago
+        (item) => item.codigo === metodoPago || item.id === pago.id_medio_pago,
       );
 
       setForm({
@@ -167,7 +245,9 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         fecha_pago: pago.fecha_pago ?? todayIso(),
         periodo_desde: pago.periodo_desde ?? pago.fecha_pago ?? todayIso(),
         periodo_hasta:
-          pago.periodo_hasta ?? pago.fecha_vencimiento ?? addMonthsIso(todayIso(), 1),
+          pago.periodo_hasta ??
+          pago.fecha_vencimiento ??
+          addMonthsIso(todayIso(), 1),
         meses_cubiertos: pago.meses_cubiertos ?? 1,
         subtotal: pago.subtotal ?? pago.monto_pagado ?? 0,
         descuento_porcentaje: pago.descuento_porcentaje ?? 0,
@@ -184,7 +264,8 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         id_medio_pago:
           prev.id_medio_pago ||
           mediosPago.find((item) => item.codigo === prev.metodo_pago)?.id ||
-          mediosPago.find((item) => item.codigo === emptyForm.metodo_pago)?.id ||
+          mediosPago.find((item) => item.codigo === emptyForm.metodo_pago)
+            ?.id ||
           "",
       }));
     }
@@ -192,7 +273,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
 
   const selectedSocio = useMemo(
     () => options.socios.find((socio) => socio.id_socio === form.socio_id),
-    [form.socio_id, options.socios]
+    [form.socio_id, options.socios],
   );
 
   const selectedCuota = useMemo(
@@ -200,7 +281,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
       options.cuotas.find((cuota) => cuota.id === form.cuota_id) ??
       options.cuotas[0] ??
       null,
-    [form.cuota_id, options.cuotas]
+    [form.cuota_id, options.cuotas],
   );
 
   const descuentoPreview = useMemo(
@@ -210,7 +291,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         mesesCubiertos: Number(form.meses_cubiertos || 1),
         config: options.descuento_config,
       }),
-    [selectedCuota?.monto, form.meses_cubiertos, options.descuento_config]
+    [selectedCuota?.monto, form.meses_cubiertos, options.descuento_config],
   );
 
   const bonificacionMensualActiva = useMemo(
@@ -220,7 +301,12 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         fechaReferencia: form.periodo_desde || form.fecha_pago,
         bonificaciones: options.bonificaciones_mensuales,
       }),
-    [form.fecha_pago, form.periodo_desde, form.socio_id, options.bonificaciones_mensuales]
+    [
+      form.fecha_pago,
+      form.periodo_desde,
+      form.socio_id,
+      options.bonificaciones_mensuales,
+    ],
   );
 
   const pagoPreview = useMemo(
@@ -229,7 +315,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         previewPagoAdelantado: descuentoPreview,
         bonificacionMensual: bonificacionMensualActiva,
       }),
-    [bonificacionMensualActiva, descuentoPreview]
+    [bonificacionMensualActiva, descuentoPreview],
   );
 
   const descuentoConfigActivo =
@@ -258,7 +344,9 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
   ]);
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
   ) => {
     const { name, value } = e.target;
 
@@ -277,18 +365,26 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
 
       if (name === "fecha_pago") {
         next.periodo_desde = value;
-        next.periodo_hasta = addMonthsIso(value, Number(next.meses_cubiertos || 1));
+        next.periodo_hasta = addMonthsIso(
+          value,
+          Number(next.meses_cubiertos || 1),
+        );
       }
 
       if (name === "periodo_desde" || name === "meses_cubiertos") {
         next.periodo_hasta = addMonthsIso(
           name === "periodo_desde" ? value : next.periodo_desde,
-          Number(name === "meses_cubiertos" ? value : next.meses_cubiertos || 1)
+          Number(
+            name === "meses_cubiertos" ? value : next.meses_cubiertos || 1,
+          ),
         );
       }
 
       if (name === "monto_pagado") {
-        next.descuento_monto = Math.max(Number(next.subtotal || 0) - Number(value || 0), 0);
+        next.descuento_monto = Math.max(
+          Number(next.subtotal || 0) - Number(value || 0),
+          0,
+        );
       }
 
       return next;
@@ -316,7 +412,12 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
     e.preventDefault();
 
     if (!form.socio_id) {
-      toast.error("Seleccioná un socio para registrar el pago");
+      toast.error(
+        tx(
+          "Seleccioná un socio para registrar el pago",
+          "Select a member to register the payment",
+        ),
+      );
       return;
     }
 
@@ -330,26 +431,33 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
 
       if (pago?.id) {
         await updatePagoApi(pago.id, payload);
-        toast.success("Pago actualizado");
+        toast.success(tx("Pago actualizado", "Payment updated"));
       } else {
         await createPagoManualApi(payload);
-        toast.success("Pago manual registrado");
+        toast.success(
+          tx("Pago manual registrado", "Manual payment registered"),
+        );
       }
 
       setForm(emptyForm);
       onCreated();
     } catch (error: any) {
-      toast.error(error.message || "Error al guardar pago");
+      toast.error(
+        error.message || tx("Error al guardar pago", "Error saving payment"),
+      );
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <form
+      onSubmit={handleSubmit}
+      className="grid grid-cols-1 gap-4 md:grid-cols-2"
+    >
       <QaFileNameBadge file="src/components/forms/PagoForm.tsx" />
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="socio_id">Socio</Label>
+        <Label htmlFor="socio_id">{tx("Socio", "Member")}</Label>
         <Popover open={socioComboboxOpen} onOpenChange={setSocioComboboxOpen}>
           <PopoverTrigger asChild>
             <Button
@@ -361,17 +469,25 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
               disabled={loadingOptions || Boolean(pago)}
               className={cn(
                 "h-10 w-full justify-between px-3 text-left font-normal",
-                !selectedSocio && "text-muted-foreground"
+                !selectedSocio && "text-muted-foreground",
               )}
             >
               <span className="truncate">
                 {selectedSocio
                   ? `${selectedSocio.nombre_completo}${
-                      selectedSocio.activo ? "" : " (inactivo / regularizar)"
+                      selectedSocio.activo
+                        ? ""
+                        : tx(
+                            " (inactivo / regularizar)",
+                            " (inactive / regularize)",
+                          )
                     }`
                   : loadingOptions
-                    ? "Cargando socios..."
-                    : "Buscar o seleccionar socio"}
+                    ? tx("Cargando socios...", "Loading members...")
+                    : tx(
+                        "Buscar o seleccionar socio",
+                        "Search or select member",
+                      )}
               </span>
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
@@ -381,13 +497,26 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
             className="w-[var(--radix-popover-trigger-width)] min-w-[320px] p-0"
           >
             <Command>
-              <CommandInput placeholder="Buscar por nombre o email..." className="h-9" />
+              <CommandInput
+                placeholder={tx(
+                  "Buscar por nombre o email...",
+                  "Search by name or email...",
+                )}
+                className="h-9"
+              />
               <CommandList className="max-h-[320px]">
-                <CommandEmpty>No se encontraron socios.</CommandEmpty>
+                <CommandEmpty>
+                  {tx("No se encontraron socios.", "No members found.")}
+                </CommandEmpty>
                 <CommandGroup>
                   {options.socios.map((socio) => {
                     const socioLabel = `${socio.nombre_completo}${
-                      socio.activo ? "" : " (inactivo / regularizar)"
+                      socio.activo
+                        ? ""
+                        : tx(
+                            " (inactivo / regularizar)",
+                            " (inactive / regularize)",
+                          )
                     }`;
                     const searchValue = `${socio.nombre_completo} ${
                       socio.email ?? ""
@@ -410,7 +539,9 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
                         <Check
                           className={cn(
                             "ml-auto h-4 w-4",
-                            form.socio_id === socio.id_socio ? "opacity-100" : "opacity-0"
+                            form.socio_id === socio.id_socio
+                              ? "opacity-100"
+                              : "opacity-0",
                           )}
                         />
                       </CommandItem>
@@ -423,13 +554,16 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         </Popover>
         {!pago ? (
           <p className="text-xs text-muted-foreground">
-            Escribí el nombre o email para encontrar al socio sin recorrer todo el listado.
+            {tx(
+              "Escribí el nombre o email para encontrar al socio sin recorrer todo el listado.",
+              "Type the name or email to find the member without browsing the full list.",
+            )}
           </p>
         ) : null}
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="cuota_id">Cuota</Label>
+        <Label htmlFor="cuota_id">{tx("Cuota", "Fee")}</Label>
         <select
           id="cuota_id"
           name="cuota_id"
@@ -438,17 +572,22 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
           disabled={loadingOptions || Boolean(pago)}
           className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
         >
-          <option value="">Cuota vigente / última activa</option>
+          <option value="">
+            {tx("Cuota vigente / última activa", "Current fee / last active")}
+          </option>
           {options.cuotas.map((cuota) => (
             <option key={cuota.id} value={cuota.id}>
-              {cuota.descripcion} - ${Number(cuota.monto).toLocaleString("es-AR")}
+              {cuota.descripcion} - $
+              {Number(cuota.monto).toLocaleString("es-AR")}
             </option>
           ))}
         </select>
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha_pago">Fecha de pago</Label>
+        <Label htmlFor="fecha_pago">
+          {tx("Fecha de pago", "Payment date")}
+        </Label>
         <Input
           id="fecha_pago"
           name="fecha_pago"
@@ -460,7 +599,9 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="meses_cubiertos">Meses cubiertos</Label>
+        <Label htmlFor="meses_cubiertos">
+          {tx("Meses cubiertos", "Covered months")}
+        </Label>
         <Input
           id="meses_cubiertos"
           name="meses_cubiertos"
@@ -474,7 +615,9 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="periodo_desde">Cubre desde</Label>
+        <Label htmlFor="periodo_desde">
+          {tx("Cubre desde", "Covers from")}
+        </Label>
         <Input
           id="periodo_desde"
           name="periodo_desde"
@@ -486,7 +629,7 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="periodo_hasta">Cubre hasta</Label>
+        <Label htmlFor="periodo_hasta">{tx("Cubre hasta", "Covers to")}</Label>
         <Input
           id="periodo_hasta"
           name="periodo_hasta"
@@ -498,12 +641,14 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="monto_pagado">Monto pagado</Label>
+        <Label htmlFor="monto_pagado">
+          {tx("Monto pagado", "Amount paid")}
+        </Label>
         <Input
           id="monto_pagado"
           name="monto_pagado"
           type="number"
-          placeholder="Monto pagado"
+          placeholder={tx("Monto pagado", "Amount paid")}
           value={form.monto_pagado}
           onChange={handleChange}
           required
@@ -511,39 +656,59 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
         />
       </div>
 
-      {(descuentoConfigActivo || pagoPreview.bonificacion_mensual_aplicada) ? (
-        <div className="rounded-xl border border-cyan-200 bg-cyan-50 p-3 text-sm text-cyan-900 md:col-span-2">
+      {descuentoConfigActivo || pagoPreview.bonificacion_mensual_aplicada ? (
+        <div className="rounded-xl border border-cyan-200 bg-cyan-50 p-3 text-sm text-cyan-900 dark:border-cyan-900/70 dark:bg-cyan-950/35 dark:text-cyan-100 md:col-span-2">
           <p className="font-semibold">
-            Descuentos y bonificación aplicados
+            {tx(
+              "Descuentos y bonificación aplicados",
+              "Applied discounts and bonus",
+            )}
           </p>
           <p className="mt-1">
-            {pagoPreview.mensaje ??
-              `Pagando ${options.descuento_config?.cuotas_minimas ?? 2} o más cuotas se aplicará ${formatDiscountPercent(
-                Number(options.descuento_config?.porcentaje ?? 0)
-              )} de descuento.`}
+            {translatePaymentPreviewMessage(pagoPreview.mensaje, isEnglish) ??
+              `${tx("Pagando", "Paying")} ${options.descuento_config?.cuotas_minimas ?? 2} ${tx("o más cuotas se aplicará", "or more fees applies")} ${formatDiscountPercent(
+                Number(options.descuento_config?.porcentaje ?? 0),
+              )} ${tx("de descuento", "discount")}.`}
           </p>
           {pagoPreview.bonificacion_mensual_aplicada ? (
-            <p className="mt-2 rounded-lg bg-white/70 px-3 py-2 text-xs font-medium text-cyan-900">
-              Bonificación mensual activa para este socio: {formatDiscountPercent(pagoPreview.bonificacion_mensual_porcentaje ?? 0)}.
+            <p className="mt-2 rounded-lg bg-white/70 px-3 py-2 text-xs font-medium text-cyan-900 dark:bg-neutral-900/80 dark:text-cyan-100">
+              {tx(
+                "Bonificación mensual activa para este socio",
+                "Active monthly bonus for this member",
+              )}
+              :{" "}
+              {formatDiscountPercent(
+                pagoPreview.bonificacion_mensual_porcentaje ?? 0,
+              )}
+              .
             </p>
           ) : null}
           <div className="mt-3 grid gap-2 text-xs md:grid-cols-4">
             <div>
-              <span className="text-cyan-700">Subtotal</span>
-              <p className="font-semibold">{formatMoney(pagoPreview.subtotal)}</p>
-            </div>
-            <div>
-              <span className="text-cyan-700">Descuento</span>
+              <span className="text-cyan-700 dark:text-cyan-300">Subtotal</span>
               <p className="font-semibold">
-                {formatMoney(pagoPreview.descuento_monto)} ({formatDiscountPercent(pagoPreview.descuento_porcentaje)})
+                {formatMoney(pagoPreview.subtotal)}
               </p>
             </div>
             <div>
-              <span className="text-cyan-700">Total sugerido</span>
+              <span className="text-cyan-700 dark:text-cyan-300">
+                {tx("Descuento", "Discount")}
+              </span>
+              <p className="font-semibold">
+                {formatMoney(pagoPreview.descuento_monto)} (
+                {formatDiscountPercent(pagoPreview.descuento_porcentaje)})
+              </p>
+            </div>
+            <div>
+              <span className="text-cyan-700 dark:text-cyan-300">
+                {tx("Total sugerido", "Suggested total")}
+              </span>
               <p className="font-semibold">{formatMoney(pagoPreview.total)}</p>
             </div>
             <div>
-              <span className="text-cyan-700">Meses cubiertos</span>
+              <span className="text-cyan-700 dark:text-cyan-300">
+                {tx("Meses cubiertos", "Covered months")}
+              </span>
               <p className="font-semibold">{form.meses_cubiertos}</p>
             </div>
           </div>
@@ -551,38 +716,51 @@ export default function PagoForm({ pago, onCreated }: PagoFormProps) {
       ) : null}
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="id_medio_pago">Método de pago</Label>
+        <Label htmlFor="id_medio_pago">
+          {tx("Método de pago", "Payment method")}
+        </Label>
         <select
           id="id_medio_pago"
           name="id_medio_pago"
-          value={form.id_medio_pago || mediosPago.find((item) => item.codigo === form.metodo_pago)?.id || form.metodo_pago}
+          value={
+            form.id_medio_pago ||
+            mediosPago.find((item) => item.codigo === form.metodo_pago)?.id ||
+            form.metodo_pago
+          }
           onChange={(e) => handleMedioPagoChange(e.target.value)}
           className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
         >
           {mediosPago.map((medio) => (
             <option key={medio.id} value={medio.id}>
-              {medio.nombre}
-              {medio.es_online ? " (online)" : ""}
+              {getPaymentMethodLabel(medio.codigo || medio.nombre, isEnglish)}
+              {medio.es_online ? ` (${tx("online", "online")})` : ""}
             </option>
           ))}
         </select>
       </div>
 
       <div className="flex flex-col gap-1.5 md:col-span-2">
-        <Label htmlFor="observaciones">Observaciones</Label>
+        <Label htmlFor="observaciones">{tx("Observaciones", "Notes")}</Label>
         <textarea
           id="observaciones"
           name="observaciones"
           value={form.observaciones}
           onChange={handleChange}
-          placeholder="Ejemplo: pago en efectivo en recepción"
+          placeholder={tx(
+            "Ejemplo: pago en efectivo en recepción",
+            "Example: cash payment at reception",
+          )}
           className="min-h-20 rounded-md border border-input bg-background px-3 py-2 text-sm"
         />
       </div>
 
       <div className="flex items-center justify-end gap-2 md:col-span-2">
         <Button type="submit" disabled={loading || loadingOptions}>
-          {loading ? "Guardando..." : pago ? "Actualizar Pago" : "Registrar pago"}
+          {loading
+            ? tx("Guardando...", "Saving...")
+            : pago
+              ? tx("Actualizar pago", "Update payment")
+              : tx("Registrar pago", "Register payment")}
         </Button>
       </div>
     </form>

--- a/src/components/modal/CuotasModal.tsx
+++ b/src/components/modal/CuotasModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import CuotasForm from "../forms/CuotasForm";
 import FechaHora from "@/components/ui/FechaHora";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function CuotasModal({
   open,
@@ -21,13 +22,17 @@ export default function CuotasModal({
   onCreated: () => void;
   cuota?: any | null;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-5xl sm:max-w-4xl">
+      <DialogContent className="w-full max-w-5xl sm:max-w-4xl dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100">
         <QaFileNameBadge file="src/components/modal/CuotasModal.tsx" />
         <DialogHeader>
           <div className="flex items-center justify-between w-full gap-4">
-            <DialogTitle>{cuota ? "Editar Cuota" : "Nueva Cuota"}</DialogTitle>
+            <DialogTitle>{cuota ? tx("Editar Cuota", "Edit fee") : tx("Nueva Cuota", "New fee")}</DialogTitle>
             <FechaHora />
           </div>
         </DialogHeader>

--- a/src/components/modal/CuotasViewModal.tsx
+++ b/src/components/modal/CuotasViewModal.tsx
@@ -8,7 +8,33 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Cuota } from "@/interfaces/cuota.interface";
-import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
+import { formatFrontendDateTime, formatFrontendDate } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
+
+function translateFeeDescription(value: string | null | undefined, isEnglish: boolean) {
+  if (!value || !isEnglish) return value || "-";
+
+  const monthMap: Record<string, string> = {
+    ENERO: "JANUARY",
+    FEBRERO: "FEBRUARY",
+    MARZO: "MARCH",
+    ABRIL: "APRIL",
+    MAYO: "MAY",
+    JUNIO: "JUNE",
+    JULIO: "JULY",
+    AGOSTO: "AUGUST",
+    SEPTIEMBRE: "SEPTEMBER",
+    SETIEMBRE: "SEPTEMBER",
+    OCTUBRE: "OCTOBER",
+    NOVIEMBRE: "NOVEMBER",
+    DICIEMBRE: "DECEMBER",
+  };
+
+  return value.replace(
+    /\b(ENERO|FEBRERO|MARZO|ABRIL|MAYO|JUNIO|JULIO|AGOSTO|SEPTIEMBRE|SETIEMBRE|OCTUBRE|NOVIEMBRE|DICIEMBRE)\b/gi,
+    (match) => monthMap[match.toUpperCase()] || match,
+  );
+}
 
 export default function CuotasViewModal({
   open,
@@ -19,15 +45,21 @@ export default function CuotasViewModal({
   onClose: () => void;
   cuota?: Cuota | null;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
+
   if (!cuota) return null;
+
+  const fieldClassName = "p-2 border rounded-md bg-muted text-foreground dark:border-neutral-800 dark:bg-black dark:text-neutral-100";
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="!max-w-[90vw] sm:!max-w-[800px] !w-full bg-background text-foreground">
+      <DialogContent className="!max-w-[90vw] sm:!max-w-[800px] !w-full bg-background text-foreground dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100">
         <QaFileNameBadge file="src/components/modal/CuotasViewModal.tsx" />
         <DialogHeader>
           <DialogTitle className="text-xl font-semibold text-foreground">
-            Detalle Cuota
+            {tx("Detalle Cuota", "Fee detail")}
           </DialogTitle>
           <div className="text-sm text-right text-muted-foreground">
             {formatFrontendDateTime(new Date())}
@@ -36,34 +68,34 @@ export default function CuotasViewModal({
         <div className="grid grid-cols-1 gap-6 mt-4 md:grid-cols-2">
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Descripción</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
-                {cuota.descripcion || "-"}
+              <label className="text-sm font-medium">{tx("Descripción", "Description")}</label>
+              <div className={fieldClassName}>
+                {translateFeeDescription(cuota.descripcion, isEnglish)}
               </div>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium">Monto</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
+              <label className="text-sm font-medium">{tx("Monto", "Amount")}</label>
+              <div className={fieldClassName}>
                 {cuota.monto || "-"}
               </div>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium">Período</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
+              <label className="text-sm font-medium">{tx("Período", "Period")}</label>
+              <div className={fieldClassName}>
                 {cuota.periodo || "-"}
               </div>
             </div>
           </div>
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Fecha de Inicio</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
+              <label className="text-sm font-medium">{tx("Fecha de Inicio", "Start date")}</label>
+              <div className={fieldClassName}>
                 {formatFrontendDate(cuota.fecha_inicio)}
               </div>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium">Fecha de Fin</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
+              <label className="text-sm font-medium">{tx("Fecha de Fin", "End date")}</label>
+              <div className={fieldClassName}>
                 {formatFrontendDate(cuota.fecha_fin)}
               </div>
             </div>

--- a/src/components/modal/NotificacionModal.tsx
+++ b/src/components/modal/NotificacionModal.tsx
@@ -5,6 +5,13 @@ import { QaFileNameBadge } from '@/components/qa/QaFileNameBadge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Notificacion, NotificacionPlantilla } from '@/interfaces/notificacion.interface';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
+
+
+function notificationTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
 
 export default function NotificacionModal({
   open,
@@ -19,13 +26,16 @@ export default function NotificacionModal({
   notificacion?: Notificacion | null;
   plantillas: NotificacionPlantilla[];
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => notificationTx(locale, es, en);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className='w-full max-w-5xl'>
         <QaFileNameBadge file='src/components/modal/NotificacionModal.tsx' />
         <DialogHeader>
           <div className='flex w-full items-center justify-between gap-4'>
-            <DialogTitle>{notificacion ? 'Editar notificación' : 'Nueva notificación'}</DialogTitle>
+            <DialogTitle>{notificacion ? c('Editar notificación', 'Edit notification') : c('Nueva notificación', 'New notification')}</DialogTitle>
             <div className='text-sm text-muted-foreground'>{formatFrontendDateTime(new Date())}</div>
           </div>
         </DialogHeader>

--- a/src/components/modal/NotificacionViewModal.tsx
+++ b/src/components/modal/NotificacionViewModal.tsx
@@ -5,6 +5,43 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Notificacion } from '@/interfaces/notificacion.interface';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
+
+
+function notificationTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function notificationValue(locale: GymMasterLocale, value?: string | null) {
+  const labels: Record<string, { es: string; en: string }> = {
+    general: { es: 'General', en: 'General' },
+    feriado: { es: 'Feriado', en: 'Holiday' },
+    promocion: { es: 'Promoción', en: 'Promotion' },
+    stock: { es: 'Stock', en: 'Stock' },
+    cumpleanos: { es: 'Cumpleaños', en: 'Birthday' },
+    cuota: { es: 'Cuota', en: 'Fee' },
+    recordatorio: { es: 'Recordatorio', en: 'Reminder' },
+    sistema: { es: 'Sistema', en: 'System' },
+    otro: { es: 'Otro', en: 'Other' },
+    email: { es: 'Email', en: 'Email' },
+    terminal: { es: 'Terminal', en: 'Terminal' },
+    email_terminal: { es: 'Email + Terminal', en: 'Email + Terminal' },
+    borrador: { es: 'Borrador', en: 'Draft' },
+    programada: { es: 'Programada', en: 'Scheduled' },
+    enviada: { es: 'Enviada', en: 'Sent' },
+    cancelada: { es: 'Cancelada', en: 'Cancelled' },
+    error: { es: 'Error', en: 'Error' },
+    todos_socios: { es: 'Todos los socios con email', en: 'All members with email' },
+    socios_activos: { es: 'Socios activos con email', en: 'Active members with email' },
+    socios_cuota_al_dia: { es: 'Socios con cuota al día', en: 'Members with up-to-date fees' },
+    manual: { es: 'Manual / personalizado', en: 'Manual / custom' },
+  };
+  const key = String(value ?? '').toLowerCase();
+  const match = labels[key];
+  if (match) return notificationTx(locale, match.es, match.en);
+  return String(value ?? '').replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
 
 function Field({ label, value }: { label: string; value?: string | number | boolean | null }) {
   return (
@@ -28,6 +65,9 @@ export default function NotificacionViewModal({
   notificacion?: Notificacion | null;
   onSend?: (notificacion: Notificacion) => void;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => notificationTx(locale, es, en);
+
   if (!notificacion) return null;
 
   return (
@@ -36,42 +76,42 @@ export default function NotificacionViewModal({
         <QaFileNameBadge file='src/components/modal/NotificacionViewModal.tsx' />
         <DialogHeader>
           <div className='flex w-full items-center justify-between gap-4'>
-            <DialogTitle>Detalle de notificación</DialogTitle>
+            <DialogTitle>{c('Detalle de notificación', 'Notification detail')}</DialogTitle>
             <div className='text-sm text-muted-foreground'>{formatFrontendDateTime(new Date())}</div>
           </div>
         </DialogHeader>
 
         <div className='grid gap-4 md:grid-cols-2'>
-          <Field label='Título' value={notificacion.titulo} />
-          <Field label='Asunto' value={notificacion.asunto} />
-          <Field label='Tipo' value={notificacion.tipo} />
-          <Field label='Canal' value={notificacion.canal} />
-          <Field label='Estado' value={notificacion.estado} />
-          <Field label='Destinatarios' value={notificacion.destinatario_segmento} />
-          <Field label='Programada' value={formatFrontendDateTime(notificacion.fecha_programada)} />
-          <Field label='Enviada' value={formatFrontendDateTime(notificacion.fecha_enviada)} />
-          <Field label='Total destinatarios' value={notificacion.total_destinatarios} />
-          <Field label='Total enviados' value={notificacion.total_enviados} />
-          <Field label='Terminal' value={notificacion.mostrar_terminal ? 'Sí' : 'No'} />
-          <Field label='Terminal visible' value={notificacion.terminal_visible ? 'Sí' : 'No'} />
+          <Field label={c('Título', 'Title')} value={notificacion.titulo} />
+          <Field label={c('Asunto', 'Subject')} value={notificacion.asunto} />
+          <Field label={c('Tipo', 'Type')} value={notificationValue(locale, notificacion.tipo)} />
+          <Field label={c('Canal', 'Channel')} value={notificationValue(locale, notificacion.canal)} />
+          <Field label={c('Estado', 'Status')} value={notificationValue(locale, notificacion.estado)} />
+          <Field label={c('Destinatarios', 'Recipients')} value={notificationValue(locale, notificacion.destinatario_segmento)} />
+          <Field label={c('Programada', 'Scheduled')} value={formatFrontendDateTime(notificacion.fecha_programada)} />
+          <Field label={c('Enviada', 'Sent')} value={formatFrontendDateTime(notificacion.fecha_enviada)} />
+          <Field label={c('Total destinatarios', 'Total recipients')} value={notificacion.total_destinatarios} />
+          <Field label={c('Total enviados', 'Total sent')} value={notificacion.total_enviados} />
+          <Field label={c('Terminal', 'Terminal')} value={notificacion.mostrar_terminal ? c('Sí', 'Yes') : c('No', 'No')} />
+          <Field label={c('Terminal visible', 'Terminal visible')} value={notificacion.terminal_visible ? c('Sí', 'Yes') : c('No', 'No')} />
         </div>
 
         <div className='rounded-xl border bg-muted/40 p-4 text-sm'>
-          <div className='font-semibold'>Mensaje</div>
+          <div className='font-semibold'>{c('Mensaje', 'Message')}</div>
           <p className='mt-2 whitespace-pre-wrap text-muted-foreground'>{notificacion.cuerpo}</p>
         </div>
 
         {notificacion.envios && notificacion.envios.length > 0 ? (
           <div className='rounded-xl border p-4'>
-            <div className='mb-3 font-semibold'>Últimos envíos</div>
+            <div className='mb-3 font-semibold'>{c('Últimos envíos', 'Latest deliveries')}</div>
             <div className='max-h-60 overflow-auto'>
               <table className='w-full text-left text-sm'>
                 <thead>
                   <tr className='border-b bg-muted/50'>
-                    <th className='px-3 py-2'>Socio</th>
-                    <th className='px-3 py-2'>Email</th>
-                    <th className='px-3 py-2'>Estado</th>
-                    <th className='px-3 py-2'>Fecha</th>
+                    <th className='px-3 py-2'>{c('Socio', 'Member')}</th>
+                    <th className='px-3 py-2'>{c('Email', 'Email')}</th>
+                    <th className='px-3 py-2'>{c('Estado', 'Status')}</th>
+                    <th className='px-3 py-2'>{c('Fecha', 'Date')}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -79,7 +119,7 @@ export default function NotificacionViewModal({
                     <tr key={envio.id} className='border-b'>
                       <td className='px-3 py-2'>{envio.nombre_destinatario ?? '-'}</td>
                       <td className='px-3 py-2'>{envio.email ?? '-'}</td>
-                      <td className='px-3 py-2'>{envio.estado}</td>
+                      <td className='px-3 py-2'>{notificationValue(locale, envio.estado)}</td>
                       <td className='px-3 py-2'>{formatFrontendDateTime(envio.enviado_en)}</td>
                     </tr>
                   ))}
@@ -92,7 +132,7 @@ export default function NotificacionViewModal({
         <div className='flex justify-end gap-2'>
           {onSend && notificacion.estado !== 'enviada' && notificacion.estado !== 'cancelada' ? (
             <Button type='button' onClick={() => onSend(notificacion)}>
-              Preparar/envíar a socios
+              {c('Preparar/enviar a socios', 'Prepare/send to members')}
             </Button>
           ) : null}
         </div>

--- a/src/components/modal/OtrosGastosModal.tsx
+++ b/src/components/modal/OtrosGastosModal.tsx
@@ -9,6 +9,8 @@ import {
 } from "@/components/ui/dialog";
 import OtrosGastosForm from "../forms/OtrosGastosForm";
 import FechaHora from "@/components/ui/FechaHora";
+import { useI18n } from "@/i18n/I18nProvider";
+import { translateOtrosGastosUi } from "@/utils/otrosGastosI18n";
 
 export default function OtrosGastosModal({
   open,
@@ -21,13 +23,16 @@ export default function OtrosGastosModal({
   onCreated: () => void;
   gasto?: any | null;
 }) {
+  const { locale } = useI18n();
+  const c = (text: string) => translateOtrosGastosUi(locale, text);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-5xl sm:max-w-4xl">
+      <DialogContent className="w-full max-w-5xl sm:max-w-4xl dark:border-neutral-800 dark:bg-neutral-950">
         <QaFileNameBadge file="src/components/modal/OtrosGastosModal.tsx" />
         <DialogHeader>
           <div className="flex gap-4 justify-between items-center w-full">
-            <DialogTitle>{gasto ? "Editar Gasto / Egreso" : "Nuevo Gasto / Egreso"}</DialogTitle>
+            <DialogTitle>{gasto ? c("Editar Gasto / Egreso") : c("Nuevo Gasto / Egreso")}</DialogTitle>
             <FechaHora />
           </div>
         </DialogHeader>

--- a/src/components/modal/OtrosGastosViewModal.tsx
+++ b/src/components/modal/OtrosGastosViewModal.tsx
@@ -12,12 +12,20 @@ import { OtrosGastos } from "@/interfaces/otros_gastos.interface";
 import { formatFrontendDateTime, formatFrontendDate } from "@/utils/dateFormat";
 import { formatCurrencyARS } from "@/lib/comercial/productos";
 import { ExternalLink } from "lucide-react";
+import { useI18n } from "@/i18n/I18nProvider";
+import {
+  getOtrosGastosEstadoLabel,
+  getOtrosGastosMedioPagoLabel,
+  getOtrosGastosTipoLabel,
+  translateOtrosGastosDescription,
+  translateOtrosGastosUi,
+} from "@/utils/otrosGastosI18n";
 
 function ReadOnlyField({ label, value }: { label: string; value?: string | number | null }) {
   return (
     <div className="space-y-2">
       <label className="text-sm font-medium">{label}</label>
-      <div className="min-h-10 rounded-md border bg-gray-50 p-2 text-sm">
+      <div className="min-h-10 rounded-md border bg-gray-50 p-2 text-sm dark:border-neutral-800 dark:bg-neutral-950">
         {value === null || value === undefined || value === "" ? "-" : value}
       </div>
     </div>
@@ -33,54 +41,57 @@ export default function OtrosGastosViewModal({
   onClose: () => void;
   gasto?: OtrosGastos | null;
 }) {
+  const { locale } = useI18n();
+  const c = (text: string) => translateOtrosGastosUi(locale, text);
+
   if (!gasto) return null;
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="!w-full !max-w-[900px]">
+      <DialogContent className="!w-full !max-w-[900px] dark:border-neutral-800 dark:bg-neutral-950">
         <QaFileNameBadge file="src/components/modal/OtrosGastosViewModal.tsx" />
         <DialogHeader>
-          <DialogTitle className="text-xl font-semibold">Detalle de gasto / egreso</DialogTitle>
+          <DialogTitle className="text-xl font-semibold">{c("Detalle de gasto / egreso")}</DialogTitle>
           <div className="text-right text-sm text-muted-foreground">
             {formatFrontendDateTime(new Date())}
           </div>
         </DialogHeader>
 
         <div className="mt-4 grid grid-cols-1 gap-5 md:grid-cols-2">
-          <ReadOnlyField label="Descripción" value={gasto.descripcion} />
-          <ReadOnlyField label="Tipo de gasto" value={gasto.tipo_gasto?.nombre ?? "Sin clasificar"} />
-          <ReadOnlyField label="Monto" value={formatCurrencyARS(Number(gasto.monto ?? 0))} />
-          <ReadOnlyField label="Estado" value={gasto.estado ?? "-"} />
-          <ReadOnlyField label="Medio de pago" value={gasto.medio_pago?.replace(/_/g, " ") ?? "-"} />
-          <ReadOnlyField label="Fecha del gasto" value={formatFrontendDate(gasto.fecha)} />
-          <ReadOnlyField label="Fecha vencimiento" value={gasto.fecha_vencimiento ? formatFrontendDate(gasto.fecha_vencimiento) : "-"} />
-          <ReadOnlyField label="Fecha pago" value={gasto.fecha_pago ? formatFrontendDate(gasto.fecha_pago) : "-"} />
-          <ReadOnlyField label="Período desde" value={gasto.periodo_desde ? formatFrontendDate(gasto.periodo_desde) : "-"} />
-          <ReadOnlyField label="Período hasta" value={gasto.periodo_hasta ? formatFrontendDate(gasto.periodo_hasta) : "-"} />
-          <ReadOnlyField label="Proveedor / entidad" value={gasto.proveedor_nombre || gasto.entidad} />
-          <ReadOnlyField label="Nº comprobante" value={gasto.numero_comprobante} />
+          <ReadOnlyField label={c("Descripción")} value={translateOtrosGastosDescription(locale, gasto.descripcion)} />
+          <ReadOnlyField label={c("Tipo de gasto")} value={getOtrosGastosTipoLabel(locale, gasto.tipo_gasto?.nombre)} />
+          <ReadOnlyField label={c("Monto")} value={formatCurrencyARS(Number(gasto.monto ?? 0))} />
+          <ReadOnlyField label={c("Estado")} value={getOtrosGastosEstadoLabel(locale, gasto.estado)} />
+          <ReadOnlyField label={c("Medio de pago")} value={getOtrosGastosMedioPagoLabel(locale, gasto.medio_pago)} />
+          <ReadOnlyField label={c("Fecha del gasto")} value={formatFrontendDate(gasto.fecha)} />
+          <ReadOnlyField label={c("Fecha vencimiento")} value={gasto.fecha_vencimiento ? formatFrontendDate(gasto.fecha_vencimiento) : "-"} />
+          <ReadOnlyField label={c("Fecha pago")} value={gasto.fecha_pago ? formatFrontendDate(gasto.fecha_pago) : "-"} />
+          <ReadOnlyField label={c("Período desde")} value={gasto.periodo_desde ? formatFrontendDate(gasto.periodo_desde) : "-"} />
+          <ReadOnlyField label={c("Período hasta")} value={gasto.periodo_hasta ? formatFrontendDate(gasto.periodo_hasta) : "-"} />
+          <ReadOnlyField label={c("Proveedor / entidad")} value={translateOtrosGastosDescription(locale, gasto.proveedor_nombre || gasto.entidad)} />
+          <ReadOnlyField label={c("Nº comprobante")} value={gasto.numero_comprobante} />
         </div>
 
         <div className="mt-5 space-y-2">
-          <label className="text-sm font-medium">Observaciones</label>
-          <div className="min-h-20 rounded-md border bg-gray-50 p-3 text-sm">
-            {gasto.observaciones || "-"}
+          <label className="text-sm font-medium">{c("Observaciones")}</label>
+          <div className="min-h-20 rounded-md border bg-gray-50 p-3 text-sm dark:border-neutral-800 dark:bg-neutral-950">
+            {translateOtrosGastosDescription(locale, gasto.observaciones)}
           </div>
         </div>
 
-        <div className="mt-5 rounded-xl border bg-muted/20 p-4">
+        <div className="mt-5 rounded-xl border bg-muted/20 p-4 dark:border-neutral-800 dark:bg-neutral-950/60">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
-              <h3 className="font-semibold">Comprobante</h3>
+              <h3 className="font-semibold">{c("Comprobante")}</h3>
               <p className="text-sm text-muted-foreground">
-                {gasto.comprobante_nombre || gasto.comprobante_url || "Sin comprobante adjunto"}
+                {gasto.comprobante_nombre || gasto.comprobante_url || c("Sin comprobante adjunto")}
               </p>
             </div>
             {gasto.comprobante_url ? (
               <Button type="button" variant="outline" asChild>
                 <a href={gasto.comprobante_url} target="_blank" rel="noreferrer">
                   <ExternalLink className="mr-2 h-4 w-4" />
-                  Abrir comprobante
+                  {c("Abrir comprobante")}
                 </a>
               </Button>
             ) : null}

--- a/src/components/modal/PagoModal.tsx
+++ b/src/components/modal/PagoModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import PagoForm from "../forms/PagoForm";
 import FechaHora from "@/components/ui/FechaHora";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function PagoModal({
   open,
@@ -21,13 +22,21 @@ export default function PagoModal({
   onCreated: () => void;
   pago?: any | null;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-5xl sm:max-w-4xl">
+      <DialogContent className="w-full max-w-5xl sm:max-w-4xl dark:border-neutral-800 dark:bg-neutral-950 dark:text-white">
         <QaFileNameBadge file="src/components/modal/PagoModal.tsx" />
         <DialogHeader>
           <div className="flex gap-4 justify-between items-center w-full">
-            <DialogTitle>{pago ? "Editar Pago" : "Nuevo Pago"}</DialogTitle>
+            <DialogTitle>
+              {pago
+                ? tx("Editar pago", "Edit payment")
+                : tx("Nuevo pago", "New payment")}
+            </DialogTitle>
             <FechaHora />
           </div>
         </DialogHeader>

--- a/src/components/modal/PagoViewModal.tsx
+++ b/src/components/modal/PagoViewModal.tsx
@@ -10,7 +10,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { ResponsePago } from "@/interfaces/pago.interface";
 import { ReceiptText } from "lucide-react";
-import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
+import { formatFrontendDateTime } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
 
 function money(value?: number | null) {
   if (value === null || value === undefined) return "-";
@@ -22,6 +23,49 @@ function date(value?: string | null) {
   return value;
 }
 
+function normalizeLabel(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function translatePaymentMethod(
+  value: string | null | undefined,
+  isEnglish: boolean,
+) {
+  if (!isEnglish) return value ?? "-";
+  const normalized = normalizeLabel(value);
+  const labels: Record<string, string> = {
+    efectivo: "Cash",
+    transferencia: "Bank transfer",
+    stripe: "Stripe",
+    mercado_pago: "Mercado Pago",
+    "mercado pago": "Mercado Pago",
+    tarjeta: "Card",
+    debito: "Debit card",
+    débito: "Debit card",
+    credito: "Credit card",
+    crédito: "Credit card",
+    otro: "Other",
+  };
+  return labels[normalized] ?? value ?? "-";
+}
+
+function translatePaymentStatus(
+  value: string | null | undefined,
+  isEnglish: boolean,
+) {
+  if (!isEnglish) return value ?? "-";
+  const normalized = normalizeLabel(value);
+  const labels: Record<string, string> = {
+    pagado: "Paid",
+    pendiente: "Pending",
+    cancelado: "Canceled",
+    rechazado: "Rejected",
+    vencido: "Overdue",
+  };
+  return labels[normalized] ?? value ?? "-";
+}
 
 function Pill({
   children,
@@ -32,12 +76,12 @@ function Pill({
 }) {
   const variantClass =
     variant === "destructive"
-      ? "border-red-200 bg-red-50 text-red-700"
-      : "border-border bg-background text-foreground";
+      ? "border-red-200 bg-red-50 text-red-700 dark:border-red-900/70 dark:bg-red-950/45 dark:text-red-300"
+      : "border-border bg-background text-foreground dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100";
 
   return (
     <span
-      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold capitalize ${variantClass}`}
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold ${variantClass}`}
     >
       {children}
     </span>
@@ -53,10 +97,10 @@ function Field({
 }) {
   return (
     <div className="space-y-1.5">
-      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-neutral-400">
         {label}
       </label>
-      <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm text-foreground">
+      <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm text-foreground dark:border-neutral-800 dark:bg-neutral-900/80 dark:text-neutral-100">
         {value === null || value === undefined || value === "" ? "-" : value}
       </div>
     </div>
@@ -74,6 +118,10 @@ export default function PagoViewModal({
   pago?: ResponsePago | null;
   onReceiptDownload?: (pago: ResponsePago) => void;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
+
   if (!pago) return null;
 
   const estado = pago.estado ?? "-";
@@ -83,13 +131,13 @@ export default function PagoViewModal({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="!max-w-[90vw] sm:!max-w-[840px] !w-full bg-background text-foreground">
+      <DialogContent className="!max-w-[90vw] sm:!max-w-[840px] !w-full bg-background text-foreground dark:border-neutral-800 dark:bg-neutral-950 dark:text-white">
         <QaFileNameBadge file="src/components/modal/PagoViewModal.tsx" />
         <DialogHeader>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <DialogTitle className="text-xl font-semibold text-foreground">
-                Detalle del pago
+              <DialogTitle className="text-xl font-semibold text-foreground dark:text-white">
+                {tx("Detalle del pago", "Payment detail")}
               </DialogTitle>
               <div className="text-sm text-muted-foreground">
                 {formatFrontendDateTime(new Date())}
@@ -100,62 +148,101 @@ export default function PagoViewModal({
               <Button
                 type="button"
                 variant="outline"
-                className="border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
+                className="border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd] dark:border-cyan-800 dark:bg-neutral-950 dark:text-cyan-300 dark:hover:bg-neutral-900"
                 onClick={() => onReceiptDownload(pago)}
               >
                 <ReceiptText className="w-4 h-4 mr-2" />
-                Descargar recibo PDF
+                {tx("Descargar recibo PDF", "Download PDF receipt")}
               </Button>
             ) : null}
           </div>
         </DialogHeader>
 
         <div className="grid grid-cols-1 gap-4 mt-4 md:grid-cols-2">
-          <Field label="Socio" value={pago.socio?.nombre_completo} />
-          <Field label="Cuota" value={pago.cuota?.descripcion} />
-          <Field label="Fecha de pago" value={date(pago.fecha_pago)} />
-          <Field label="Fecha de vencimiento" value={date(pago.fecha_vencimiento)} />
-          <Field label="Periodo desde" value={date(periodoDesde)} />
-          <Field label="Periodo hasta" value={date(periodoHasta)} />
-          <Field label="Meses cubiertos" value={pago.meses_cubiertos ?? 1} />
-          <Field label="Subtotal" value={money(pago.subtotal ?? pago.monto_pagado)} />
           <Field
-            label="Descuento"
+            label={tx("Socio", "Member")}
+            value={pago.socio?.nombre_completo}
+          />
+          <Field label={tx("Cuota", "Fee")} value={pago.cuota?.descripcion} />
+          <Field
+            label={tx("Fecha de pago", "Payment date")}
+            value={date(pago.fecha_pago)}
+          />
+          <Field
+            label={tx("Fecha de vencimiento", "Due date")}
+            value={date(pago.fecha_vencimiento)}
+          />
+          <Field
+            label={tx("Período desde", "Period from")}
+            value={date(periodoDesde)}
+          />
+          <Field
+            label={tx("Período hasta", "Period to")}
+            value={date(periodoHasta)}
+          />
+          <Field
+            label={tx("Meses cubiertos", "Covered months")}
+            value={pago.meses_cubiertos ?? 1}
+          />
+          <Field
+            label="Subtotal"
+            value={money(pago.subtotal ?? pago.monto_pagado)}
+          />
+          <Field
+            label={tx("Descuento", "Discount")}
             value={
               Number(pago.descuento_monto ?? 0) > 0
                 ? `${money(pago.descuento_monto)} (${pago.descuento_porcentaje ?? 0}%)`
                 : money(0)
             }
           />
-          <Field label="Monto pagado" value={money(pago.monto_pagado)} />
+          <Field
+            label={tx("Monto pagado", "Amount paid")}
+            value={money(pago.monto_pagado)}
+          />
           <Field label="Total" value={money(pago.total ?? pago.monto_pagado)} />
-          <Field label="Registrado por" value={pago.registrado_por?.nombre} />
+          <Field
+            label={tx("Registrado por", "Registered by")}
+            value={pago.registrado_por?.nombre}
+          />
         </div>
 
-        <div className="grid grid-cols-1 gap-4 pt-4 mt-4 border-t md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 pt-4 mt-4 border-t dark:border-neutral-800 md:grid-cols-2">
           <div className="space-y-1.5">
-            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Método de pago
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-neutral-400">
+              {tx("Método de pago", "Payment method")}
             </label>
-            <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm capitalize">
-              <Pill variant="outline">{metodo}</Pill>
+            <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-900/80">
+              <Pill variant="outline">
+                {translatePaymentMethod(metodo, isEnglish)}
+              </Pill>
             </div>
           </div>
           <div className="space-y-1.5">
-            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Estado
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground dark:text-neutral-400">
+              {tx("Estado", "Status")}
             </label>
-            <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm capitalize">
-              <Pill variant={estado === "cancelado" ? "destructive" : "outline"}>{estado}</Pill>
+            <div className="min-h-10 rounded-md border bg-muted/60 px-3 py-2 text-sm dark:border-neutral-800 dark:bg-neutral-900/80">
+              <Pill
+                variant={estado === "cancelado" ? "destructive" : "outline"}
+              >
+                {translatePaymentStatus(estado, isEnglish)}
+              </Pill>
             </div>
           </div>
           <Field label="Stripe session" value={pago.stripe_session_id} />
-          <Field label="Stripe payment intent" value={pago.stripe_payment_intent_id} />
+          <Field
+            label="Stripe payment intent"
+            value={pago.stripe_payment_intent_id}
+          />
         </div>
 
         {pago.observaciones ? (
-          <div className="pt-4 mt-4 border-t">
-            <Field label="Observaciones" value={pago.observaciones} />
+          <div className="pt-4 mt-4 border-t dark:border-neutral-800">
+            <Field
+              label={tx("Observaciones", "Notes")}
+              value={pago.observaciones}
+            />
           </div>
         ) : null}
       </DialogContent>

--- a/src/components/tables/CuotaTable.tsx
+++ b/src/components/tables/CuotaTable.tsx
@@ -16,6 +16,32 @@ import {
 import { Cuota } from "@/interfaces/cuota.interface";
 import { useAuthStore } from "@/stores/authStore";
 import { formatFrontendDate } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
+
+function translateFeeDescription(value: string | null | undefined, isEnglish: boolean) {
+  if (!value || !isEnglish) return value || "-";
+
+  const monthMap: Record<string, string> = {
+    ENERO: "JANUARY",
+    FEBRERO: "FEBRUARY",
+    MARZO: "MARCH",
+    ABRIL: "APRIL",
+    MAYO: "MAY",
+    JUNIO: "JUNE",
+    JULIO: "JULY",
+    AGOSTO: "AUGUST",
+    SEPTIEMBRE: "SEPTEMBER",
+    SETIEMBRE: "SEPTEMBER",
+    OCTUBRE: "OCTOBER",
+    NOVIEMBRE: "NOVEMBER",
+    DICIEMBRE: "DECEMBER",
+  };
+
+  return value.replace(
+    /\b(ENERO|FEBRERO|MARZO|ABRIL|MAYO|JUNIO|JULIO|AGOSTO|SEPTIEMBRE|SETIEMBRE|OCTUBRE|NOVIEMBRE|DICIEMBRE)\b/gi,
+    (match) => monthMap[match.toUpperCase()] || match,
+  );
+}
 
 export default function CuotaTable({
   cuotas,
@@ -33,6 +59,9 @@ export default function CuotaTable({
   onToggleActivo?: (cuota: Cuota) => void;
 }) {
   const { user } = useAuthStore();
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
   const userRole = user?.rol;
   const isAdminOnly = userRole === "admin";
 
@@ -49,43 +78,53 @@ export default function CuotaTable({
   if (cuotas.length === 0 && !loading) {
     return (
       <div className="py-10 text-center text-muted-foreground">
-        No hay cuotas registradas aún.
+        {tx("No hay cuotas registradas aún.", "No fees registered yet.")}
       </div>
     );
   }
 
   return (
-    <Table className="w-full overflow-hidden text-sm border rounded-md border-border">
+    <Table className="w-full overflow-hidden text-sm border rounded-md border-border dark:border-neutral-800">
       <TableHeader>
-        <TableRow className="bg-muted/50 text-muted-foreground">
-          <TableHead>Descripción</TableHead>
-          <TableHead>Monto</TableHead>
-          <TableHead>Período</TableHead>
-          <TableHead>Fecha Inicio</TableHead>
-          <TableHead>Fecha Fin</TableHead>
-          <TableHead>Activo</TableHead>
-          <TableHead>Acciones</TableHead>
+        <TableRow className="bg-muted/50 text-muted-foreground dark:bg-neutral-900 dark:text-neutral-300">
+          <TableHead>{tx("Descripción", "Description")}</TableHead>
+          <TableHead>{tx("Monto", "Amount")}</TableHead>
+          <TableHead>{tx("Período", "Period")}</TableHead>
+          <TableHead>{tx("Fecha Inicio", "Start date")}</TableHead>
+          <TableHead>{tx("Fecha Fin", "End date")}</TableHead>
+          <TableHead>{tx("Activo", "Active")}</TableHead>
+          <TableHead>{tx("Acciones", "Actions")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {cuotas.map((c, i) => (
           <TableRow
             key={i}
-            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors"
+            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors dark:odd:bg-neutral-950/70 dark:hover:bg-neutral-900"
           >
-            <TableCell className="font-medium">{c.descripcion}</TableCell>
+            <TableCell className="font-medium">{translateFeeDescription(c.descripcion, isEnglish)}</TableCell>
             <TableCell>${c.monto}</TableCell>
             <TableCell>{c.periodo}</TableCell>
             <TableCell>{formatFrontendDate(c.fecha_inicio)}</TableCell>
             <TableCell>{formatFrontendDate(c.fecha_fin)}</TableCell>
-            <TableCell>{c.activo ? "✅" : "❌"}</TableCell>
+            <TableCell>
+              <span
+                className={
+                  c.activo
+                    ? "inline-flex rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-semibold text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/45 dark:text-emerald-300"
+                    : "inline-flex rounded-full border border-neutral-200 bg-neutral-50 px-2 py-0.5 text-xs font-semibold text-neutral-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-300"
+                }
+              >
+                {c.activo ? tx("Activa", "Active") : tx("Inactiva", "Inactive")}
+              </span>
+            </TableCell>
             <TableCell className="flex gap-2">
               <Button
                 size="sm"
                 variant="outline"
                 onClick={() => onView && onView(c)}
               >
-                Ver
+                {tx("Ver", "View")}
               </Button>
               {isAdminOnly && (
                 <>
@@ -93,7 +132,7 @@ export default function CuotaTable({
                     size="sm"
                     variant="outline"
                     onClick={() => onEdit(c)}
-                    title="Editar"
+                    title={tx("Editar", "Edit")}
                   >
                     <Pencil className="w-4 h-4" />
                   </Button>
@@ -107,14 +146,14 @@ export default function CuotaTable({
                     }
                     onClick={() => onToggleActivo && onToggleActivo(c)}
                   >
-                    {c.activo ? "Desactivar" : "Activar"}
+                    {c.activo ? tx("Desactivar", "Deactivate") : tx("Activar", "Activate")}
                   </Button>
                   <Button
                     size="sm"
                     className="bg-red-500 hover:bg-red-600 text-white w-[100px]"
                     onClick={() => onDelete && onDelete(c)}
                   >
-                    Eliminar
+                    {tx("Eliminar", "Delete")}
                   </Button>
                 </>
               )}
@@ -124,11 +163,11 @@ export default function CuotaTable({
       </TableBody>
       <TableFooter>
         <TableRow>
-          <TableCell colSpan={6}>Total de cuotas</TableCell>
+          <TableCell colSpan={6}>{tx("Total de cuotas", "Total fees")}</TableCell>
           <TableCell className="text-right">{cuotas.length}</TableCell>
         </TableRow>
       </TableFooter>
-      <TableCaption>Listado de cuotas registradas.</TableCaption>
+      <TableCaption>{tx("Listado de cuotas registradas.", "Registered fees list.")}</TableCaption>
     </Table>
   );
 }

--- a/src/components/tables/NotificacionTable.tsx
+++ b/src/components/tables/NotificacionTable.tsx
@@ -3,7 +3,40 @@
 import { Button } from '@/components/ui/button';
 import { Notificacion } from '@/interfaces/notificacion.interface';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import { BellRing, CalendarClock, Eye, Mail, Pencil, Send, SquareTerminal, XCircle } from 'lucide-react';
+
+
+function notificationTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function notificationValue(locale: GymMasterLocale, value?: string | null) {
+  const labels: Record<string, { es: string; en: string }> = {
+    general: { es: 'General', en: 'General' },
+    feriado: { es: 'Feriado', en: 'Holiday' },
+    promocion: { es: 'Promoción', en: 'Promotion' },
+    stock: { es: 'Stock', en: 'Stock' },
+    cumpleanos: { es: 'Cumpleaños', en: 'Birthday' },
+    cuota: { es: 'Cuota', en: 'Fee' },
+    recordatorio: { es: 'Recordatorio', en: 'Reminder' },
+    sistema: { es: 'Sistema', en: 'System' },
+    otro: { es: 'Otro', en: 'Other' },
+    email: { es: 'Email', en: 'Email' },
+    terminal: { es: 'Terminal', en: 'Terminal' },
+    email_terminal: { es: 'Email + Terminal', en: 'Email + Terminal' },
+    borrador: { es: 'Borrador', en: 'Draft' },
+    programada: { es: 'Programada', en: 'Scheduled' },
+    enviada: { es: 'Enviada', en: 'Sent' },
+    cancelada: { es: 'Cancelada', en: 'Cancelled' },
+    error: { es: 'Error', en: 'Error' },
+  };
+  const key = String(value ?? '').toLowerCase();
+  const match = labels[key];
+  if (match) return notificationTx(locale, match.es, match.en);
+  return String(value ?? '').replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
 
 function estadoClass(estado: string) {
   if (estado === 'enviada') return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-100 dark:ring-emerald-800/70';
@@ -13,10 +46,6 @@ function estadoClass(estado: string) {
   return 'bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700/70';
 }
 
-function normalizeLabel(value?: string | null) {
-  if (!value) return '-';
-  return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
 
 function NotificacionMobileCard({
   notificacion,
@@ -31,13 +60,16 @@ function NotificacionMobileCard({
   onCancel: (notificacion: Notificacion) => void;
   onSend: (notificacion: Notificacion) => void;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => notificationTx(locale, es, en);
+
   return (
     <article className='rounded-[1.5rem] border border-border bg-background p-4 shadow-sm dark:bg-slate-950/80'>
       <div className='flex items-start justify-between gap-3'>
         <div className='min-w-0'>
           <div className='flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-muted-foreground'>
             <BellRing className='h-4 w-4' />
-            Notificación
+            {c('Notificación', 'Notification')}
           </div>
           <h3 className='mt-2 break-words text-base font-black leading-tight text-foreground'>
             {notificacion.titulo}
@@ -47,18 +79,18 @@ function NotificacionMobileCard({
           </p>
         </div>
         <span className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-bold uppercase ring-1 ${estadoClass(notificacion.estado)}`}>
-          {normalizeLabel(notificacion.estado)}
+          {notificationValue(locale, notificacion.estado)}
         </span>
       </div>
 
       <div className='mt-4 grid grid-cols-2 gap-2 text-sm'>
         <div className='rounded-2xl border border-border/70 bg-muted/30 p-3'>
-          <p className='text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground'>Tipo</p>
-          <p className='mt-1 font-semibold text-foreground'>{normalizeLabel(notificacion.tipo)}</p>
+          <p className='text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground'>{c('Tipo', 'Type')}</p>
+          <p className='mt-1 font-semibold text-foreground'>{notificationValue(locale, notificacion.tipo)}</p>
         </div>
         <div className='rounded-2xl border border-border/70 bg-muted/30 p-3'>
-          <p className='text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground'>Canal</p>
-          <p className='mt-1 font-semibold text-foreground'>{normalizeLabel(notificacion.canal)}</p>
+          <p className='text-[11px] font-bold uppercase tracking-[0.16em] text-muted-foreground'>{c('Canal', 'Channel')}</p>
+          <p className='mt-1 font-semibold text-foreground'>{notificationValue(locale, notificacion.canal)}</p>
         </div>
       </div>
 
@@ -66,31 +98,31 @@ function NotificacionMobileCard({
         <div className='flex items-start gap-2'>
           <CalendarClock className='mt-0.5 h-4 w-4 shrink-0 text-sky-600 dark:text-sky-300' />
           <div>
-            <p className='font-semibold text-foreground'>Programada</p>
+            <p className='font-semibold text-foreground'>{c('Programada', 'Scheduled')}</p>
             <p className='text-muted-foreground'>{formatFrontendDateTime(notificacion.fecha_programada)}</p>
-            <p className='text-xs text-muted-foreground'>Hasta: {formatFrontendDateTime(notificacion.fecha_vigencia_hasta)}</p>
+            <p className='text-xs text-muted-foreground'>{c('Hasta', 'Until')}: {formatFrontendDateTime(notificacion.fecha_vigencia_hasta)}</p>
           </div>
         </div>
         <div className='flex items-start gap-2'>
           <Mail className='mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-300' />
           <div>
-            <p className='font-semibold text-foreground'>Envíos</p>
-            <p className='text-muted-foreground'>{notificacion.total_enviados}/{notificacion.total_destinatarios} destinatarios</p>
+            <p className='font-semibold text-foreground'>{c('Envíos', 'Deliveries')}</p>
+            <p className='text-muted-foreground'>{notificacion.total_enviados}/{notificacion.total_destinatarios} {c('destinatarios', 'recipients')}</p>
             {notificacion.total_errores > 0 ? (
-              <p className='text-xs font-semibold text-red-600 dark:text-red-300'>Errores: {notificacion.total_errores}</p>
+              <p className='text-xs font-semibold text-red-600 dark:text-red-300'>{c('Errores', 'Errors')}: {notificacion.total_errores}</p>
             ) : null}
           </div>
         </div>
         <div className='flex items-start gap-2'>
           <SquareTerminal className='mt-0.5 h-4 w-4 shrink-0 text-violet-600 dark:text-violet-300' />
           <div>
-            <p className='font-semibold text-foreground'>Terminal</p>
+            <p className='font-semibold text-foreground'>{c('Terminal', 'Terminal')}</p>
             <p className='text-muted-foreground'>
               {notificacion.mostrar_terminal
                 ? notificacion.terminal_visible
-                  ? 'Visible en terminal'
-                  : 'Configurada, no visible'
-                : 'No visible en terminal'}
+                  ? c('Visible en terminal', 'Visible in terminal')
+                  : c('Configurada, no visible', 'Configured, not visible')
+                : c('No visible en terminal', 'Not visible in terminal')}
             </p>
           </div>
         </div>
@@ -98,19 +130,19 @@ function NotificacionMobileCard({
 
       <div className='mt-4 grid grid-cols-2 gap-2'>
         <Button type='button' variant='outline' onClick={() => onView(notificacion)} className='w-full'>
-          <Eye className='mr-2 h-4 w-4' /> Ver
+          <Eye className='mr-2 h-4 w-4' /> {c('Ver', 'View')}
         </Button>
         <Button type='button' variant='outline' onClick={() => onEdit(notificacion)} className='w-full'>
-          <Pencil className='mr-2 h-4 w-4' /> Editar
+          <Pencil className='mr-2 h-4 w-4' /> {c('Editar', 'Edit')}
         </Button>
         {notificacion.estado !== 'enviada' && notificacion.estado !== 'cancelada' ? (
           <Button type='button' variant='outline' onClick={() => onSend(notificacion)} className='w-full'>
-            <Send className='mr-2 h-4 w-4' /> Enviar
+            <Send className='mr-2 h-4 w-4' /> {c('Enviar', 'Send')}
           </Button>
         ) : null}
         {notificacion.estado !== 'cancelada' ? (
           <Button type='button' variant='destructive' onClick={() => onCancel(notificacion)} className='w-full'>
-            <XCircle className='mr-2 h-4 w-4' /> Cancelar
+            <XCircle className='mr-2 h-4 w-4' /> {c('Cancelar', 'Cancel')}
           </Button>
         ) : null}
       </div>
@@ -131,10 +163,13 @@ export default function NotificacionTable({
   onCancel: (notificacion: Notificacion) => void;
   onSend: (notificacion: Notificacion) => void;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => notificationTx(locale, es, en);
+
   if (notificaciones.length === 0) {
     return (
       <div className='rounded-[1.5rem] border border-dashed border-border bg-muted/20 px-4 py-10 text-center text-sm text-muted-foreground'>
-        No hay notificaciones para los filtros seleccionados.
+        {c('No hay notificaciones para los filtros seleccionados.', 'No notifications match the selected filters.')}
       </div>
     );
   }
@@ -158,13 +193,13 @@ export default function NotificacionTable({
         <table className='w-full text-left text-sm'>
           <thead>
             <tr className='border-b bg-muted/50'>
-              <th className='px-4 py-3'>Notificación</th>
-              <th className='px-4 py-3'>Tipo / canal</th>
-              <th className='px-4 py-3'>Estado</th>
-              <th className='px-4 py-3'>Programada</th>
-              <th className='px-4 py-3'>Envíos</th>
-              <th className='px-4 py-3'>Terminal</th>
-              <th className='px-4 py-3 text-right'>Acciones</th>
+              <th className='px-4 py-3'>{c('Notificación', 'Notification')}</th>
+              <th className='px-4 py-3'>{c('Tipo / canal', 'Type / channel')}</th>
+              <th className='px-4 py-3'>{c('Estado', 'Status')}</th>
+              <th className='px-4 py-3'>{c('Programada', 'Scheduled')}</th>
+              <th className='px-4 py-3'>{c('Envíos', 'Deliveries')}</th>
+              <th className='px-4 py-3'>{c('Terminal', 'Terminal')}</th>
+              <th className='px-4 py-3 text-right'>{c('Acciones', 'Actions')}</th>
             </tr>
           </thead>
           <tbody>
@@ -175,48 +210,48 @@ export default function NotificacionTable({
                   <div className='text-xs text-muted-foreground'>{notificacion.asunto}</div>
                 </td>
                 <td className='px-4 py-3'>
-                  <div>{normalizeLabel(notificacion.tipo)}</div>
-                  <div className='text-xs text-muted-foreground'>{normalizeLabel(notificacion.canal)}</div>
+                  <div>{notificationValue(locale, notificacion.tipo)}</div>
+                  <div className='text-xs text-muted-foreground'>{notificationValue(locale, notificacion.canal)}</div>
                 </td>
                 <td className='px-4 py-3'>
                   <span className={`rounded-full px-2 py-1 text-xs font-semibold ${estadoClass(notificacion.estado)}`}>
-                    {normalizeLabel(notificacion.estado)}
+                    {notificationValue(locale, notificacion.estado)}
                   </span>
                 </td>
                 <td className='px-4 py-3'>
                   <div>{formatFrontendDateTime(notificacion.fecha_programada)}</div>
-                  <div className='text-xs text-muted-foreground'>Hasta: {formatFrontendDateTime(notificacion.fecha_vigencia_hasta)}</div>
+                  <div className='text-xs text-muted-foreground'>{c('Hasta', 'Until')}: {formatFrontendDateTime(notificacion.fecha_vigencia_hasta)}</div>
                 </td>
                 <td className='px-4 py-3'>
                   <div>{notificacion.total_enviados}/{notificacion.total_destinatarios}</div>
                   {notificacion.total_errores > 0 ? (
-                    <div className='text-xs text-red-600'>Errores: {notificacion.total_errores}</div>
+                    <div className='text-xs text-red-600'>{c('Errores', 'Errors')}: {notificacion.total_errores}</div>
                   ) : null}
                 </td>
                 <td className='px-4 py-3'>
                   {notificacion.mostrar_terminal ? (
                     <span className='rounded-full bg-violet-100 px-2 py-1 text-xs font-semibold text-violet-800 dark:bg-violet-950/50 dark:text-violet-100'>
-                      {notificacion.terminal_visible ? 'Visible' : 'Oculta'}
+                      {notificacion.terminal_visible ? c('Visible', 'Visible') : c('Oculta', 'Hidden')}
                     </span>
                   ) : (
-                    <span className='text-muted-foreground'>No</span>
+                    <span className='text-muted-foreground'>{c('No', 'No')}</span>
                   )}
                 </td>
                 <td className='px-4 py-3'>
                   <div className='flex justify-end gap-2'>
-                    <Button type='button' size='sm' variant='outline' onClick={() => onView(notificacion)} title='Ver'>
+                    <Button type='button' size='sm' variant='outline' onClick={() => onView(notificacion)} title={c('Ver', 'View')}>
                       <Eye className='h-4 w-4' />
                     </Button>
-                    <Button type='button' size='sm' variant='outline' onClick={() => onEdit(notificacion)} title='Editar'>
+                    <Button type='button' size='sm' variant='outline' onClick={() => onEdit(notificacion)} title={c('Editar', 'Edit')}>
                       <Pencil className='h-4 w-4' />
                     </Button>
                     {notificacion.estado !== 'enviada' && notificacion.estado !== 'cancelada' ? (
-                      <Button type='button' size='sm' variant='outline' onClick={() => onSend(notificacion)} title='Enviar/preparar'>
+                      <Button type='button' size='sm' variant='outline' onClick={() => onSend(notificacion)} title={c('Enviar/preparar', 'Send/prepare')}>
                         <Send className='h-4 w-4' />
                       </Button>
                     ) : null}
                     {notificacion.estado !== 'cancelada' ? (
-                      <Button type='button' size='sm' variant='destructive' onClick={() => onCancel(notificacion)} title='Cancelar'>
+                      <Button type='button' size='sm' variant='destructive' onClick={() => onCancel(notificacion)} title={c('Cancelar', 'Cancel')}>
                         <XCircle className='h-4 w-4' />
                       </Button>
                     ) : null}

--- a/src/components/tables/OtrosGastosTable.tsx
+++ b/src/components/tables/OtrosGastosTable.tsx
@@ -16,26 +16,31 @@ import {
 import { OtrosGastos } from "@/interfaces/otros_gastos.interface";
 import { formatFrontendDate } from "@/utils/dateFormat";
 import { formatCurrencyARS } from "@/lib/comercial/productos";
+import { useI18n } from "@/i18n/I18nProvider";
+import {
+  getOtrosGastosEstadoLabel,
+  getOtrosGastosMedioPagoLabel,
+  getOtrosGastosTipoLabel,
+  translateOtrosGastosDescription,
+  translateOtrosGastosUi,
+} from "@/utils/otrosGastosI18n";
 
 function getEstadoBadgeClass(estado?: string | null) {
   switch (estado) {
     case "pagado":
-      return "bg-emerald-50 text-emerald-700 border-emerald-200";
+      return "bg-emerald-50 text-emerald-700 border-emerald-200 dark:border-emerald-900/70 dark:bg-emerald-950/35 dark:text-emerald-300";
     case "pendiente":
-      return "bg-amber-50 text-amber-700 border-amber-200";
+      return "bg-amber-50 text-amber-700 border-amber-200 dark:border-amber-900/70 dark:bg-amber-950/35 dark:text-amber-300";
     case "vencido":
-      return "bg-red-50 text-red-700 border-red-200";
+      return "bg-red-50 text-red-700 border-red-200 dark:border-red-900/70 dark:bg-red-950/35 dark:text-red-300";
     case "anulado":
-      return "bg-slate-100 text-slate-600 border-slate-200";
+      return "bg-slate-100 text-slate-600 border-slate-200 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300";
     default:
-      return "bg-slate-50 text-slate-600 border-slate-200";
+      return "bg-slate-50 text-slate-600 border-slate-200 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-300";
   }
 }
 
-function getEstadoLabel(estado?: string | null) {
-  if (!estado) return "Sin estado";
-  return estado.charAt(0).toUpperCase() + estado.slice(1);
-}
+
 
 export default function OtrosGastosTable({
   gastos,
@@ -50,6 +55,9 @@ export default function OtrosGastosTable({
   onEdit: (gasto: OtrosGastos) => void;
   onDelete?: (gasto: OtrosGastos) => void;
 }) {
+  const { locale } = useI18n();
+  const c = (text: string) => translateOtrosGastosUi(locale, text);
+
   if (loading) {
     return (
       <div className="space-y-2">
@@ -63,7 +71,7 @@ export default function OtrosGastosTable({
   if (gastos.length === 0 && !loading) {
     return (
       <div className="py-10 text-center text-muted-foreground">
-        No hay gastos registrados aún.
+        {c("No hay gastos registrados aún.")}
       </div>
     );
   }
@@ -71,45 +79,45 @@ export default function OtrosGastosTable({
   const total = gastos.reduce((acc, gasto) => acc + Number(gasto.monto ?? 0), 0);
 
   return (
-    <Table className="w-full overflow-hidden rounded-md border border-border text-sm">
+    <Table className="w-full overflow-hidden rounded-md border border-border text-sm dark:border-neutral-800">
       <TableHeader>
-        <TableRow className="bg-muted/50 text-muted-foreground">
-          <TableHead>Descripción</TableHead>
-          <TableHead>Tipo</TableHead>
-          <TableHead>Entidad</TableHead>
-          <TableHead>Estado</TableHead>
-          <TableHead>Medio</TableHead>
-          <TableHead className="text-right">Monto</TableHead>
-          <TableHead>Fecha</TableHead>
-          <TableHead>Vencimiento</TableHead>
-          <TableHead>Comprobante</TableHead>
-          <TableHead>Acciones</TableHead>
+        <TableRow className="bg-muted/50 text-muted-foreground dark:bg-neutral-900/80 dark:text-neutral-300">
+          <TableHead>{c("Descripción")}</TableHead>
+          <TableHead>{c("Tipo")}</TableHead>
+          <TableHead>{c("Entidad")}</TableHead>
+          <TableHead>{c("Estado")}</TableHead>
+          <TableHead>{c("Medio")}</TableHead>
+          <TableHead className="text-right">{c("Monto")}</TableHead>
+          <TableHead>{c("Fecha")}</TableHead>
+          <TableHead>{c("Vencimiento")}</TableHead>
+          <TableHead>{c("Comprobante")}</TableHead>
+          <TableHead>{c("Acciones")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {gastos.map((g) => (
-          <TableRow key={g.id} className="odd:bg-muted/40 transition-colors hover:bg-[#a8d9f9]">
+          <TableRow key={g.id} className="odd:bg-muted/40 transition-colors hover:bg-[#a8d9f9] dark:odd:bg-neutral-900/40 dark:hover:bg-neutral-800/80">
             <TableCell className="max-w-[220px] font-medium">
-              <div className="line-clamp-2">{g.descripcion}</div>
+              <div className="line-clamp-2">{translateOtrosGastosDescription(locale, g.descripcion)}</div>
               {g.numero_comprobante ? (
-                <div className="text-xs text-muted-foreground">Comp.: {g.numero_comprobante}</div>
+                <div className="text-xs text-muted-foreground">{c("Comp.")}: {g.numero_comprobante}</div>
               ) : null}
             </TableCell>
-            <TableCell>{g.tipo_gasto?.nombre ?? "Sin clasificar"}</TableCell>
-            <TableCell>{g.proveedor_nombre || g.entidad || "-"}</TableCell>
+            <TableCell>{getOtrosGastosTipoLabel(locale, g.tipo_gasto?.nombre)}</TableCell>
+            <TableCell>{translateOtrosGastosDescription(locale, g.proveedor_nombre || g.entidad || "-")}</TableCell>
             <TableCell>
               <span className={`inline-flex rounded-full border px-2 py-1 text-xs font-semibold ${getEstadoBadgeClass(g.estado)}`}>
-                {getEstadoLabel(g.estado)}
+                {getOtrosGastosEstadoLabel(locale, g.estado)}
               </span>
             </TableCell>
-            <TableCell>{g.medio_pago ? g.medio_pago.replace(/_/g, " ") : "-"}</TableCell>
+            <TableCell>{getOtrosGastosMedioPagoLabel(locale, g.medio_pago)}</TableCell>
             <TableCell className="text-right font-semibold">{formatCurrencyARS(Number(g.monto ?? 0))}</TableCell>
             <TableCell>{formatFrontendDate(g.fecha)}</TableCell>
             <TableCell>{g.fecha_vencimiento ? formatFrontendDate(g.fecha_vencimiento) : "-"}</TableCell>
             <TableCell>
               {g.comprobante_url ? (
                 <Button size="sm" variant="outline" asChild>
-                  <a href={g.comprobante_url} target="_blank" rel="noreferrer" title="Abrir comprobante">
+                  <a href={g.comprobante_url} target="_blank" rel="noreferrer" title={c("Abrir comprobante")}>
                     <ExternalLink className="h-4 w-4" />
                   </a>
                 </Button>
@@ -120,18 +128,18 @@ export default function OtrosGastosTable({
             <TableCell>
               <div className="flex flex-wrap gap-2">
                 {onView ? (
-                  <Button size="sm" variant="outline" onClick={() => onView(g)} title="Ver">
+                  <Button size="sm" variant="outline" onClick={() => onView(g)} title={c("Ver")}>
                     <Eye className="h-4 w-4" />
                   </Button>
                 ) : null}
-                <Button size="sm" variant="outline" onClick={() => onEdit(g)} title="Editar">
+                <Button size="sm" variant="outline" onClick={() => onEdit(g)} title={c("Editar")}>
                   <Pencil className="h-4 w-4" />
                 </Button>
                 <Button
                   size="sm"
                   className="bg-red-500 text-white hover:bg-red-600"
                   onClick={() => onDelete && onDelete(g)}
-                  title="Anular"
+                  title={c("Anular")}
                 >
                   <Trash2 className="h-4 w-4" />
                 </Button>
@@ -142,14 +150,14 @@ export default function OtrosGastosTable({
       </TableBody>
       <TableFooter>
         <TableRow>
-          <TableCell colSpan={5}>Total de gastos filtrados</TableCell>
+          <TableCell colSpan={5}>{c("Total de gastos filtrados")}</TableCell>
           <TableCell className="text-right font-bold">{formatCurrencyARS(total)}</TableCell>
           <TableCell colSpan={4} className="text-right">
-            {gastos.length} registros
+            {gastos.length} {c("registros")}
           </TableCell>
         </TableRow>
       </TableFooter>
-      <TableCaption>Listado de gastos y egresos operativos registrados.</TableCaption>
+      <TableCaption>{c("Listado de gastos y egresos operativos registrados.")}</TableCaption>
     </Table>
   );
 }

--- a/src/components/tables/PagoTable.tsx
+++ b/src/components/tables/PagoTable.tsx
@@ -14,10 +14,61 @@ import {
   TableCaption,
 } from "@/components/ui/table";
 import { ResponsePago } from "@/interfaces/pago.interface";
+import { useI18n } from "@/i18n/I18nProvider";
 
 function money(value?: number | null) {
   if (value === null || value === undefined) return "-";
   return `$${Number(value).toLocaleString("es-AR")}`;
+}
+
+function normalizeLabel(value?: string | null) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function translatePaymentMethod(
+  value: string | null | undefined,
+  isEnglish: boolean,
+) {
+  if (!isEnglish) return value ?? "-";
+  const normalized = normalizeLabel(value);
+  const labels: Record<string, string> = {
+    efectivo: "Cash",
+    cash: "Cash",
+    transferencia: "Bank transfer",
+    transfer: "Bank transfer",
+    stripe: "Stripe",
+    mercado_pago: "Mercado Pago",
+    "mercado pago": "Mercado Pago",
+    tarjeta: "Card",
+    debito: "Debit card",
+    débito: "Debit card",
+    credito: "Credit card",
+    crédito: "Credit card",
+    otro: "Other",
+  };
+  return labels[normalized] ?? value ?? "-";
+}
+
+function translatePaymentStatus(
+  value: string | null | undefined,
+  isEnglish: boolean,
+) {
+  if (!isEnglish) return value ?? "-";
+  const normalized = normalizeLabel(value);
+  const labels: Record<string, string> = {
+    pagado: "Paid",
+    paid: "Paid",
+    pendiente: "Pending",
+    pending: "Pending",
+    cancelado: "Canceled",
+    cancelled: "Canceled",
+    canceled: "Canceled",
+    rechazado: "Rejected",
+    vencido: "Overdue",
+  };
+  return labels[normalized] ?? value ?? "-";
 }
 
 export default function PagoTable({
@@ -35,6 +86,10 @@ export default function PagoTable({
   onDelete?: (pago: ResponsePago) => void;
   onReceipt?: (pago: ResponsePago) => void;
 }) {
+  const { locale } = useI18n();
+  const isEnglish = locale === "en";
+  const tx = (es: string, en: string) => (isEnglish ? en : es);
+
   if (loading) {
     return (
       <div className="space-y-2">
@@ -48,31 +103,34 @@ export default function PagoTable({
   if (pagos.length === 0 && !loading) {
     return (
       <div className="py-10 text-center text-muted-foreground">
-        No hay pagos registrados aún.
+        {tx(
+          "No hay pagos registrados aún.",
+          "No payments have been registered yet.",
+        )}
       </div>
     );
   }
 
   return (
-    <Table className="w-full overflow-hidden text-sm border rounded-md border-border">
+    <Table className="w-full overflow-hidden text-sm border rounded-md border-border dark:border-neutral-800">
       <TableHeader>
-        <TableRow className="bg-muted/50 text-muted-foreground">
-          <TableHead>Socio</TableHead>
-          <TableHead>Cuota</TableHead>
-          <TableHead>Fecha Pago</TableHead>
-          <TableHead>Cobertura</TableHead>
-          <TableHead>Método</TableHead>
-          <TableHead>Estado</TableHead>
-          <TableHead>Monto</TableHead>
-          <TableHead>Registrado Por</TableHead>
-          <TableHead>Acciones</TableHead>
+        <TableRow className="bg-muted/50 text-muted-foreground dark:bg-neutral-900/80 dark:text-neutral-300">
+          <TableHead>{tx("Socio", "Member")}</TableHead>
+          <TableHead>{tx("Cuota", "Fee")}</TableHead>
+          <TableHead>{tx("Fecha pago", "Payment date")}</TableHead>
+          <TableHead>{tx("Cobertura", "Coverage")}</TableHead>
+          <TableHead>{tx("Método", "Method")}</TableHead>
+          <TableHead>{tx("Estado", "Status")}</TableHead>
+          <TableHead>{tx("Monto", "Amount")}</TableHead>
+          <TableHead>{tx("Registrado por", "Registered by")}</TableHead>
+          <TableHead>{tx("Acciones", "Actions")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {pagos.map((p) => (
           <TableRow
             key={p.id}
-            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors"
+            className="odd:bg-muted/40 transition-colors hover:bg-[#a8d9f9] dark:odd:bg-neutral-950/50 dark:hover:bg-neutral-800/80"
           >
             <TableCell className="font-medium">
               {p.socio?.nombre_completo ?? "-"}
@@ -82,18 +140,25 @@ export default function PagoTable({
             <TableCell>
               <div className="flex flex-col text-xs">
                 <span>{p.periodo_desde ?? p.fecha_pago}</span>
-                <span>hasta {p.periodo_hasta ?? p.fecha_vencimiento}</span>
-                <span>{p.meses_cubiertos ?? 1} mes/es</span>
+                <span>
+                  {tx("hasta", "to")} {p.periodo_hasta ?? p.fecha_vencimiento}
+                </span>
+                <span>
+                  {p.meses_cubiertos ?? 1} {tx("mes/es", "month(s)")}
+                </span>
               </div>
             </TableCell>
-            <TableCell className="capitalize">{p.metodo_pago ?? "-"}</TableCell>
-            <TableCell className="capitalize">{p.estado ?? "-"}</TableCell>
+            <TableCell>
+              {translatePaymentMethod(p.metodo_pago, isEnglish)}
+            </TableCell>
+            <TableCell>{translatePaymentStatus(p.estado, isEnglish)}</TableCell>
             <TableCell>
               <div className="flex flex-col">
                 <span>{money(p.monto_pagado)}</span>
                 {Number(p.descuento_monto ?? 0) > 0 ? (
-                  <span className="text-xs text-emerald-700">
-                    Desc. {money(p.descuento_monto)} ({p.descuento_porcentaje ?? 0}%)
+                  <span className="text-xs text-emerald-700 dark:text-emerald-300">
+                    {tx("Desc.", "Disc.")} {money(p.descuento_monto)} (
+                    {p.descuento_porcentaje ?? 0}%)
                   </span>
                 ) : null}
               </div>
@@ -105,13 +170,13 @@ export default function PagoTable({
                 variant="outline"
                 onClick={() => onView && onView(p)}
               >
-                Ver
+                {tx("Ver", "View")}
               </Button>
               <Button
                 size="sm"
                 variant="outline"
                 onClick={() => onReceipt && onReceipt(p)}
-                title="Descargar recibo PDF"
+                title={tx("Descargar recibo PDF", "Download PDF receipt")}
               >
                 <ReceiptText className="w-4 h-4" />
               </Button>
@@ -119,7 +184,7 @@ export default function PagoTable({
                 size="sm"
                 variant="outline"
                 onClick={() => onEdit(p)}
-                title="Editar"
+                title={tx("Editar", "Edit")}
               >
                 <Pencil className="w-4 h-4" />
               </Button>
@@ -128,19 +193,23 @@ export default function PagoTable({
                 className="bg-red-500 hover:bg-red-600 text-white w-[100px]"
                 onClick={() => onDelete && onDelete(p)}
               >
-                Eliminar
+                {tx("Eliminar", "Delete")}
               </Button>
             </TableCell>
           </TableRow>
         ))}
       </TableBody>
       <TableFooter>
-        <TableRow>
-          <TableCell colSpan={8}>Total de pagos</TableCell>
+        <TableRow className="dark:bg-neutral-900/80">
+          <TableCell colSpan={8}>
+            {tx("Total de pagos", "Total payments")}
+          </TableCell>
           <TableCell className="text-right">{pagos.length}</TableCell>
         </TableRow>
       </TableFooter>
-      <TableCaption>Listado de pagos registrados.</TableCaption>
+      <TableCaption>
+        {tx("Listado de pagos registrados.", "Registered payments list.")}
+      </TableCaption>
     </Table>
   );
 }

--- a/src/utils/otrosGastosI18n.ts
+++ b/src/utils/otrosGastosI18n.ts
@@ -1,0 +1,350 @@
+import type { GymMasterLocale } from '@/i18n/config';
+import { translateCommercialUi } from '@/i18n/commercialUi';
+
+const enOtrosGastosUi: Record<string, string> = {
+  'Cargando...': 'Loading...',
+  'Gastos / Egresos': 'Expenses / Outflows',
+  'Total egresos': 'Total outflows',
+  'Activos': 'Active',
+  'Pendientes': 'Pending',
+  'Vencidos': 'Overdue',
+  'Comprobantes': 'Receipts',
+  'Listado de Gastos / Egresos': 'Expenses / Outflows list',
+  'Registrá gastos operativos, vencimientos, medios de pago y comprobantes.': 'Register operating expenses, due dates, payment methods, and receipts.',
+  'Todos': 'All',
+  'Pagados': 'Paid',
+  'Pendiente': 'Pending',
+  'Pagado': 'Paid',
+  'Vencido': 'Overdue',
+  'Anulado': 'Cancelled',
+  'Anulados': 'Cancelled',
+  'Sin estado': 'No status',
+  'Sin clasificar': 'Unclassified',
+  'Sueldos': 'Salaries',
+  'Mantenimiento': 'Maintenance',
+  'Servicios': 'Services',
+  'Insumos': 'Supplies',
+  'Alquiler': 'Rent',
+  'Impuestos': 'Taxes',
+  'Limpieza': 'Cleaning',
+  'Marketing': 'Marketing',
+  'Otros': 'Other',
+  'Reparación': 'Repair',
+  'Reparaciones': 'Repairs',
+  'Servicios públicos': 'Utilities',
+  'Honorarios': 'Professional fees',
+  'Gastos asociados a mantenimiento de equipamiento o infraestructura.': 'Expenses related to equipment or infrastructure maintenance.',
+  'Gastos asociados a sueldos, jornales o liquidaciones del personal.': 'Expenses related to salaries, wages, or staff settlements.',
+  'Gastos asociados a servicios contratados, profesionales o tercerizados.': 'Expenses related to contracted, professional, or outsourced services.',
+  'Gastos asociados a insumos operativos, limpieza, oficina o mantenimiento.': 'Expenses related to operating, cleaning, office, or maintenance supplies.',
+  'Gastos asociados a alquileres, renta del local o espacios operativos.': 'Expenses related to rent, facility rental, or operating spaces.',
+  'Gastos asociados a impuestos, tasas o cargas fiscales.': 'Expenses related to taxes, fees, or fiscal charges.',
+  'Gastos asociados a limpieza, higiene o desinfección.': 'Expenses related to cleaning, hygiene, or disinfection.',
+  'Gastos asociados a marketing, publicidad o comunicación.': 'Expenses related to marketing, advertising, or communications.',
+  'Gastos asociados a otros conceptos operativos.': 'Expenses related to other operating concepts.',
+  'Gasto sin tipo asignado.': 'Expense without an assigned type.',
+  'Gastos no clasificados.': 'Unclassified expenses.',
+  'Gastos no clasificados': 'Unclassified expenses.',
+  'Otros gastos no clasificados.': 'Other unclassified expenses.',
+  'Otros gastos no clasificados': 'Other unclassified expenses.',
+  'Pagos mensuales a empleados.': 'Monthly payments to employees.',
+  'Pagos mensuales a empleados': 'Monthly payments to employees.',
+  'Pagos a empleados.': 'Payments to employees.',
+  'Pagos a empleados': 'Payments to employees.',
+  'Sin descripción de tipo.': 'No type description.',
+  'Sueldos, jornales, cargas sociales o liquidaciones del personal.': 'Salaries, wages, payroll taxes, or staff settlements.',
+  'Sueldos, jornales o liquidaciones del personal.': 'Salaries, wages, or staff settlements.',
+  'Gastos de sueldos, jornales o liquidaciones del personal.': 'Salary, wage, or staff settlement expenses.',
+  'Mantenimiento de equipamiento o infraestructura.': 'Equipment or infrastructure maintenance.',
+  'Reparaciones, mantenimiento de equipamiento o infraestructura.': 'Repairs and equipment or infrastructure maintenance.',
+  'Servicios contratados, profesionales o tercerizados.': 'Contracted, professional, or outsourced services.',
+  'Luz, agua, internet, software u otros servicios.': 'Electricity, water, internet, software, or other services.',
+  'Luz, agua, internet, software u otros servicios': 'Electricity, water, internet, software, or other services.',
+  'Servicios públicos, internet, software u otros servicios.': 'Utilities, internet, software, or other services.',
+  'Servicios públicos, internet, software u otros servicios': 'Utilities, internet, software, or other services.',
+  'Insumos operativos, limpieza, oficina o mantenimiento.': 'Operating, cleaning, office, or maintenance supplies.',
+  'Compra de insumos operativos, limpieza, oficina o mantenimiento.': 'Purchase of operating, cleaning, office, or maintenance supplies.',
+  'Alquileres, renta del local o espacios operativos.': 'Rent, facility rental, or operating spaces.',
+  'Alquiler del local, depósitos o espacios operativos.': 'Facility rent, storage, or operating spaces.',
+  'Impuestos, tasas o cargas fiscales.': 'Taxes, fees, or fiscal charges.',
+  'Impuestos, tasas, cargas fiscales o retenciones.': 'Taxes, fees, fiscal charges, or withholdings.',
+  'Limpieza, higiene o desinfección.': 'Cleaning, hygiene, or disinfection.',
+  'Productos o servicios de limpieza, higiene y desinfección.': 'Cleaning, hygiene, and disinfection products or services.',
+  'Marketing, publicidad o comunicación.': 'Marketing, advertising, or communications.',
+  'Publicidad, redes sociales, diseño o campañas comerciales.': 'Advertising, social media, design, or commercial campaigns.',
+  'Otros conceptos operativos.': 'Other operating concepts.',
+  'Otros gastos operativos no clasificados.': 'Other unclassified operating expenses.',
+  'Fecha desde': 'From date',
+  'Fecha hasta': 'To date',
+  'Limpiar': 'Clear',
+  'Buscar gasto, tipo, entidad, comprobante...': 'Search expense, type, entity, receipt...',
+  'Descargar PDF': 'Download PDF',
+  'Exportar': 'Export',
+  'Añadir Gasto': 'Add expense',
+  'Añadir': 'Add',
+  'Los comprobantes pueden guardarse como URL o subirse a Cloudinary en formato PDF o imagen. Los gastos anulados quedan fuera del total operativo.': 'Receipts can be stored as a URL or uploaded to Cloudinary as PDF or image. Cancelled expenses are excluded from the operating total.',
+  'Total de gastos filtrados': 'Total filtered expenses',
+  'Listado de gastos y egresos operativos registrados.': 'Registered operating expenses and outflows list.',
+  'No hay gastos registrados aún.': 'No expenses registered yet.',
+  'Descripción': 'Description',
+  'Descripción *': 'Description *',
+  'Monto *': 'Amount *',
+  'Fecha del gasto *': 'Expense date *',
+  'Nº comprobante / factura': 'Receipt / invoice No.',
+  'Nº comprobante': 'Receipt No.',
+  'Control operativo de egresos del gimnasio': 'Operational control of gym outflows',
+  'Con comprobante': 'With receipt',
+  'Gastos': 'Expenses',
+  'Tipo': 'Type',
+  'Tipo de gasto': 'Expense type',
+  'Entidad': 'Entity',
+  'Estado': 'Status',
+  'Medio': 'Medium',
+  'Medio de pago': 'Payment method',
+  'Monto': 'Amount',
+  'Fecha': 'Date',
+  'Fecha del gasto': 'Expense date',
+  'Vencimiento': 'Due date',
+  'Fecha vencimiento': 'Due date',
+  'Fecha de vencimiento': 'Due date',
+  'Fecha pago': 'Payment date',
+  'Fecha de pago': 'Payment date',
+  'Comprobante': 'Receipt',
+  'Acciones': 'Actions',
+  'Comp.': 'Receipt',
+  'Abrir comprobante': 'Open receipt',
+  'Ver': 'View',
+  'Editar': 'Edit',
+  'Anular': 'Cancel',
+  '¿Está seguro de anular el gasto?': 'Are you sure you want to cancel this expense?',
+  'Gasto anulado correctamente': 'Expense cancelled successfully',
+  'Error al anular gasto': 'Error cancelling expense',
+  'Estado:': 'Status:',
+  'Desde:': 'From:',
+  'Hasta:': 'To:',
+  'Búsqueda:': 'Search:',
+  'Listado de gastos-egresos': 'expenses-outflows-list',
+  'Total': 'Total',
+  'Período desde': 'Period from',
+  'Período hasta': 'Period to',
+  'Observaciones': 'Notes',
+  'Nuevo Gasto / Egreso': 'New expense / outflow',
+  'Editar Gasto / Egreso': 'Edit expense / outflow',
+  'Detalle de gasto / egreso': 'Expense / outflow detail',
+  'Proveedor / entidad': 'Supplier / entity',
+  'Sin comprobante adjunto': 'No receipt attached',
+  'Subir PDF o imagen': 'Upload PDF or image',
+  'Seleccionar archivo': 'Select file',
+  'Sin archivo seleccionado': 'No file selected',
+  'Subiendo...': 'Uploading...',
+  'Formatos permitidos: PDF, PNG, JPG, WEBP, GIF, HEIC/HEIF. Máximo 10MB.': 'Allowed formats: PDF, PNG, JPG, WEBP, GIF, HEIC/HEIF. Max 10MB.',
+  'URL del comprobante': 'Receipt URL',
+  'URL de Cloudinary o comprobante externo': 'Cloudinary URL or external receipt',
+  'Archivo:': 'File:',
+  'Notas internas, detalle del gasto, condiciones de pago...': 'Internal notes, expense details, payment terms...',
+  'Guardando...': 'Saving...',
+  'Actualizar Gasto': 'Update expense',
+  'Crear Gasto': 'Create expense',
+  'Gasto actualizado': 'Expense updated',
+  'Gasto creado': 'Expense created',
+  'Error al guardar gasto': 'Error saving expense',
+  'Comprobante subido correctamente': 'Receipt uploaded successfully',
+  'Error al subir comprobante': 'Error uploading receipt',
+  'Ej.: Factura de luz, reparación, insumos de limpieza...': 'Ex: electricity bill, repair, cleaning supplies...',
+  'Ej.: Edesur, AFIP, alquiler, técnico...': 'Ex: Edesur, tax agency, rent, technician...',
+  'Factura, ticket, transferencia...': 'Invoice, ticket, transfer...',
+  'Efectivo': 'Cash',
+  'Transferencia': 'Transfer',
+  'Tarjeta débito': 'Debit card',
+  'Tarjeta crédito': 'Credit card',
+  'Mercado Pago': 'Mercado Pago',
+  'Stripe': 'Stripe',
+  'Otro': 'Other',
+  'efectivo': 'cash',
+  'transferencia': 'transfer',
+  'tarjeta debito': 'debit card',
+  'tarjeta credito': 'credit card',
+  'mercado pago': 'mercado pago',
+  'otro': 'other',
+  'registros': 'records',
+  'gastos': 'expenses',
+};
+
+export function translateOtrosGastosUi(locale: GymMasterLocale, text: string) {
+  if (locale !== 'en') return text;
+  return enOtrosGastosUi[text] ?? translateCommercialUi(locale, text);
+}
+
+export function getOtrosGastosEstadoLabel(locale: GymMasterLocale, estado?: string | null) {
+  if (!estado) return translateOtrosGastosUi(locale, 'Sin estado');
+  const normalized = estado.toLowerCase();
+  const esLabel = normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  return translateOtrosGastosUi(locale, esLabel);
+}
+
+export function getOtrosGastosMedioPagoLabel(locale: GymMasterLocale, medio?: string | null) {
+  if (!medio) return '-';
+  const normalized = medio.replace(/_/g, ' ');
+  if (locale !== 'en') return normalized;
+  return enOtrosGastosUi[normalized] ?? normalized;
+}
+
+
+function translateOtrosGastosTipoDescriptionByMeaning(normalized: string) {
+  if (!normalized) return null;
+
+  const compact = normalized
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const hasAny = (...words: string[]) => words.some((word) => compact.includes(word));
+  const hasAll = (...words: string[]) => words.every((word) => compact.includes(word));
+
+  if (
+    hasAny('sin descripcion', 'sin tipo') ||
+    hasAll('sin', 'clasificar') ||
+    hasAny('no clasificado', 'no clasificados')
+  ) {
+    return 'Unclassified expenses.';
+  }
+
+  if (hasAny('sueldo', 'jornal', 'liquidacion', 'carga social', 'nomina', 'personal', 'empleado', 'empleados')) {
+    return 'Salaries, wages, payroll taxes, or staff settlements.';
+  }
+
+  if (hasAny('mantenimiento', 'infraestructura', 'equipamiento', 'reparacion')) {
+    return 'Expenses related to equipment or infrastructure maintenance.';
+  }
+
+  if (hasAny('luz', 'agua', 'internet', 'software', 'servicio publico') || hasAll('otros', 'servicios')) {
+    return 'Electricity, water, internet, software, or other services.';
+  }
+
+  if (hasAny('insumo', 'oficina', 'suministro')) {
+    return 'Operating, cleaning, office, or maintenance supplies.';
+  }
+
+  if (hasAny('alquiler', 'renta', 'local', 'deposito')) {
+    return 'Rent, facility rental, or operating spaces.';
+  }
+
+  if (hasAny('impuesto', 'tasa', 'fiscal', 'retencion')) {
+    return 'Taxes, fees, or fiscal charges.';
+  }
+
+  if (hasAny('limpieza', 'higiene', 'desinfeccion')) {
+    return 'Cleaning, hygiene, or disinfection.';
+  }
+
+  if (hasAny('marketing', 'publicidad', 'comunicacion', 'redes sociales', 'campana', 'diseño', 'diseno')) {
+    return 'Marketing, advertising, or communications.';
+  }
+
+  if (hasAny('otro concepto', 'otros conceptos', 'otros gastos')) {
+    return 'Other operating concepts.';
+  }
+
+  return null;
+}
+
+export function getOtrosGastosTipoLabel(locale: GymMasterLocale, value?: string | null) {
+  if (!value) return translateOtrosGastosUi(locale, 'Sin clasificar');
+  if (locale !== 'en') return value;
+
+  const translated = translateOtrosGastosUi(locale, value);
+  if (translated !== value) return translated;
+
+  const normalized = value.trim().toLowerCase();
+  const fallbackCatalog: Record<string, string> = {
+    sueldos: 'Salaries',
+    mantenimiento: 'Maintenance',
+    servicios: 'Services',
+    insumos: 'Supplies',
+    alquiler: 'Rent',
+    impuestos: 'Taxes',
+    limpieza: 'Cleaning',
+    marketing: 'Marketing',
+    otros: 'Other',
+    otro: 'Other',
+    reparación: 'Repair',
+    reparaciones: 'Repairs',
+    'servicios públicos': 'Utilities',
+    honorarios: 'Professional fees',
+    'gastos asociados a mantenimiento de equipamiento o infraestructura.': 'Expenses related to equipment or infrastructure maintenance.',
+    'gastos asociados a sueldos, jornales o liquidaciones del personal.': 'Expenses related to salaries, wages, or staff settlements.',
+    'gastos asociados a servicios contratados, profesionales o tercerizados.': 'Expenses related to contracted, professional, or outsourced services.',
+    'gastos asociados a insumos operativos, limpieza, oficina o mantenimiento.': 'Expenses related to operating, cleaning, office, or maintenance supplies.',
+    'gastos asociados a alquileres, renta del local o espacios operativos.': 'Expenses related to rent, facility rental, or operating spaces.',
+    'gastos asociados a impuestos, tasas o cargas fiscales.': 'Expenses related to taxes, fees, or fiscal charges.',
+    'gastos asociados a limpieza, higiene o desinfección.': 'Expenses related to cleaning, hygiene, or disinfection.',
+    'gastos asociados a marketing, publicidad o comunicación.': 'Expenses related to marketing, advertising, or communications.',
+    'gastos asociados a otros conceptos operativos.': 'Expenses related to other operating concepts.',
+    'gasto sin tipo asignado.': 'Expense without an assigned type.',
+    'gastos no clasificados.': 'Unclassified expenses.',
+    'gastos no clasificados': 'Unclassified expenses.',
+    'otros gastos no clasificados.': 'Other unclassified expenses.',
+    'otros gastos no clasificados': 'Other unclassified expenses.',
+    'pagos mensuales a empleados.': 'Monthly payments to employees.',
+    'pagos mensuales a empleados': 'Monthly payments to employees.',
+    'pagos a empleados.': 'Payments to employees.',
+    'pagos a empleados': 'Payments to employees.',
+    'sin descripción de tipo.': 'No type description.',
+    'sueldos, jornales, cargas sociales o liquidaciones del personal.': 'Salaries, wages, payroll taxes, or staff settlements.',
+    'sueldos, jornales o liquidaciones del personal.': 'Salaries, wages, or staff settlements.',
+    'gastos de sueldos, jornales o liquidaciones del personal.': 'Salary, wage, or staff settlement expenses.',
+    'mantenimiento de equipamiento o infraestructura.': 'Equipment or infrastructure maintenance.',
+    'reparaciones, mantenimiento de equipamiento o infraestructura.': 'Repairs and equipment or infrastructure maintenance.',
+    'servicios contratados, profesionales o tercerizados.': 'Contracted, professional, or outsourced services.',
+    'luz, agua, internet, software u otros servicios.': 'Electricity, water, internet, software, or other services.',
+    'luz, agua, internet, software u otros servicios': 'Electricity, water, internet, software, or other services.',
+    'servicios públicos, internet, software u otros servicios.': 'Utilities, internet, software, or other services.',
+    'servicios públicos, internet, software u otros servicios': 'Utilities, internet, software, or other services.',
+    'insumos operativos, limpieza, oficina o mantenimiento.': 'Operating, cleaning, office, or maintenance supplies.',
+    'compra de insumos operativos, limpieza, oficina o mantenimiento.': 'Purchase of operating, cleaning, office, or maintenance supplies.',
+    'alquileres, renta del local o espacios operativos.': 'Rent, facility rental, or operating spaces.',
+    'alquiler del local, depósitos o espacios operativos.': 'Facility rent, storage, or operating spaces.',
+    'impuestos, tasas o cargas fiscales.': 'Taxes, fees, or fiscal charges.',
+    'impuestos, tasas, cargas fiscales o retenciones.': 'Taxes, fees, fiscal charges, or withholdings.',
+    'limpieza, higiene o desinfección.': 'Cleaning, hygiene, or disinfection.',
+    'productos o servicios de limpieza, higiene y desinfección.': 'Cleaning, hygiene, and disinfection products or services.',
+    'marketing, publicidad o comunicación.': 'Marketing, advertising, or communications.',
+    'publicidad, redes sociales, diseño o campañas comerciales.': 'Advertising, social media, design, or commercial campaigns.',
+    'otros conceptos operativos.': 'Other operating concepts.',
+    'otros gastos operativos no clasificados.': 'Other unclassified operating expenses.',
+  };
+
+  const exactFallback = fallbackCatalog[normalized];
+  if (exactFallback) return exactFallback;
+
+  const meaningFallback = translateOtrosGastosTipoDescriptionByMeaning(normalized);
+  if (meaningFallback) return meaningFallback;
+
+  return value
+    .replace(/Gastos no clasificados\.?/gi, 'Unclassified expenses.')
+    .replace(/Pagos mensuales a empleados\.?/gi, 'Monthly payments to employees.')
+    .replace(/Pagos a empleados\.?/gi, 'Payments to employees.')
+    .replace(/Gastos asociados a mantenimiento de equipamiento o infraestructura\.?/gi, 'Expenses related to equipment or infrastructure maintenance.')
+    .replace(/Gastos asociados a sueldos, jornales o liquidaciones del personal\.?/gi, 'Expenses related to salaries, wages, or staff settlements.')
+    .replace(/Gastos asociados a servicios contratados, profesionales o tercerizados\.?/gi, 'Expenses related to contracted, professional, or outsourced services.')
+    .replace(/Gastos asociados a insumos operativos, limpieza, oficina o mantenimiento\.?/gi, 'Expenses related to operating, cleaning, office, or maintenance supplies.')
+    .replace(/Gastos asociados a alquileres, renta del local o espacios operativos\.?/gi, 'Expenses related to rent, facility rental, or operating spaces.')
+    .replace(/Gastos asociados a impuestos, tasas o cargas fiscales\.?/gi, 'Expenses related to taxes, fees, or fiscal charges.')
+    .replace(/Gastos asociados a limpieza, higiene o desinfección\.?/gi, 'Expenses related to cleaning, hygiene, or disinfection.')
+    .replace(/Gastos asociados a marketing, publicidad o comunicación\.?/gi, 'Expenses related to marketing, advertising, or communications.')
+    .replace(/Gastos asociados a otros conceptos operativos\.?/gi, 'Expenses related to other operating concepts.');
+}
+
+export function translateOtrosGastosDescription(locale: GymMasterLocale, value?: string | null) {
+  if (!value) return '-';
+  if (locale !== 'en') return value;
+
+  return value
+    .replace(/^Gasto demo/i, 'Demo expense')
+    .replace(/^Gasto/i, 'Expense')
+    .replace(/^Luz$/i, 'Electricity')
+    .replace(/^Comp\.:/i, 'Receipt:')
+    .replace(/Proveedor demo operativo/gi, 'Demo operating supplier')
+    .replace(/Sin clasificar/gi, 'Unclassified');
+}


### PR DESCRIPTION
# PR: i18n ES/EN Admin Dashboard Final Sweep v2

## Rama

`feature/i18n-es-en-admin-dashboard-final-sweep-v2`

## Resumen

Este PR continúa el recorrido final de internacionalización ES/EN del dashboard administrador de Gym Master, cubriendo módulos administrativos financieros, BI, notificaciones, RAG Corpus y rankings operativos. El foco fue eliminar textos residuales en español cuando la UI está en inglés, normalizar labels dinámicos visibles, mejorar consistencia de modo oscuro y mantener intacta la lógica funcional existente.

## Alcance funcional

### Pagos

- Traducción de listado, filtros, columnas, estados, métodos de pago, acciones y modales.
- Corrección del mensaje dinámico de descuento por pago anticipado.
- Mejora visual puntual de tabla, cards y modales en dark mode.

### Cuotas

- Traducción de listado de cuotas, filtros, columnas, estados, acciones, footer y modales.
- Normalización visual de períodos/meses en inglés.
- Mejora de contraste y superficies en dark mode.

### Otros gastos

- Traducción completa del módulo de gastos/egresos.
- Corrección de tipos de gasto, estados, medios de pago, descripciones dinámicas y textos de comprobantes.
- Traducción defensiva de valores persistidos o semidinámicos como gastos no clasificados, pagos a empleados, servicios, mantenimiento, impuestos y otros.
- Fix final de duplicados TypeScript en `src/utils/otrosGastosI18n.ts` detectados durante build.

### Finanzas / BI

- Traducción de hero, filtros, KPIs, bloque ejecutivo, decisión sugerida, gráficos, categorías, ranking y tabla mensual.
- Normalización de labels dinámicos como ventas de productos/kiosco, cuotas/membresías, compras a proveedores, gastos pendientes, luz y registros.
- Mejora local de dark mode en cards, contenedores de gráficos, categorías y tabla.

### BI socios, demografía y promociones

- Traducción de métricas de socios, demografía, asistencia, consumo, rankings y promociones sugeridas.
- Normalización de segmentos dinámicos: hombres, mujeres, sin dato, menores de 18, sin fecha de nacimiento, etc.
- Traducción de promociones sugeridas generadas desde la API.
- Mejora visual de cards, gráficos, listas, promociones y tabla final.

### Ranking y bonificación mensual de socios

- Traducción de KPIs, filtros, gráfico, tabla, badges, paginación y reglas comerciales.
- Normalización de estados de cuota y bonificación: al día, pendiente, bonificado, no bonificado, bloqueada por pago.
- Mejora local de dark mode en cards, tabla, badges y paneles.

### RAG Corpus

- Traducción del estado del corpus RAG, KPIs, coberturas, acciones de ingesta/vectorización, dominios, recomendaciones y última ejecución.
- Normalización de dominios visibles: exercises, diet rules, routine rules, safety, evolution, business y general.
- Mejora local de dark mode en hero, cards, coverage panels, tabla y recomendaciones.

### Notificaciones

- Traducción del centro de notificaciones, cards KPI, salud del centro de avisos, prioridades, filtros, tabla, estados, tipos, canales, botones y modales.
- Traducción del formulario de creación/edición, incluyendo plantilla base, destinatarios, programación, terminal de asistencia, color neón y visibilidad.
- Traducción de modal view/edit, toasts y confirms asociados.

## Archivos principales modificados

- `src/app/dashboard/bi-socios-demografia-promociones/page.tsx`
- `src/app/dashboard/cuotas/page.tsx`
- `src/app/dashboard/finanzas/page.tsx`
- `src/app/dashboard/notificaciones/page.tsx`
- `src/app/dashboard/otros-gastos/page.tsx`
- `src/app/dashboard/pagos/page.tsx`
- `src/app/dashboard/rag-corpus/page.tsx`
- `src/app/dashboard/socios-ranking-bonificacion/page.tsx`
- `src/components/forms/CuotasForm.tsx`
- `src/components/forms/NotificacionForm.tsx`
- `src/components/forms/OtrosGastosForm.tsx`
- `src/components/forms/PagoForm.tsx`
- `src/components/modal/CuotasModal.tsx`
- `src/components/modal/CuotasViewModal.tsx`
- `src/components/modal/NotificacionModal.tsx`
- `src/components/modal/NotificacionViewModal.tsx`
- `src/components/modal/OtrosGastosModal.tsx`
- `src/components/modal/OtrosGastosViewModal.tsx`
- `src/components/modal/PagoModal.tsx`
- `src/components/modal/PagoViewModal.tsx`
- `src/components/tables/CuotaTable.tsx`
- `src/components/tables/NotificacionTable.tsx`
- `src/components/tables/OtrosGastosTable.tsx`
- `src/components/tables/PagoTable.tsx`
- `src/utils/otrosGastosI18n.ts`

## Fuera de alcance

- No se modificaron endpoints.
- No se modificó Swagger/OpenAPI.
- No se modificó base de datos ni migraciones.
- No se modificó lógica de pagos, cuotas, gastos, BI, notificaciones, RAG, rankings ni bonificaciones.
- No se tradujeron aún datos persistidos desde DB de forma estructural; eso queda para la futura feature de i18n de datos persistidos.
- No se abordó todavía el sweep dedicado de PDFs, Excel, tickets, etiquetas y exportables.

## Validación realizada

- `npm run build` ejecutado correctamente luego de corregir duplicados en `src/utils/otrosGastosI18n.ts`.
- Limpieza de artefactos PWA generados por build: `public/sw.js` y `public/fallback-*.js`.
- QA visual recomendado en ES/EN + light/dark para:
  - `/dashboard/pagos`
  - `/dashboard/cuotas`
  - `/dashboard/otros-gastos`
  - `/dashboard/finanzas`
  - `/dashboard/bi-socios-demografia-promociones`
  - `/dashboard/socios-ranking-bonificacion`
  - `/dashboard/rag-corpus`
  - `/dashboard/notificaciones`

## Notas técnicas

- Se priorizaron fixes quirúrgicos y locales por pantalla.
- Se agregaron helpers de presentación para normalizar labels dinámicos sin alterar contratos de API ni datos persistidos.
- Se mantuvo la compatibilidad con el provider i18n existente del proyecto.
- Se reforzó dark mode solo en componentes afectados por el recorrido.

## Siguiente paso sugerido

Después de mergear este PR en `main`, crear una nueva rama desde `main` actualizado para continuar el último tramo del recorrido admin:

`feature/i18n-es-en-admin-dashboard-final-sweep-v3`

Próximo foco sugerido: seguir con pantallas admin restantes, reportes/exportables visibles, configuraciones, parametrización, usuarios/roles/permisos y cualquier residuo ES/EN detectado antes de pasar al sweep socio.
