### PR TITLE
feat(i18n): complete admin dashboard final sweep v3

### DIFF
--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_AVISOS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_AVISOS_FIX_V1.md
@@ -1,0 +1,44 @@
+# I18N ES/EN Admin Dashboard Final Sweep V3 - Avisos Fix V1
+
+## Alcance
+
+Pantalla: `/dashboard/avisos`.
+
+Este patch corrige textos mixtos ES/EN y mejora dark mode local en la pantalla de avisos/notices del administrador.
+
+## Cambios principales
+
+- Header de la página: `Avisos` / `Notices`.
+- Card principal: `Listado de avisos` / `Notices list`.
+- Buscador: `Buscar por título, mensaje, tipo o fecha...` / `Search by title, message, type, or date...`.
+- Botón: `Nuevo aviso` / `New notice`.
+- Tabla: `Título`, `Mensaje`, `Tipo`, `Fecha de envío`, `Acciones`, `Total de avisos`, caption y empty state.
+- Acciones de tabla: `Ver`, `Editar`, `Eliminar` / `View`, `Edit`, `Delete`.
+- Modal create/edit: `Nuevo aviso`, `Editar aviso`, labels, placeholders, checkbox y botón submit.
+- Modal view: `Detalle del aviso`, `Asunto`, `Fecha de envío`, `Mensaje`.
+- Editor Markdown compartido: tabs, contador, placeholder, toolbar titles y footer helper ES/EN.
+- Dark mode local en page/card/table/modal/form/editor.
+
+## Fuera de alcance
+
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica de envío, edición, borrado o renderizado de avisos.
+- No traduce contenido persistido de avisos ya guardados en base de datos.
+
+## Validación sugerida
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+rm -rf .next
+npm run build
+```
+
+Luego limpiar PWA generado por build:
+
+```bash
+git checkout -- public/sw.js
+rm -f public/fallback-*.js
+git status --short
+```

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_GIMNASIO_PARAMETRIZACION_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_GIMNASIO_PARAMETRIZACION_FIX_V1.md
@@ -1,0 +1,40 @@
+# I18N ES/EN Admin Dashboard Final Sweep V3 - Gimnasio Parametrización Fix V1
+
+## Ruta
+
+- `/dashboard/gimnasio-parametrizacion`
+
+## Archivos modificados
+
+- `src/app/dashboard/gimnasio-parametrizacion/page.tsx`
+
+## Alcance
+
+- Agrega uso local de `useI18n` para la pantalla de datos del gimnasio.
+- Traduce labels, headings, ayudas, placeholders, mensajes de carga/éxito/error y estado Stripe.
+- Traduce contenido visible de combos de condición fiscal, estado de integración Stripe y modo Stripe sin cambiar los values enviados al backend.
+- Ajusta algunos estilos dark mode locales en alertas, preview, avisos y estado Stripe.
+
+## No incluido
+
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia lógica de guardado, upload de Cloudinary ni configuración real de Stripe.
+- No traduce contenido persistido de textos legales/documentos; eso queda para el sweep dedicado de exportables/DB i18n.
+
+## Validación sugerida
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+rm -rf .next
+npm run build
+```
+
+Luego limpiar artefactos PWA si aparecen:
+
+```bash
+git checkout -- public/sw.js
+rm -f public/fallback-*.js
+git status --short
+```

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_MENSAJES_ADMIN_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_MENSAJES_ADMIN_FIX_V1.md
@@ -1,0 +1,18 @@
+# i18n ES/EN Admin Dashboard Final Sweep v3 - Mensajes Admin Fix v1
+
+## Alcance
+Pantalla: `/dashboard/mensajes-admin`
+Archivo modificado: `src/app/dashboard/mensajes-admin/page.tsx`
+
+## Cambios
+- Traduce la pantalla de mensajes de socios del administrador según el idioma activo ES/EN.
+- Cubre header, KPI cards, bandeja de entrada, filtros, estados, buscador, vacíos/loading, panel de detalle y acciones de respuesta/cierre.
+- Traduce labels de estado: pendiente/leído/respondido/cerrado.
+- Traduce fallback de socio/sin email/sin nombre y toasts de acciones.
+- Mejora dark mode local en cards, bandeja, detalle, inputs, textarea, selección de mensaje y alertas.
+
+## Fuera de alcance
+- No modifica DB.
+- No modifica endpoints.
+- No modifica Swagger/OpenAPI.
+- No cambia la lógica de lectura, respuesta, cierre ni envío de email.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_PARAMETRIZACION_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_PARAMETRIZACION_FIX_V1.md
@@ -1,0 +1,39 @@
+# I18N ES/EN Admin Dashboard Final Sweep V3 - Parametrización Fix V1
+
+## Ruta cubierta
+
+- `/dashboard/parametrizacion`
+
+## Alcance
+
+- Traduce al inglés la pantalla de parametrización de catálogos cuando el locale activo es `en`.
+- Mantiene español cuando el locale activo es `es`.
+- Corrige textos estáticos de hero, KPIs, descuento por pago adelantado, listado de catálogos, acciones y modal de alta/edición.
+- Traduce etiquetas dinámicas de catálogos y registros persistidos solo a nivel presentación, sin modificar valores reales de DB.
+- Traduce badges de estado/prioridad: `Disponible`, `Base existente`, `Planificado`, `Alta`, `Media`, `Futura`, `Activo`, `Inactivo`.
+- Traduce contenido visible usado como opciones/valores de catálogos para combos: condiciones fiscales, tipos de empleado, contratación, puestos, áreas, turnos, horarios, medios de pago, tipos de gasto/ingreso, categorías de producto, equipamiento, ubicaciones y mantenimiento.
+- Mejora dark mode local en cards, tablas/listas de registros, chips, contenedores, formulario y modal.
+
+## Fuera de alcance
+
+- No modifica DB.
+- No modifica endpoints.
+- No modifica Swagger/OpenAPI.
+- No cambia lógica de creación, edición, activación/desactivación ni descuento.
+- No traduce persistencia real de catálogos; eso queda para la futura feature DB i18n con campos `*_en` o tabla de traducciones.
+
+## Validación sugerida
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+rm -rf .next
+npm run build
+```
+
+Luego limpiar artefactos PWA si aparecen:
+
+```bash
+git checkout -- public/sw.js
+rm -f public/fallback-*.js
+git status --short
+```

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_PERFIL_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_PERFIL_FIX_V1.md
@@ -1,0 +1,27 @@
+# I18N ES/EN Admin Dashboard Final Sweep V3 - Perfil Fix V1
+
+## Ruta
+
+- `/dashboard/perfil`
+
+## Alcance
+
+- Traduce la pantalla de perfil personal en ES/EN.
+- Traduce hero, estado de cuenta, datos de cuenta, accesos rápidos y recomendación de seguridad.
+- Traduce el bloque de foto de perfil, botones de subir/sacar/guardar/cambiar/cancelar foto y modal de cámara.
+- Traduce labels dinámicos de rol, estado, datos no registrados y estado de contraseña.
+- Mantiene la lógica de autenticación, carga de usuario, cámara y upload sin cambios funcionales.
+
+## Archivos modificados
+
+- `src/app/dashboard/perfil/page.tsx`
+- `src/components/perfil/ProfileCard.tsx`
+- `src/components/perfil/ProfileDetails.tsx`
+- `src/components/perfil/ProfileImage.tsx`
+
+## No incluido
+
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica lógica de upload/cámara/permisos.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_RESPALDO_NEGOCIO_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_RESPALDO_NEGOCIO_FIX_V1.md
@@ -1,0 +1,70 @@
+# i18n ES/EN Admin Dashboard Final Sweep V3 — Respaldo negocio fix v1
+
+## Ruta
+
+- `/dashboard/respaldo-negocio`
+
+## Alcance
+
+Este patch corrige residuos ES/EN de la pantalla de respaldo/exportación del negocio y mejora el modo oscuro local.
+
+## Cambios principales
+
+- Agrega `useI18n()` a la pantalla.
+- Traduce header de página:
+  - `Respaldo / Exportación` / `Backup / Export`
+  - `Exportación segura de datos operativos` / `Secure operational data export`
+  - `Respaldo del negocio` / `Business backup`
+- Traduce acciones y estados:
+  - `Actualizar` / `Refresh`
+  - `Generando...` / `Generating...`
+  - `Completado` / `Completed`
+  - `Generando` / `Generating`
+  - `Sin registros` / `No records`
+- Traduce cards/resumen:
+  - `Módulos disponibles` / `Available modules`
+  - `Seleccionados` / `Selected`
+  - `Última exportación` / `Last export`
+- Traduce panel de módulos:
+  - `Módulos exportables` / `Exportable modules`
+  - `Seleccionar todos` / `Select all`
+  - `Deseleccionar todos` / `Deselect all`
+  - `Cargando módulos...` / `Loading modules...`
+- Traduce labels/descripciones dinámicas de módulos recibidos desde API sin modificar backend ni DB:
+  - Datos del gimnasio, Socios, Usuarios internos, Empleados, Sueldos, Cuotas/Fees, Pagos, Asistencias, Ventas, Detalle de ventas, Compras, Detalle de compras, Productos/stock, Proveedores, Servicios, Gastos/egresos, Mensajes de socios, Tickets Dragon Pyramid.
+- Traduce historial:
+  - `Historial reciente` / `Recent history`
+  - `Formato` / `Format`
+  - `Registros` / `Records`
+  - `Módulos` / `Modules`
+  - `Todavía no hay exportaciones registradas.` / `No exports registered yet.`
+- Mejora dark mode local de:
+  - hero/card superior,
+  - KPI cards,
+  - cards de módulos seleccionados/no seleccionados,
+  - historial reciente,
+  - badges de estado.
+
+## Fuera de alcance
+
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No modifica la lógica de exportación Excel/JSON.
+- No traduce columnas internas del archivo exportado; eso queda para el sweep específico de exportables/PDF/Excel/tickets/labels.
+
+## Validación sugerida
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+rm -rf .next
+npm run build
+```
+
+Luego limpiar PWA si corresponde:
+
+```bash
+git checkout -- public/sw.js
+rm -f public/fallback-*.js
+git status --short
+```

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_SOPORTE_DRAGON_PYRAMID_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_SOPORTE_DRAGON_PYRAMID_FIX_V1.md
@@ -1,0 +1,73 @@
+# I18N ES/EN Admin Dashboard Final Sweep V3 — Soporte Dragon Pyramid Fix V1
+
+## Alcance
+
+Pantalla corregida:
+
+- `/dashboard/soporte-dragon-pyramid`
+
+## Cambios incluidos
+
+- Integra `useI18n()` en la pantalla de soporte Dragon Pyramid.
+- Traduce los textos estáticos del módulo en ES/EN:
+  - Header y hero.
+  - Cards KPI.
+  - Lectura ejecutiva.
+  - Nuevo ticket.
+  - Tickets enviados.
+  - Panel de detalle e historial.
+  - Toasts, errores, placeholders y estados vacíos.
+- Traduce explícitamente el contenido de combos y badges:
+  - Categorías: `Fallas`, `Dudas`, `Problemas`, `Sugerencias`, `Otros`.
+  - Prioridades: `Baja`, `Media`, `Alta`, `Crítica`.
+  - Estados/filtros: `Todos`, `Pendientes`, `En revisión`, `Respondidos`, `Cerrados`.
+- Corrige labels dinámicos de presentación:
+  - `Prioridad Alta` deja de depender de traducciones globales ambiguas y muestra `Priority High` en EN.
+  - `Email no confirmado`, `+48 h abierto`, `pendiente/no configurado`, etc.
+- Mantiene el contenido propio escrito por usuarios/tickets sin traducir, porque es dato ingresado/manual y no catálogo UI.
+
+## Archivos modificados
+
+- `src/app/dashboard/soporte-dragon-pyramid/page.tsx`
+
+## Fuera de alcance
+
+- No toca DB.
+- No toca endpoints.
+- No toca Swagger/OpenAPI.
+- No cambia la lógica de creación, seguimiento, respuesta ni cierre de tickets.
+- No traduce contenidos libres escritos por usuarios en asuntos/descripciones/comentarios.
+
+## Validación sugerida
+
+```bash
+cd /e/gym-master-2026/sistema/gym-master
+
+git status --short
+rm -rf .next
+npm run build
+```
+
+Después del build:
+
+```bash
+git checkout -- public/sw.js
+rm -f public/fallback-*.js
+
+git status --short
+```
+
+## QA manual sugerido
+
+Revisar `/dashboard/soporte-dragon-pyramid` en EN y ES:
+
+- Header/hero.
+- Cards KPI.
+- Lectura ejecutiva.
+- Formulario Nuevo ticket.
+- Combos Categoría, Prioridad y Estado.
+- Lista de tickets.
+- Badges de prioridad/estado/categoría.
+- Panel de detalle.
+- Historial.
+- Dark mode.

--- a/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_USUARIOS_FIX_V1.md
+++ b/README_I18N_ES_EN_ADMIN_DASHBOARD_FINAL_SWEEP_V3_USUARIOS_FIX_V1.md
@@ -1,0 +1,25 @@
+# i18n ES/EN Admin Dashboard Final Sweep v3 — Usuarios fix v1
+
+## Ruta
+
+- `/dashboard/usuarios`
+
+## Alcance
+
+- Traducción ES/EN de listado de usuarios, filtros, acciones, modales de alta/edición/detalle y mensajes de validación/toast.
+- Traducción de contenido de combos visibles: rol, sexo, puestos, áreas, tipos de contratación, turnos y horarios/disponibilidad.
+- Traducción de permisos, roles y estados presentados en tabla y modal de detalle.
+- Mejora local de dark mode en cards, tabla, modales, secciones operativas y permisos.
+
+## Archivos modificados
+
+- `src/app/dashboard/usuarios/page.tsx`
+- `src/components/forms/UserForm.tsx`
+- `src/components/modal/UserModal.tsx`
+- `src/components/modal/UserViewModal.tsx`
+- `src/components/tables/UserTable.tsx`
+
+## No incluido
+
+- No se tocan DB, endpoints, Swagger/OpenAPI, autenticación ni lógica de permisos.
+- No se modifica la estructura de roles/permisos; solo presentación UI ES/EN.

--- a/src/app/dashboard/avisos/page.tsx
+++ b/src/app/dashboard/avisos/page.tsx
@@ -16,10 +16,13 @@ import { getAllAvisos, deleteAviso } from "@/services/avisoService";
 import { Aviso } from "@/interfaces/aviso.interface";
 import AvisosModal from "@/components/modal/AvisosModal";
 import AvisosModalView from "@/components/modal/AvisosModalView";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function AvisosPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } =
     useAuthStore();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => (locale === "en" ? en : es);
   const router = useRouter();
   const [avisos, setAvisos] = useState<Aviso[]>([]);
   const [filteredAvisos, setFilteredAvisos] = useState<Aviso[]>([]);
@@ -80,7 +83,7 @@ export default function AvisosPage() {
   };
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{c("Cargando...", "Loading...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -92,30 +95,43 @@ export default function AvisosPage() {
       <div className="flex w-full min-h-screen">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Avisos" />
-          <main className="flex-1 p-6 space-y-6">
-            <Card className="w-full">
-              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
-                <h2 className="text-xl font-bold">Listado de Avisos</h2>
+          <AppHeader title={c("Avisos", "Notices")} />
+          <main className="flex-1 p-6 space-y-6 bg-slate-50/60 dark:bg-slate-950">
+            <Card className="w-full overflow-hidden border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
+              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b border-slate-200 md:flex-nowrap dark:border-slate-800">
+                <div>
+                  <h2 className="text-xl font-bold text-slate-950 dark:text-slate-50">
+                    {c("Listado de avisos", "Notices list")}
+                  </h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {c(
+                      "Gestioná avisos enviados, mensajes internos y comunicaciones al socio.",
+                      "Manage sent notices, internal messages, and member communications."
+                    )}
+                  </p>
+                </div>
                 <div className="flex flex-wrap items-center w-full gap-2 md:w-auto">
                   <div className="relative flex-grow md:flex-grow-0">
                     <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
                       type="search"
-                      placeholder="Buscar por título, mensaje, tipo o fecha..."
-                      className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
+                      placeholder={c(
+                        "Buscar por título, mensaje, tipo o fecha...",
+                        "Search by title, message, type, or date..."
+                      )}
+                      className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
                     />
                   </div>
                   <Button
-                    className="bg-[#02a8e1] hover:bg-[#0288b1]"
+                    className="bg-[#02a8e1] hover:bg-[#0288b1] text-white"
                     onClick={() => {
                       setSelectedAviso(null);
                       setOpenModal(true);
                     }}
                   >
-                    Nuevo Aviso
+                    {c("Nuevo aviso", "New notice")}
                   </Button>
                 </div>
               </CardHeader>

--- a/src/app/dashboard/gimnasio-parametrizacion/page.tsx
+++ b/src/app/dashboard/gimnasio-parametrizacion/page.tsx
@@ -21,8 +21,58 @@ import {
 } from '@/services/gimnasioParametrizacionService';
 import { useAuthStore } from '@/stores/authStore';
 import { useCatalogosParametrizables } from '@/hooks/useCatalogosParametrizables';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 
 const DEFAULT_LOGO = '/gm_logo.svg';
+
+function gymParamTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function normalizeGymParamText(value?: string | null) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+const FISCAL_CONDITION_LABELS_EN: Record<string, string> = {
+  responsable_inscripto: 'Registered VAT taxpayer',
+  'responsable inscripto': 'Registered VAT taxpayer',
+  monotributo: 'Monotributo',
+  consumidor_final: 'Final consumer',
+  'consumidor final': 'Final consumer',
+  exento: 'Tax-exempt',
+  no_responsable: 'Not liable',
+  'no responsable': 'Not liable',
+  otro: 'Other',
+};
+
+function translateFiscalCondition(locale: GymMasterLocale, value?: string | null) {
+  const text = String(value ?? '');
+  if (locale !== 'en') return text;
+  return FISCAL_CONDITION_LABELS_EN[normalizeGymParamText(text)] ?? text;
+}
+
+const STRIPE_STATUS_LABELS: Record<string, { es: string; en: string }> = {
+  no_configurado: { es: 'No configurado', en: 'Not configured' },
+  configurado: { es: 'Configurado', en: 'Configured' },
+  activo: { es: 'Activo', en: 'Active' },
+  inactivo: { es: 'Inactivo', en: 'Inactive' },
+};
+
+function translateStripeStatus(locale: GymMasterLocale, value: string) {
+  const labels = STRIPE_STATUS_LABELS[value];
+  return labels ? gymParamTx(locale, labels.es, labels.en) : value;
+}
+
+function translateStripeMode(locale: GymMasterLocale, value: 'test' | 'live') {
+  if (value === 'live') return gymParamTx(locale, 'Producción', 'Production');
+  return gymParamTx(locale, 'Test / sandbox', 'Test / sandbox');
+}
+
 
 const emptyForm: GimnasioParametrizacionPayload = {
   nombre_comercial: '',
@@ -104,6 +154,8 @@ const fallbackCondicionesFiscales = [
 export default function GimnasioParametrizacionPage() {
   const { user } = useAuthStore();
   const { catalogos } = useCatalogosParametrizables();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => gymParamTx(locale, es, en);
   const logoFileInputRef = useRef<HTMLInputElement | null>(null);
   const [form, setForm] = useState<GimnasioParametrizacionPayload>(emptyForm);
   const [data, setData] = useState<GimnasioParametrizacion | null>(null);
@@ -127,7 +179,7 @@ export default function GimnasioParametrizacionPage() {
         setForm(formFromData(response));
       } catch (err) {
         if (!mounted) return;
-        setError(err instanceof Error ? err.message : 'No se pudo cargar la parametrización.');
+        setError(err instanceof Error ? err.message : c('No se pudo cargar la parametrización.', 'Could not load gym settings.'));
       } finally {
         if (mounted) setLoading(false);
       }
@@ -137,7 +189,7 @@ export default function GimnasioParametrizacionPage() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [locale]);
 
   const logoPreview = useMemo(() => {
     const value = textValue(form.logo_url).trim();
@@ -193,9 +245,9 @@ export default function GimnasioParametrizacionPage() {
     try {
       const uploaded = await uploadGimnasioLogo(file);
       updateField('logo_url', uploaded.secure_url || uploaded.url);
-      setSuccessMessage('Logo subido a Cloudinary. Guardá la parametrización para persistirlo.');
+      setSuccessMessage(c('Logo subido a Cloudinary. Guardá la parametrización para persistirlo.', 'Logo uploaded to Cloudinary. Save the settings to persist the change.'));
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'No se pudo subir el logo a Cloudinary.');
+      setError(err instanceof Error ? err.message : c('No se pudo subir el logo a Cloudinary.', 'Could not upload the logo to Cloudinary.'));
     } finally {
       setUploadingLogo(false);
     }
@@ -211,9 +263,9 @@ export default function GimnasioParametrizacionPage() {
       const saved = await updateGimnasioParametrizacion(form);
       setData(saved);
       setForm(formFromData(saved));
-      setSuccessMessage('Parametrización del gimnasio actualizada correctamente.');
+      setSuccessMessage(c('Parametrización del gimnasio actualizada correctamente.', 'Gym settings updated successfully.'));
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'No se pudo guardar la parametrización.');
+      setError(err instanceof Error ? err.message : c('No se pudo guardar la parametrización.', 'Could not save gym settings.'));
     } finally {
       setSaving(false);
     }
@@ -224,23 +276,22 @@ export default function GimnasioParametrizacionPage() {
       <AppSidebar />
       <SidebarInset>
         <div className='min-h-screen bg-slate-50 dark:bg-slate-950'>
-          <AppHeader title="Datos del Gimnasio" />
+          <AppHeader title={c('Datos del Gimnasio', 'Gym data')} />
           <main className='mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 lg:px-8'>
             <section className='rounded-3xl border border-sky-100 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900'>
               <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
                 <div>
-                  <p className='text-sm font-semibold uppercase tracking-wide text-sky-600'>Parametrización</p>
+                  <p className='text-sm font-semibold uppercase tracking-wide text-sky-600'>{c('Parametrización', 'Settings')}</p>
                   <h1 className='mt-1 text-3xl font-bold tracking-tight text-slate-900 dark:text-white'>
-                    Branding y datos legales del gimnasio
+                    {c('Branding y datos legales del gimnasio', 'Branding and legal gym data')}
                   </h1>
                   <p className='mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300'>
-                    Configurá la identidad comercial y fiscal del gimnasio. Estos datos quedan listos para recibos,
-                    PDFs, reportes, exportaciones y futuras pantallas con branding propio del cliente.
+                    {c('Configurá la identidad comercial y fiscal del gimnasio. Estos datos quedan listos para recibos, PDFs, reportes, exportaciones y futuras pantallas con branding propio del cliente.', "Configure the gym's commercial and tax identity. These data are ready for receipts, PDFs, reports, exports, and future screens with the client's own branding.")}
                   </p>
                 </div>
                 <div className='rounded-2xl border border-sky-100 bg-sky-50 px-4 py-3 text-sm text-sky-800 dark:border-sky-900/60 dark:bg-sky-950/40 dark:text-sky-100'>
-                  <div className='font-semibold'>Administrador</div>
-                  <div>{user?.email ?? 'Usuario actual'}</div>
+                  <div className='font-semibold'>{c('Administrador', 'Administrator')}</div>
+                  <div>{user?.email ?? c('Usuario actual', 'Current user')}</div>
                 </div>
               </div>
             </section>
@@ -249,20 +300,20 @@ export default function GimnasioParametrizacionPage() {
               <Card>
                 <CardContent className='flex items-center gap-3 p-6 text-sm text-muted-foreground'>
                   <Loader2 className='h-4 w-4 animate-spin' />
-                  Cargando parametrización del gimnasio...
+                  {c('Cargando parametrización del gimnasio...', 'Loading gym settings...')}
                 </CardContent>
               </Card>
             ) : (
               <form onSubmit={handleSubmit} className='grid gap-6 xl:grid-cols-[1fr_360px]'>
                 <div className='space-y-6'>
                   {error && (
-                    <div className='rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700'>
+                    <div className='rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-200'>
                       {error}
                     </div>
                   )}
 
                   {successMessage && (
-                    <div className='flex items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700'>
+                    <div className='flex items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200'>
                       <CheckCircle2 className='h-4 w-4' />
                       {successMessage}
                     </div>
@@ -272,64 +323,64 @@ export default function GimnasioParametrizacionPage() {
                     <CardHeader>
                       <div className='flex items-center gap-2 text-lg font-semibold'>
                         <Building2 className='h-5 w-5 text-sky-600' />
-                        Identidad comercial y legal
+                        {c('Identidad comercial y legal', 'Commercial and legal identity')}
                       </div>
                     </CardHeader>
                     <CardContent className='grid gap-4 md:grid-cols-2'>
                       <div className='space-y-2'>
-                        <Label htmlFor='nombre_comercial'>Nombre comercial</Label>
+                        <Label htmlFor='nombre_comercial'>{c('Nombre comercial', 'Trade name')}</Label>
                         <Input id='nombre_comercial' value={textValue(form.nombre_comercial)} onChange={(e) => updateField('nombre_comercial', e.target.value)} required />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='razon_social'>Razón social</Label>
+                        <Label htmlFor='razon_social'>{c('Razón social', 'Legal name')}</Label>
                         <Input id='razon_social' value={textValue(form.razon_social)} onChange={(e) => updateField('razon_social', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='identificacion_fiscal'>CUIT / DNI fiscal</Label>
+                        <Label htmlFor='identificacion_fiscal'>{c('CUIT / DNI fiscal', 'Tax ID')}</Label>
                         <Input id='identificacion_fiscal' value={textValue(form.identificacion_fiscal)} onChange={(e) => updateField('identificacion_fiscal', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='condicion_fiscal'>Condición fiscal</Label>
+                        <Label htmlFor='condicion_fiscal'>{c('Condición fiscal', 'Tax condition')}</Label>
                         <select
                           id='condicion_fiscal'
                           value={textValue(form.condicion_fiscal)}
                           onChange={(e) => updateField('condicion_fiscal', e.target.value)}
                           className='h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                         >
-                          <option value=''>Seleccionar condición fiscal</option>
+                          <option value=''>{c('Seleccionar condición fiscal', 'Select tax condition')}</option>
                           {condicionesFiscales.map((item) => (
                             <option key={item.codigo} value={item.nombre}>
-                              {item.nombre}
+                              {translateFiscalCondition(locale, item.nombre)}
                             </option>
                           ))}
                         </select>
                       </div>
                       <div className='space-y-2 md:col-span-2'>
-                        <Label htmlFor='domicilio_legal'>Domicilio legal</Label>
+                        <Label htmlFor='domicilio_legal'>{c('Domicilio legal', 'Legal address')}</Label>
                         <Input id='domicilio_legal' value={textValue(form.domicilio_legal)} onChange={(e) => updateField('domicilio_legal', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='ciudad'>Ciudad</Label>
+                        <Label htmlFor='ciudad'>{c('Ciudad', 'City')}</Label>
                         <Input id='ciudad' value={textValue(form.ciudad)} onChange={(e) => updateField('ciudad', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='provincia'>Provincia</Label>
+                        <Label htmlFor='provincia'>{c('Provincia', 'Province')}</Label>
                         <Input id='provincia' value={textValue(form.provincia)} onChange={(e) => updateField('provincia', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='pais'>País</Label>
+                        <Label htmlFor='pais'>{c('País', 'Country')}</Label>
                         <Input id='pais' value={textValue(form.pais)} onChange={(e) => updateField('pais', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='telefono'>Teléfono</Label>
+                        <Label htmlFor='telefono'>{c('Teléfono', 'Phone')}</Label>
                         <Input id='telefono' value={textValue(form.telefono)} onChange={(e) => updateField('telefono', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='email'>Email institucional</Label>
+                        <Label htmlFor='email'>{c('Email institucional', 'Institutional email')}</Label>
                         <Input id='email' type='email' value={textValue(form.email)} onChange={(e) => updateField('email', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='sitio_web'>Sitio web</Label>
+                        <Label htmlFor='sitio_web'>{c('Sitio web', 'Website')}</Label>
                         <Input id='sitio_web' placeholder='https://...' value={textValue(form.sitio_web)} onChange={(e) => updateField('sitio_web', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
@@ -347,16 +398,16 @@ export default function GimnasioParametrizacionPage() {
                     <CardHeader>
                       <div className='flex items-center gap-2 text-lg font-semibold'>
                         <Palette className='h-5 w-5 text-sky-600' />
-                        Branding visual
+                        {c('Branding visual', 'Visual branding')}
                       </div>
                     </CardHeader>
                     <CardContent className='grid gap-4 md:grid-cols-2'>
                       <div className='space-y-2 md:col-span-2'>
-                        <Label htmlFor='logo_url'>Logo principal</Label>
+                        <Label htmlFor='logo_url'>{c('Logo principal', 'Main logo')}</Label>
                         <div className='grid gap-2 md:grid-cols-[1fr_auto]'>
                           <Input
                             id='logo_url'
-                            placeholder='/gm_logo.svg o https://...'
+                            placeholder={c('/gm_logo.svg o https://...', '/gm_logo.svg or https://...')}
                             value={textValue(form.logo_url)}
                             onChange={(e) => updateField('logo_url', e.target.value)}
                           />
@@ -372,7 +423,7 @@ export default function GimnasioParametrizacionPage() {
                             ) : (
                               <UploadCloud className='mr-2 h-4 w-4' />
                             )}
-                            Subir a Cloudinary
+                            {c('Subir a Cloudinary', 'Upload to Cloudinary')}
                           </Button>
                         </div>
                         <input
@@ -382,28 +433,28 @@ export default function GimnasioParametrizacionPage() {
                           className='hidden'
                           onChange={handleLogoFileChange}
                         />
-                        <p className='text-xs text-muted-foreground'>Podés pegar una URL pública o subir el logo principal a Cloudinary. Luego guardá la parametrización para persistir el cambio.</p>
+                        <p className='text-xs text-muted-foreground'>{c('Podés pegar una URL pública o subir el logo principal a Cloudinary. Luego guardá la parametrización para persistir el cambio.', 'You can paste a public URL or upload the main logo to Cloudinary. Then save the settings to persist the change.')}</p>
                       </div>
                       <div className='space-y-2 md:col-span-2'>
-                        <Label htmlFor='logo_alternativo_url'>Logo alternativo</Label>
-                        <Input id='logo_alternativo_url' placeholder='Opcional: versión horizontal, blanco o membrete' value={textValue(form.logo_alternativo_url)} onChange={(e) => updateField('logo_alternativo_url', e.target.value)} />
+                        <Label htmlFor='logo_alternativo_url'>{c('Logo alternativo', 'Alternative logo')}</Label>
+                        <Input id='logo_alternativo_url' placeholder={c('Opcional: versión horizontal, blanco o membrete', 'Optional: horizontal, white, or letterhead version')} value={textValue(form.logo_alternativo_url)} onChange={(e) => updateField('logo_alternativo_url', e.target.value)} />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='color_primario'>Color primario</Label>
+                        <Label htmlFor='color_primario'>{c('Color primario', 'Primary color')}</Label>
                         <div className='flex gap-2'>
                           <Input id='color_primario' type='color' value={textValue(form.color_primario) || '#0EA5E9'} onChange={(e) => updateField('color_primario', e.target.value)} className='h-10 w-16 p-1' />
                           <Input value={textValue(form.color_primario)} onChange={(e) => updateField('color_primario', e.target.value)} />
                         </div>
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='color_secundario'>Color secundario</Label>
+                        <Label htmlFor='color_secundario'>{c('Color secundario', 'Secondary color')}</Label>
                         <div className='flex gap-2'>
                           <Input id='color_secundario' type='color' value={textValue(form.color_secundario) || '#111827'} onChange={(e) => updateField('color_secundario', e.target.value)} className='h-10 w-16 p-1' />
                           <Input value={textValue(form.color_secundario)} onChange={(e) => updateField('color_secundario', e.target.value)} />
                         </div>
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='color_acento'>Color de acento</Label>
+                        <Label htmlFor='color_acento'>{c('Color de acento', 'Accent color')}</Label>
                         <div className='flex gap-2'>
                           <Input id='color_acento' type='color' value={textValue(form.color_acento) || '#22C55E'} onChange={(e) => updateField('color_acento', e.target.value)} className='h-10 w-16 p-1' />
                           <Input value={textValue(form.color_acento)} onChange={(e) => updateField('color_acento', e.target.value)} />
@@ -416,7 +467,7 @@ export default function GimnasioParametrizacionPage() {
                     <CardHeader>
                       <div className='flex items-center gap-2 text-lg font-semibold'>
                         <CreditCard className='h-5 w-5 text-sky-600' />
-                        Pagos online Stripe
+                        {c('Pagos online Stripe', 'Stripe online payments')}
                       </div>
                     </CardHeader>
                     <CardContent className='grid gap-4 md:grid-cols-2'>
@@ -429,68 +480,68 @@ export default function GimnasioParametrizacionPage() {
                             className='mt-1 h-4 w-4 rounded border-slate-300'
                           />
                           <span>
-                            <span className='block font-semibold text-slate-900 dark:text-white'>Habilitar pagos online con Stripe</span>
+                            <span className='block font-semibold text-slate-900 dark:text-white'>{c('Habilitar pagos online con Stripe', 'Enable online payments with Stripe')}</span>
                             <span className='mt-1 block text-xs leading-5 text-slate-600 dark:text-slate-300'>
-                              Si está desactivado, los socios no verán disponible el checkout online y deberán abonar por medios manuales registrados por administración.
+                              {c('Si está desactivado, los socios no verán disponible el checkout online y deberán abonar por medios manuales registrados por administración.', 'If disabled, members will not see online checkout available and must pay through manual methods registered by administration.')}
                             </span>
                           </span>
                         </label>
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='stripe_estado'>Estado de integración</Label>
+                        <Label htmlFor='stripe_estado'>{c('Estado de integración', 'Integration status')}</Label>
                         <select
                           id='stripe_estado'
                           value={textValue(form.stripe_estado) || 'no_configurado'}
                           onChange={(e) => updateStripeEstado(e.target.value)}
                           className='h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                         >
-                          <option value='no_configurado'>No configurado</option>
-                          <option value='configurado'>Configurado</option>
-                          <option value='activo'>Activo</option>
-                          <option value='inactivo'>Inactivo</option>
+                          <option value='no_configurado'>{translateStripeStatus(locale, 'no_configurado')}</option>
+                          <option value='configurado'>{translateStripeStatus(locale, 'configurado')}</option>
+                          <option value='activo'>{translateStripeStatus(locale, 'activo')}</option>
+                          <option value='inactivo'>{translateStripeStatus(locale, 'inactivo')}</option>
                         </select>
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='stripe_modo'>Modo</Label>
+                        <Label htmlFor='stripe_modo'>{c('Modo', 'Mode')}</Label>
                         <select
                           id='stripe_modo'
                           value={textValue(form.stripe_modo) || 'test'}
                           onChange={(e) => updateField('stripe_modo', e.target.value)}
                           className='h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                         >
-                          <option value='test'>Test / sandbox</option>
-                          <option value='live'>Producción</option>
+                          <option value='test'>{translateStripeMode(locale, 'test')}</option>
+                          <option value='live'>{translateStripeMode(locale, 'live')}</option>
                         </select>
                       </div>
                       <div className='space-y-2 md:col-span-2'>
-                        <Label htmlFor='stripe_public_key'>Publishable key / referencia pública</Label>
+                        <Label htmlFor='stripe_public_key'>{c('Publishable key / referencia pública', 'Publishable key / public reference')}</Label>
                         <Input
                           id='stripe_public_key'
-                          placeholder='Opcional. No guardar claves secretas acá.'
+                          placeholder={c('Opcional. No guardar claves secretas acá.', 'Optional. Do not store secret keys here.')}
                           value={textValue(form.stripe_public_key)}
                           onChange={(e) => updateField('stripe_public_key', e.target.value)}
                         />
                         <p className='text-xs text-muted-foreground'>
-                          Las claves secretas y webhooks se manejan por variables de entorno seguras. Este campo es solo referencia operativa.
+                          {c('Las claves secretas y webhooks se manejan por variables de entorno seguras. Este campo es solo referencia operativa.', 'Secret keys and webhooks are managed through secure environment variables. This field is only an operational reference.')}
                         </p>
                       </div>
                       <div className='space-y-2 md:col-span-2'>
-                        <Label htmlFor='stripe_account_reference'>Referencia de cuenta Stripe</Label>
+                        <Label htmlFor='stripe_account_reference'>{c('Referencia de cuenta Stripe', 'Stripe account reference')}</Label>
                         <Input
                           id='stripe_account_reference'
-                          placeholder='Ej: cuenta conectada, cliente, alias o identificador interno'
+                          placeholder={c('Ej: cuenta conectada, cliente, alias o identificador interno', 'Example: connected account, client, alias, or internal identifier')}
                           value={textValue(form.stripe_account_reference)}
                           onChange={(e) => updateField('stripe_account_reference', e.target.value)}
                         />
                       </div>
                       <div className='space-y-2 md:col-span-2'>
-                        <Label htmlFor='stripe_observaciones'>Observaciones Stripe</Label>
+                        <Label htmlFor='stripe_observaciones'>{c('Observaciones Stripe', 'Stripe notes')}</Label>
                         <textarea
                           id='stripe_observaciones'
                           value={textValue(form.stripe_observaciones)}
                           onChange={(e) => updateField('stripe_observaciones', e.target.value)}
                           className='min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm'
-                          placeholder='Notas internas sobre configuración, estado comercial o validaciones pendientes.'
+                          placeholder={c('Notas internas sobre configuración, estado comercial o validaciones pendientes.', 'Internal notes about configuration, commercial status, or pending validations.')}
                         />
                       </div>
                     </CardContent>
@@ -500,20 +551,20 @@ export default function GimnasioParametrizacionPage() {
                     <CardHeader>
                       <div className='flex items-center gap-2 text-lg font-semibold'>
                         <ReceiptText className='h-5 w-5 text-sky-600' />
-                        Textos legales para documentos
+                        {c('Textos legales para documentos', 'Legal texts for documents')}
                       </div>
                     </CardHeader>
                     <CardContent className='grid gap-4'>
                       <div className='space-y-2'>
-                        <Label htmlFor='texto_legal_recibos'>Texto legal para recibos</Label>
+                        <Label htmlFor='texto_legal_recibos'>{c('Texto legal para recibos', 'Legal text for receipts')}</Label>
                         <textarea id='texto_legal_recibos' value={textValue(form.texto_legal_recibos)} onChange={(e) => updateField('texto_legal_recibos', e.target.value)} className='min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm' />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='texto_legal_reportes'>Texto legal para reportes/PDF</Label>
+                        <Label htmlFor='texto_legal_reportes'>{c('Texto legal para reportes/PDF', 'Legal text for reports/PDF')}</Label>
                         <textarea id='texto_legal_reportes' value={textValue(form.texto_legal_reportes)} onChange={(e) => updateField('texto_legal_reportes', e.target.value)} className='min-h-[90px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm' />
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='pie_pagina_documentos'>Pie de página institucional</Label>
+                        <Label htmlFor='pie_pagina_documentos'>{c('Pie de página institucional', 'Institutional footer')}</Label>
                         <textarea id='pie_pagina_documentos' value={textValue(form.pie_pagina_documentos)} onChange={(e) => updateField('pie_pagina_documentos', e.target.value)} className='min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm' />
                       </div>
                     </CardContent>
@@ -525,17 +576,17 @@ export default function GimnasioParametrizacionPage() {
                     <CardHeader>
                       <div className='flex items-center gap-2 text-lg font-semibold'>
                         <ShieldCheck className='h-5 w-5 text-sky-600' />
-                        Vista previa
+                        {c('Vista previa', 'Preview')}
                       </div>
                     </CardHeader>
                     <CardContent className='space-y-5'>
-                      <div className='rounded-2xl border bg-white p-5 text-center shadow-sm dark:bg-slate-950'>
-                        <div className='mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-2xl border bg-slate-50 p-3'>
-                          <img src={logoPreview} alt='Logo del gimnasio' className='max-h-20 max-w-20 object-contain' onError={() => setLogoBroken(true)} />
+                      <div className='rounded-2xl border bg-white p-5 text-center shadow-sm dark:border-slate-800 dark:bg-slate-950'>
+                        <div className='mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-2xl border bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-900'>
+                          <img src={logoPreview} alt={c('Logo del gimnasio', 'Gym logo')} className='max-h-20 max-w-20 object-contain' onError={() => setLogoBroken(true)} />
                         </div>
                         <h2 className='text-xl font-bold'>{textValue(form.nombre_comercial) || 'Gym Master'}</h2>
-                        <p className='text-sm text-muted-foreground'>{textValue(form.razon_social) || 'Razón social pendiente'}</p>
-                        <p className='text-xs text-muted-foreground'>{textValue(form.identificacion_fiscal) || 'CUIT/DNI fiscal pendiente'}</p>
+                        <p className='text-sm text-muted-foreground'>{textValue(form.razon_social) || c('Razón social pendiente', 'Pending legal name')}</p>
+                        <p className='text-xs text-muted-foreground'>{textValue(form.identificacion_fiscal) || c('CUIT/DNI fiscal pendiente', 'Pending tax ID')}</p>
                         <div className='mt-4 flex justify-center gap-2'>
                           <span className='h-8 w-8 rounded-full border' style={{ backgroundColor: textValue(form.color_primario) || '#0EA5E9' }} />
                           <span className='h-8 w-8 rounded-full border' style={{ backgroundColor: textValue(form.color_secundario) || '#111827' }} />
@@ -543,28 +594,28 @@ export default function GimnasioParametrizacionPage() {
                         </div>
                       </div>
 
-                      <div className='rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-800'>
-                        La parametrización se usa como fuente única para recibos, reportes PDF comerciales y exportaciones. Los nuevos documentos deben consumir estos datos del gimnasio.
+                      <div className='rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs leading-5 text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200'>
+                        {c('La parametrización se usa como fuente única para recibos, reportes PDF comerciales y exportaciones. Los nuevos documentos deben consumir estos datos del gimnasio.', 'These settings are used as the single source for receipts, commercial PDF reports, and exports. New documents must consume these gym data.')}
                       </div>
 
                       <div className={`rounded-xl border px-4 py-3 text-xs leading-5 ${
                         form.stripe_habilitado && form.stripe_estado === 'activo'
-                          ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
-                          : 'border-slate-200 bg-slate-50 text-slate-700'
+                          ? 'border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-200'
+                          : 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300'
                       }`}>
                         <strong>Stripe:</strong>{' '}
                         {form.stripe_habilitado && form.stripe_estado === 'activo'
-                          ? 'pagos online habilitados para socios.'
-                          : 'pagos online deshabilitados o pendientes de activación.'}
+                          ? c('pagos online habilitados para socios.', 'online payments enabled for members.')
+                          : c('pagos online deshabilitados o pendientes de activación.', 'online payments disabled or pending activation.')}
                       </div>
 
                       <Button type='submit' disabled={saving} className='w-full'>
                         {saving ? <Loader2 className='mr-2 h-4 w-4 animate-spin' /> : <Save className='mr-2 h-4 w-4' />}
-                        Guardar parametrización
+                        {c('Guardar parametrización', 'Save settings')}
                       </Button>
 
                       {data?.actualizado_en && (
-                        <p className='text-center text-xs text-muted-foreground'>Última actualización: {new Date(data.actualizado_en).toLocaleString('es-AR')}</p>
+                        <p className='text-center text-xs text-muted-foreground'>{c('Última actualización:', 'Last update:')} {new Date(data.actualizado_en).toLocaleString(locale === 'en' ? 'en-US' : 'es-AR')}</p>
                       )}
                     </CardContent>
                   </Card>

--- a/src/app/dashboard/mensajes-admin/page.tsx
+++ b/src/app/dashboard/mensajes-admin/page.tsx
@@ -14,24 +14,49 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
 import { SocioMensaje, SocioMensajeEstado } from '@/interfaces/socioMensaje.interface';
 import { actualizarMensajeSocioAdmin, getMensajesSociosAdmin } from '@/services/apiClient';
 import { useAuthStore } from '@/stores/authStore';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
 
-const estados: Array<{ value: SocioMensajeEstado | 'todos'; label: string }> = [
-  { value: 'todos', label: 'Todos' },
-  { value: 'pendiente', label: 'Pendientes' },
-  { value: 'leido', label: 'Leídos' },
-  { value: 'respondido', label: 'Respondidos' },
-  { value: 'cerrado', label: 'Cerrados' },
-];
+function mensajesAdminTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
 
-const estadoLabel: Record<string, string> = {
-  pendiente: 'Pendiente',
-  leido: 'Leído',
-  respondido: 'Respondido',
-  cerrado: 'Cerrado',
-};
+function getEstadosOptions(locale: GymMasterLocale): Array<{ value: SocioMensajeEstado | 'todos'; label: string }> {
+  const c = (es: string, en: string) => mensajesAdminTx(locale, es, en);
+
+  return [
+    { value: 'todos', label: c('Todos', 'All') },
+    { value: 'pendiente', label: c('Pendientes', 'Pending') },
+    { value: 'leido', label: c('Leídos', 'Read') },
+    { value: 'respondido', label: c('Respondidos', 'Responded') },
+    { value: 'cerrado', label: c('Cerrados', 'Closed') },
+  ];
+}
+
+function getEstadoLabel(locale: GymMasterLocale, estado: string) {
+  const labels: Record<GymMasterLocale, Record<string, string>> = {
+    es: {
+      pendiente: 'Pendiente',
+      leido: 'Leído',
+      respondido: 'Respondido',
+      cerrado: 'Cerrado',
+    },
+    en: {
+      pendiente: 'Pending',
+      leido: 'Read',
+      respondido: 'Responded',
+      cerrado: 'Closed',
+    },
+  };
+
+  return labels[locale][estado] ?? estado;
+}
 
 export default function MensajesAdminPage() {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => mensajesAdminTx(locale, es, en);
+  const estados = useMemo(() => getEstadosOptions(locale), [locale]);
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const [mensajes, setMensajes] = useState<SocioMensaje[]>([]);
   const [selected, setSelected] = useState<SocioMensaje | null>(null);
@@ -49,11 +74,11 @@ export default function MensajesAdminPage() {
     setLoading(true);
     try {
       const response = await getMensajesSociosAdmin({ estado: estadoFilter, q: searchTerm.trim() });
-      if (!response.ok) throw new Error(response.error || 'No se pudieron cargar los mensajes');
+      if (!response.ok) throw new Error(response.error || c('No se pudieron cargar los mensajes', 'Messages could not be loaded'));
       setMensajes(response.data ?? []);
     } catch (error) {
       setMensajes([]);
-      toast.error(error instanceof Error ? error.message : 'Error al cargar mensajes');
+      toast.error(error instanceof Error ? error.message : c('Error al cargar mensajes', 'Error loading messages'));
     } finally {
       setLoading(false);
     }
@@ -96,19 +121,19 @@ export default function MensajesAdminPage() {
   const handleResponder = async () => {
     if (!selected) return;
     if (!respuesta.trim()) {
-      toast.error('Escribí una respuesta antes de enviar.');
+      toast.error(c('Escribí una respuesta antes de enviar.', 'Write a reply before sending.'));
       return;
     }
 
     setSaving(true);
     try {
       const response = await actualizarMensajeSocioAdmin(selected.id, { respuesta });
-      if (!response.ok || !response.data) throw new Error(response.error || 'No se pudo responder el mensaje');
-      toast.success('Respuesta guardada y enviada al socio por email');
+      if (!response.ok || !response.data) throw new Error(response.error || c('No se pudo responder el mensaje', 'The message could not be answered'));
+      toast.success(c('Respuesta guardada y enviada al socio por email', 'Reply saved and sent to the member by email'));
       setSelected(response.data);
       await loadMensajes();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Error al responder');
+      toast.error(error instanceof Error ? error.message : c('Error al responder', 'Error sending reply'));
     } finally {
       setSaving(false);
     }
@@ -119,18 +144,18 @@ export default function MensajesAdminPage() {
     setSaving(true);
     try {
       const response = await actualizarMensajeSocioAdmin(selected.id, { estado: 'cerrado' });
-      if (!response.ok || !response.data) throw new Error(response.error || 'No se pudo cerrar el mensaje');
-      toast.success('Mensaje cerrado');
+      if (!response.ok || !response.data) throw new Error(response.error || c('No se pudo cerrar el mensaje', 'The message could not be closed'));
+      toast.success(c('Mensaje cerrado', 'Message closed'));
       setSelected(response.data);
       await loadMensajes();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Error al cerrar mensaje');
+      toast.error(error instanceof Error ? error.message : c('Error al cerrar mensaje', 'Error closing message'));
     } finally {
       setSaving(false);
     }
   };
 
-  if (!isInitialized) return <div>Cargando...</div>;
+  if (!isInitialized) return <div>{c('Cargando...', 'Loading...')}</div>;
   if (!isAuthenticated) return null;
 
   return (
@@ -138,32 +163,32 @@ export default function MensajesAdminPage() {
       <div className='flex min-h-screen w-full'>
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title='Mensajes de socios' />
-          <main className='flex-1 space-y-6 p-6'>
+          <AppHeader title={c('Mensajes de socios', 'Member messages')} />
+          <main className='flex-1 space-y-6 bg-slate-50/70 p-6 dark:bg-slate-950'>
             <section className='grid gap-4 md:grid-cols-3'>
-              <Card>
+              <Card className='border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950/70'>
                 <CardContent className='flex items-center gap-3 p-4'>
                   <Inbox className='h-8 w-8 text-sky-600' />
                   <div>
-                    <p className='text-sm text-muted-foreground'>Mensajes</p>
+                    <p className='text-sm text-muted-foreground'>{c('Mensajes', 'Messages')}</p>
                     <p className='text-2xl font-bold'>{totals.total}</p>
                   </div>
                 </CardContent>
               </Card>
-              <Card>
+              <Card className='border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950/70'>
                 <CardContent className='flex items-center gap-3 p-4'>
                   <MessageSquareReply className='h-8 w-8 text-amber-600' />
                   <div>
-                    <p className='text-sm text-muted-foreground'>Pendientes</p>
+                    <p className='text-sm text-muted-foreground'>{c('Pendientes', 'Pending')}</p>
                     <p className='text-2xl font-bold'>{totals.pendientes}</p>
                   </div>
                 </CardContent>
               </Card>
-              <Card>
+              <Card className='border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950/70'>
                 <CardContent className='flex items-center gap-3 p-4'>
                   <MailCheck className='h-8 w-8 text-emerald-600' />
                   <div>
-                    <p className='text-sm text-muted-foreground'>Respondidos</p>
+                    <p className='text-sm text-muted-foreground'>{c('Respondidos', 'Responded')}</p>
                     <p className='text-2xl font-bold'>{totals.respondidos}</p>
                   </div>
                 </CardContent>
@@ -171,18 +196,18 @@ export default function MensajesAdminPage() {
             </section>
 
             <div className='grid gap-6 xl:grid-cols-[1.1fr_0.9fr]'>
-              <Card>
-                <CardHeader className='border-b p-4'>
+              <Card className='border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950/70'>
+                <CardHeader className='border-b border-slate-200 p-4 dark:border-slate-800'>
                   <div className='flex flex-wrap items-center justify-between gap-3'>
                     <div>
-                      <h2 className='text-xl font-bold'>Bandeja de entrada</h2>
-                      <p className='text-sm text-muted-foreground'>Consultas, reclamos y preguntas enviadas por socios.</p>
+                      <h2 className='text-xl font-bold'>{c('Bandeja de entrada', 'Inbox')}</h2>
+                      <p className='text-sm text-muted-foreground'>{c('Consultas, reclamos y preguntas enviadas por socios.', 'Queries, complaints, and questions sent by members.')}</p>
                     </div>
                     <form className='flex flex-wrap gap-2' onSubmit={handleSearchSubmit}>
                       <select
                         value={estadoFilter}
                         onChange={(event) => setEstadoFilter(event.target.value as SocioMensajeEstado | 'todos')}
-                        className='h-10 rounded-md border border-input bg-background px-3 text-sm'
+                        className='h-10 rounded-md border border-input bg-background px-3 text-sm dark:border-slate-700 dark:bg-slate-950'
                       >
                         {estados.map((estado) => (
                           <option key={estado.value} value={estado.value}>{estado.label}</option>
@@ -192,37 +217,37 @@ export default function MensajesAdminPage() {
                         <Search className='absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground' />
                         <Input
                           type='search'
-                          className='w-64 pl-8'
-                          placeholder='Buscar asunto o mensaje...'
+                          className='w-64 pl-8 dark:border-slate-700 dark:bg-slate-950'
+                          placeholder={c('Buscar asunto o mensaje...', 'Search subject or message...')}
                           value={searchTerm}
                           onChange={(event) => setSearchTerm(event.target.value)}
                         />
                       </div>
-                      <Button type='submit' variant='outline'>Buscar</Button>
+                      <Button type='submit' variant='outline'>{c('Buscar', 'Search')}</Button>
                     </form>
                   </div>
                 </CardHeader>
                 <CardContent className='space-y-3 p-4'>
                   {loading ? (
-                    <div className='py-8 text-center text-muted-foreground'>Cargando mensajes...</div>
+                    <div className='py-8 text-center text-muted-foreground'>{c('Cargando mensajes...', 'Loading messages...')}</div>
                   ) : mensajes.length === 0 ? (
-                    <div className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>No hay mensajes para el filtro seleccionado.</div>
+                    <div className='rounded-lg border border-dashed border-slate-300 p-6 text-center text-sm text-muted-foreground dark:border-slate-700'>{c('No hay mensajes para el filtro seleccionado.', 'There are no messages for the selected filter.')}</div>
                   ) : (
                     mensajes.map((mensaje) => (
                       <button
                         key={mensaje.id}
                         type='button'
                         onClick={() => handleSelect(mensaje)}
-                        className={`w-full rounded-xl border p-4 text-left transition hover:bg-muted/60 ${selected?.id === mensaje.id ? 'border-primary bg-muted' : ''}`}
+                        className={`w-full rounded-xl border p-4 text-left transition hover:bg-muted/60 dark:border-slate-800 dark:hover:bg-slate-900/80 ${selected?.id === mensaje.id ? 'border-primary bg-muted dark:bg-slate-900' : 'bg-white dark:bg-slate-950/40'}`}
                       >
                         <div className='flex flex-wrap items-start justify-between gap-3'>
                           <div>
                             <h3 className='font-semibold'>{mensaje.asunto}</h3>
                             <p className='text-xs text-muted-foreground'>
-                              {mensaje.socio?.nombre_completo ?? 'Socio'} · {mensaje.socio?.email ?? 'sin email'}
+                              {mensaje.socio?.nombre_completo ?? c('Socio', 'Member')} · {mensaje.socio?.email ?? c('sin email', 'no email')}
                             </p>
                           </div>
-                          <span className='rounded-full bg-background px-3 py-1 text-xs font-medium'>{estadoLabel[mensaje.estado] ?? mensaje.estado}</span>
+                          <span className='rounded-full bg-background px-3 py-1 text-xs font-medium dark:bg-slate-900'>{getEstadoLabel(locale, mensaje.estado)}</span>
                         </div>
                         <p className='mt-2 line-clamp-2 text-sm text-muted-foreground'>{mensaje.mensaje}</p>
                         <p className='mt-2 text-xs text-muted-foreground'>{formatFrontendDateTime(mensaje.creado_en)}</p>
@@ -232,49 +257,49 @@ export default function MensajesAdminPage() {
                 </CardContent>
               </Card>
 
-              <Card>
-                <CardHeader className='border-b p-4'>
-                  <h2 className='text-xl font-bold'>Detalle y respuesta</h2>
+              <Card className='border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950/70'>
+                <CardHeader className='border-b border-slate-200 p-4 dark:border-slate-800'>
+                  <h2 className='text-xl font-bold'>{c('Detalle y respuesta', 'Details and reply')}</h2>
                 </CardHeader>
                 <CardContent className='space-y-4 p-4'>
                   {!selected ? (
-                    <div className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>Seleccioná un mensaje para responder.</div>
+                    <div className='rounded-lg border border-dashed border-slate-300 p-6 text-center text-sm text-muted-foreground dark:border-slate-700'>{c('Seleccioná un mensaje para responder.', 'Select a message to reply.')}</div>
                   ) : (
                     <>
                       <div>
-                        <p className='text-xs text-muted-foreground'>Socio</p>
-                        <p className='font-semibold'>{selected.socio?.nombre_completo ?? 'Sin nombre'}</p>
-                        <p className='text-sm text-muted-foreground'>{selected.socio?.email ?? 'Sin email'} · DNI {selected.socio?.dni ?? '-'}</p>
+                        <p className='text-xs text-muted-foreground'>{c('Socio', 'Member')}</p>
+                        <p className='font-semibold'>{selected.socio?.nombre_completo ?? c('Sin nombre', 'No name')}</p>
+                        <p className='text-sm text-muted-foreground'>{selected.socio?.email ?? c('Sin email', 'No email')} · {c('DNI', 'ID')} {selected.socio?.dni ?? '-'}</p>
                       </div>
                       <div>
-                        <p className='text-xs text-muted-foreground'>Asunto</p>
+                        <p className='text-xs text-muted-foreground'>{c('Asunto', 'Subject')}</p>
                         <p className='font-semibold'>{selected.asunto}</p>
                       </div>
-                      <div className='rounded-lg bg-muted p-3 text-sm'>
+                      <div className='rounded-lg bg-muted p-3 text-sm dark:bg-slate-900'>
                         <p className='whitespace-pre-line'>{selected.mensaje}</p>
                       </div>
                       <div className='space-y-2'>
-                        <Label htmlFor='respuesta'>Respuesta administrativa</Label>
+                        <Label htmlFor='respuesta'>{c('Respuesta administrativa', 'Admin reply')}</Label>
                         <textarea
                           id='respuesta'
                           value={respuesta}
                           rows={7}
-                          placeholder='Escribí la respuesta para el socio...'
+                          placeholder={c('Escribí la respuesta para el socio...', 'Write the reply for the member...')}
                           onChange={(event) => setRespuesta(event.target.value)}
-                          className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                          className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-slate-700 dark:bg-slate-950'
                         />
                       </div>
                       {selected.email_respuesta_error && (
-                        <div className='rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900'>
-                          Email no enviado: {selected.email_respuesta_error}
+                        <div className='rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100'>
+                          {c('Email no enviado:', 'Email not sent:')} {selected.email_respuesta_error}
                         </div>
                       )}
                       <div className='flex flex-wrap justify-end gap-2'>
                         <Button type='button' variant='outline' onClick={handleCerrar} disabled={saving || selected.estado === 'cerrado'}>
-                          Cerrar
+                          {c('Cerrar', 'Close')}
                         </Button>
                         <Button type='button' onClick={handleResponder} disabled={saving}>
-                          {saving ? 'Guardando...' : 'Responder y enviar email'}
+                          {saving ? c('Guardando...', 'Saving...') : c('Responder y enviar email', 'Reply and send email')}
                         </Button>
                       </div>
                     </>

--- a/src/app/dashboard/parametrizacion/page.tsx
+++ b/src/app/dashboard/parametrizacion/page.tsx
@@ -60,6 +60,8 @@ import {
 } from "@/services/parametrizacionService";
 import { useAuthStore } from "@/stores/authStore";
 import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
 type CatalogUiDefinition = {
   icon: React.ElementType;
@@ -183,6 +185,206 @@ function formatDateTime(value?: string) {
   return Number.isNaN(date.getTime()) ? "-" : formatFrontendDateTime(value);
 }
 
+function parametrizacionTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function normalizeParametrizacionText(value?: string | null) {
+  return String(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+}
+
+const PARAMETRIZACION_TEXT_EN: Record<string, string> = {
+  disponible: "Available",
+  "base existente": "Existing base",
+  planificado: "Planned",
+  active: "Active",
+  activo: "Active",
+  activos: "Active",
+  inactive: "Inactive",
+  inactivo: "Inactive",
+  inactivos: "Inactive",
+  alta: "High",
+  media: "Medium",
+  futura: "Future",
+  registros: "Records",
+  total: "Total",
+
+  "descuento por pago adelantado": "Advance payment discount",
+  "descuento configurable para socios que pagan cuotas por adelantado.":
+    "Configurable discount for members who pay fees in advance.",
+  "mensaje al socio/admin": "Message to member/admin",
+
+  "condiciones fiscales": "Fiscal conditions",
+  "catalogo fiscal para datos legales del gimnasio: responsable inscripto, monotributo, consumidor final, exento u otras condiciones.":
+    "Fiscal catalog for gym legal data: registered VAT taxpayer, monotributo, final consumer, tax-exempt, or other conditions.",
+  "tipos de empleado": "Employee types",
+  "base para evolucionar entrenadores hacia empleados, sueldos, recibos y reportes por rol.":
+    "Base to evolve trainers into employees, salaries, receipts, and role-based reports.",
+  "tipos de contratacion": "Contract types",
+  "modalidades contractuales para empleados de gimnasio: mensual, por hora, jornal, eventual, pasantia u otras.":
+    "Contract modalities for gym employees: monthly, hourly, daily wage, temporary, internship, or others.",
+  "puestos / responsabilidades": "Roles / responsibilities",
+  "responsabilidades laborales usadas al crear usuarios internos y perfiles de empleados.":
+    "Work responsibilities used when creating internal users and employee profiles.",
+  "areas de trabajo": "Work areas",
+  "areas operativas del gimnasio: recepcion, entrenamiento, mantenimiento, limpieza, bar/snack y administracion.":
+    "Operational gym areas: reception, training, maintenance, cleaning, bar/snack, and administration.",
+  shifts: "Shifts",
+  turnos: "Shifts",
+  "shifts laborales disponibles para usuarios internos y empleados.":
+    "Work shifts available for internal users and employees.",
+  "schedule / availability": "Schedule / availability",
+  "horarios / disponibilidad": "Schedule / availability",
+  "bloques de disponibilidad horaria frecuentes para empleados de gimnasio.":
+    "Frequent schedule availability blocks for gym employees.",
+  "medios de pago": "Payment methods",
+  "medios disponibles para cuotas, ventas, transferencias, stripe y futuros recibos verificables.":
+    "Available methods for fees, sales, transfers, Stripe, and future verifiable receipts.",
+  "tipos de gasto": "Expense types",
+  "clasificacion de egresos operativos: sueldos, mantenimiento, servicios, insumos e impuestos.":
+    "Classification of operational outflows: salaries, maintenance, services, supplies, and taxes.",
+  "tipos de ingreso": "Income types",
+  "clasificacion de ingresos por cuotas, ventas, servicios, clases especiales y promociones.":
+    "Classification of income from fees, sales, services, special classes, and promotions.",
+  "categorias de producto": "Product categories",
+  "categorias para ordenar productos, ventas adicionales, stock y reportes comerciales.":
+    "Categories to organize products, add-on sales, stock, and commercial reports.",
+  "tipos de equipamiento": "Equipment types",
+  "catalogo base para clasificar maquinas y equipamiento del gimnasio.":
+    "Base catalog for classifying gym machines and equipment.",
+  "ubicaciones de equipamiento": "Equipment locations",
+  "sectores fisicos donde se ubican maquinas, accesorios y espacios operativos del gimnasio.":
+    "Physical sectors where machines, accessories, and operational gym spaces are located.",
+  "ubicaciones del gimnasio": "Gym locations",
+  "catalogo global de zonas, salas y sectores fisicos del gimnasio para actividades, equipamiento, mantenimiento, asistencia y bi.":
+    "Global catalog of gym zones, rooms, and physical sectors for activities, equipment, maintenance, attendance, and BI.",
+  "tipos de mantenimiento": "Maintenance types",
+  "viewificaciones configurables por frecuencia, alerta anticipada e impacto operativo.":
+    "Configurable checks by frequency, early alert, and operational impact.",
+  "verificaciones configurables por frecuencia, alerta anticipada e impacto operativo.":
+    "Configurable checks by frequency, early alert, and operational impact.",
+
+  "responsable inscripto": "Registered VAT taxpayer",
+  monotributo: "Monotributo",
+  "consumidor final": "Final consumer",
+  exento: "Tax-exempt",
+  administrativo: "Administrative",
+  administrative: "Administrative",
+  administracion: "Administration",
+  entrenador: "Trainer",
+  trainer: "Trainer",
+  maintenance: "Maintenance",
+  mantenimiento: "Maintenance",
+  limpieza: "Cleaning",
+  "mayordomia/bar-snack": "Janitorial/bar-snack",
+  mensual: "Monthly",
+  monthly: "Monthly",
+  "por hora": "Hourly",
+  jornal: "Daily wage",
+  eventual: "Temporary",
+  externo: "External",
+  recepcion: "Reception",
+  "recepcion y caja": "Reception and cash desk",
+  caja: "Cash desk",
+  "entrenador de sala": "Floor trainer",
+  ventas: "Sales",
+  manana: "Morning",
+  tarde: "Afternoon",
+  noche: "Night",
+  rotativo: "Rotating",
+  "fin de semana": "Weekend",
+  cuotas: "Fees",
+  servicios: "Services",
+  recibos: "Receipts",
+  sueldos: "Salaries",
+  insumos: "Supplies",
+  promociones: "Promotions",
+  bebidas: "Beverages",
+  snacks: "Snacks",
+  suplementos: "Supplements",
+  indumentaria: "Apparel",
+  stock: "Stock",
+  cardio: "Cardio",
+  fuerza: "Strength",
+  funcional: "Functional",
+  "peso libre": "Free weights",
+  "weight libre": "Free weights",
+  zonas: "Zones",
+  sala: "Room",
+  deposito: "Storage",
+  "bar/snack": "Bar/snack",
+  "sala principal": "Main room",
+  spinning: "Spinning",
+  lubricacion: "Lubrication",
+  cableado: "Cabling",
+  seguridad: "Safety",
+  alertas: "Alerts",
+  preventivo: "Preventive",
+  correctivo: "Corrective",
+  "cableado / correas": "Cabling / belts",
+  "zona a": "Zone A",
+  "zona b": "Zone B",
+  "zona c": "Zone C",
+  "zona d": "Zone D",
+  "zona vip": "VIP zone",
+  "sala funcional": "Functional room",
+  "sala spinning": "Spinning room",
+  efectivo: "Cash",
+  cash: "Cash",
+  stripe: "Stripe",
+  "bank transfer": "Bank transfer",
+  "transferencia bancaria": "Bank transfer",
+  "tarjeta de debito": "Debit card",
+  "clases especiales": "Special classes",
+  masajista: "Massage therapist",
+
+  "responsable inscripto ante el organismo fiscal.": "Registered VAT taxpayer with the tax authority.",
+  "regimen simplificado / monotributo.": "Simplified tax regime / Monotributo.",
+  "empleado administrativo con posibles permisos de menu/rbac.": "Administrative employee with possible menu/RBAC permissions.",
+  "hace masajes a socios": "Provides massages to members.",
+  "pago mensual fijo para empleados estables.": "Fixed monthly payment for stable employees.",
+  "pago por hora trabajada o clase asignada.": "Payment per hour worked or assigned class.",
+  "atencion al socio, cobros, consultas y control de ingreso.": "Member service, collections, queries, and entry control.",
+  "gestion administrativa, carga de datos, pagos y reportes.": "Administrative management, data entry, payments, and reports.",
+  "backoffice, pagos, reportes y operacion administrativa.": "Back office, payments, reports, and administrative operations.",
+  "shift manana.": "Morning shift.",
+  "shift tarde.": "Afternoon shift.",
+  "bloque administrativo o recepcion de manana.": "Administrative or reception morning block.",
+  "bloque tarde/noche para recepcion, caja o sala.": "Afternoon/night block for reception, cash desk, or floor.",
+  "pago manual registrado por administracion.": "Manual payment recorded by administration.",
+  "pago online procesado por stripe.": "Online payment processed by Stripe.",
+  "pagos mensuales a empleados.": "Monthly payments to employees.",
+  "gastos asociados a mantenimiento de equipamiento o infraestructura.": "Expenses related to equipment or infrastructure maintenance.",
+  "ingresos por pago de cuotas de socios.": "Income from member fee payments.",
+  "ingresos por venta de productos.": "Income from product sales.",
+  "agua, bebidas isotonicas, cafe u otras bebidas.": "Water, isotonic drinks, coffee, or other beverages.",
+  "snacks y alimentos rapidos.": "Snacks and quick food.",
+  "equipamiento cardiovascular.": "Cardio equipment.",
+  "maquinas y equipamiento de fuerza.": "Strength machines and equipment.",
+  "zona operativa a del gimnasio.": "Gym operational zone A.",
+  "zona operativa b del gimnasio.": "Gym operational zone B.",
+  "zona exclusiva para clientes importantes": "Exclusive zone for important clients.",
+  "sala principal para clases, activities generales o usos multiples.": "Main room for classes, general activities, or multipurpose use.",
+  "maintenance preventivo general.": "General preventive maintenance.",
+  "maintenance correctivo por falla o rotura.": "Corrective maintenance for failure or breakage.",
+  "monday a viernes 08:00-16:00": "Monday to Friday 08:00-16:00",
+  "monday a viernes 14:00-22:00": "Monday to Friday 14:00-22:00",
+  "monday a sabado 07:00-13:00": "Monday to Saturday 07:00-13:00",
+  "monday a sabado 16:00-22:00": "Monday to Saturday 16:00-22:00",
+};
+
+function translateParametrizacionText(locale: GymMasterLocale, value?: string | null) {
+  const text = String(value ?? "");
+  if (locale !== "en" || !text) return text;
+  const normalized = normalizeParametrizacionText(text);
+  return PARAMETRIZACION_TEXT_EN[normalized] ?? text;
+}
+
+
 function emptyFormState(): CatalogFormState {
   return {
     codigo: "",
@@ -232,6 +434,8 @@ function descuentoFormFromConfig(config: PagoDescuentoConfig | null): CuotaDescu
 export default function ParametrizacionPage() {
   const { user, isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const router = useRouter();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => parametrizacionTx(locale, es, en);
   const [catalogosData, setCatalogosData] = useState<ParametrizacionCatalogosResponse | null>(null);
   const [loadingCatalogos, setLoadingCatalogos] = useState(false);
   const [catalogosError, setCatalogosError] = useState<string | null>(null);
@@ -271,12 +475,12 @@ export default function ParametrizacionPage() {
       setDescuentoForm(descuentoFormFromConfig(descuento));
     } catch (error) {
       setCatalogosError(
-        error instanceof Error ? error.message : "No se pudieron cargar los catálogos"
+        error instanceof Error ? error.message : parametrizacionTx(locale, "No se pudieron cargar los catálogos", "Catalogs could not be loaded")
       );
     } finally {
       setLoadingCatalogos(false);
     }
-  }, []);
+  }, [locale]);
 
   useEffect(() => {
     if (isInitialized && isAuthenticated && user?.rol === "admin") {
@@ -344,16 +548,16 @@ export default function ParametrizacionPage() {
     try {
       if (selectedItem) {
         await updateParametrizacionCatalogoItem(payload);
-        setActionMessage("Registro actualizado correctamente.");
+        setActionMessage(c("Registro actualizado correctamente.", "Record updated successfully."));
       } else {
         await createParametrizacionCatalogoItem(payload);
-        setActionMessage("Registro creado correctamente.");
+        setActionMessage(c("Registro creado correctamente.", "Record created successfully."));
       }
 
       setDialogOpen(false);
       await loadCatalogos();
     } catch (error) {
-      setCatalogosError(error instanceof Error ? error.message : "No se pudo guardar el registro");
+      setCatalogosError(error instanceof Error ? error.message : c("No se pudo guardar el registro", "The record could not be saved"));
     } finally {
       setSaving(false);
     }
@@ -372,10 +576,10 @@ export default function ParametrizacionPage() {
         id: item.id,
         activo: !item.activo,
       });
-      setActionMessage(item.activo ? "Registro desactivado." : "Registro activado.");
+      setActionMessage(item.activo ? c("Registro desactivado.", "Record deactivated.") : c("Registro activado.", "Record activated."));
       await loadCatalogos();
     } catch (error) {
-      setCatalogosError(error instanceof Error ? error.message : "No se pudo cambiar el estado");
+      setCatalogosError(error instanceof Error ? error.message : c("No se pudo cambiar el estado", "The status could not be changed"));
     }
   };
 
@@ -396,12 +600,12 @@ export default function ParametrizacionPage() {
 
       setDescuentoConfig(saved);
       setDescuentoForm(descuentoFormFromConfig(saved));
-      setActionMessage("Descuento por pago adelantado actualizado correctamente.");
+      setActionMessage(c("Descuento por pago adelantado actualizado correctamente.", "Advance payment discount updated successfully."));
     } catch (error) {
       setCatalogosError(
         error instanceof Error
           ? error.message
-          : "No se pudo actualizar el descuento por pago adelantado"
+          : c("No se pudo actualizar el descuento por pago adelantado", "The advance payment discount could not be updated")
       );
     } finally {
       setSavingDescuento(false);
@@ -409,7 +613,7 @@ export default function ParametrizacionPage() {
   };
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{c("Cargando...", "Loading...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -426,16 +630,16 @@ export default function ParametrizacionPage() {
       <div className="flex w-full min-h-screen">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Parametrización" />
-          <main className="flex-1 p-6 space-y-6">
+          <AppHeader title={c("Parametrización", "Parametrization")} />
+          <main className="flex-1 p-6 space-y-6 bg-slate-50 dark:bg-slate-950">
             {!isAdmin ? (
               <Card className="border-amber-200 bg-amber-50">
                 <CardContent className="flex items-start gap-3 p-5 text-amber-800">
                   <AlertTriangle className="mt-0.5 h-5 w-5" />
                   <div>
-                    <h2 className="text-lg font-semibold">Acceso restringido</h2>
+                    <h2 className="text-lg font-semibold">{c("Acceso restringido", "Restricted access")}</h2>
                     <p className="mt-1 text-sm">
-                      La parametrización del sistema está disponible para usuarios administradores.
+                      {c("La parametrización del sistema está disponible para usuarios administradores.", "System parametrization is available to administrator users.")}
                     </p>
                   </div>
                 </CardContent>
@@ -448,12 +652,12 @@ export default function ParametrizacionPage() {
                       <div>
                         <div className="flex items-center gap-2 text-sm text-cyan-100">
                           <ShieldCheck className="h-4 w-4" />
-                          Configuración administrativa
+                          {c("Configuración administrativa", "Administrative configuration")}
                         </div>
-                        <h1 className="mt-2 text-2xl font-bold">Parametrización de catálogos</h1>
+                        <h1 className="mt-2 text-2xl font-bold">{c("Parametrización de catálogos", "Catalog parametrization")}</h1>
                       </div>
                       <div className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm backdrop-blur">
-                        <p className="font-semibold">Última lectura</p>
+                        <p className="font-semibold">{c("Última lectura", "Last read")}</p>
                         <p className="mt-1 text-cyan-100">{formatDateTime(catalogosData?.generated_at)}</p>
                       </div>
                     </div>
@@ -461,39 +665,39 @@ export default function ParametrizacionPage() {
                 </Card>
 
                 <div className="grid gap-4 md:grid-cols-3">
-                  <Card>
+                  <Card className="border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
                     <CardContent className="p-4">
-                      <p className="text-sm text-gray-500">Catálogos reales</p>
-                      <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.catalogos}</p>
-                      <p className="mt-1 text-xs text-gray-500">Leídos desde Supabase vía API interna.</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">{c("Catálogos reales", "Real catalogs")}</p>
+                      <p className="mt-1 text-2xl font-bold text-gray-950 dark:text-gray-50">{resumen.catalogos}</p>
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{c("Leídos desde Supabase vía API interna.", "Read from Supabase via internal API.")}</p>
                     </CardContent>
                   </Card>
-                  <Card>
+                  <Card className="border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
                     <CardContent className="p-4">
-                      <p className="text-sm text-gray-500">Registros parametrizables</p>
-                      <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.registros}</p>
-                      <p className="mt-1 text-xs text-gray-500">Seeds y valores vivos para próximas integraciones.</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">{c("Registros parametrizables", "Configurable records")}</p>
+                      <p className="mt-1 text-2xl font-bold text-gray-950 dark:text-gray-50">{resumen.registros}</p>
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{c("Seeds y valores vivos para próximas integraciones.", "Seeds and live values for upcoming integrations.")}</p>
                     </CardContent>
                   </Card>
-                  <Card>
+                  <Card className="border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
                     <CardContent className="p-4">
-                      <p className="text-sm text-gray-500">Activos</p>
-                      <p className="mt-1 text-2xl font-bold text-gray-950">{resumen.activos}</p>
-                      <p className="mt-1 text-xs text-gray-500">Base para futuros selectores y CRUD administrativo.</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400">{c("Activos", "Active")}</p>
+                      <p className="mt-1 text-2xl font-bold text-gray-950 dark:text-gray-50">{resumen.activos}</p>
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{c("Base para futuros selectores y CRUD administrativo.", "Base for future selectors and administrative CRUD.")}</p>
                     </CardContent>
                   </Card>
                 </div>
 
-                <Card className="border-cyan-100">
+                <Card className="border-cyan-100 bg-white dark:border-cyan-900/50 dark:bg-slate-900">
                   <CardHeader className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
                     <div className="flex items-start gap-3">
                       <div className="rounded-xl bg-cyan-50 p-2 text-cyan-700">
                         <Percent className="h-5 w-5" />
                       </div>
                       <div>
-                        <h2 className="text-xl font-bold">Descuento por pago adelantado</h2>
+                        <h2 className="text-xl font-bold">{c("Descuento por pago adelantado", "Advance payment discount")}</h2>
                         <p className="text-sm text-gray-500">
-                          Configura la promoción que se aplica cuando un socio paga varias cuotas juntas. Impacta en pago manual, Stripe, recibos e historial.
+                          {c("Configura la promoción que se aplica cuando un socio paga varias cuotas juntas. Impacta en pago manual, Stripe, recibos e historial.", "Configure the promotion applied when a member pays multiple fees together. It affects manual payments, Stripe, receipts, and history.")}
                         </p>
                       </div>
                     </div>
@@ -502,12 +706,12 @@ export default function ParametrizacionPage() {
                         ? "border-emerald-200 bg-emerald-50 text-emerald-700"
                         : "border-slate-200 bg-slate-50 text-slate-600"
                     }`}>
-                      {descuentoConfig?.activo ? "Activo" : "Desactivado"}
+                      {descuentoConfig?.activo ? c("Activo", "Active") : c("Desactivado", "Disabled")}
                     </span>
                   </CardHeader>
                   <CardContent className="p-4">
                     <form onSubmit={handleSaveDescuento} className="grid gap-4 md:grid-cols-4">
-                      <div className="flex items-center gap-2 rounded-xl border bg-white p-3 md:col-span-1">
+                      <div className="flex items-center gap-2 rounded-xl border bg-white p-3 md:col-span-1 dark:border-slate-700 dark:bg-slate-950">
                         <Checkbox
                           id="descuento_activo"
                           checked={descuentoForm.activo}
@@ -516,12 +720,12 @@ export default function ParametrizacionPage() {
                           }
                         />
                         <Label htmlFor="descuento_activo" className="text-sm font-medium">
-                          Activar descuento
+                          {c("Activar descuento", "Enable discount")}
                         </Label>
                       </div>
 
                       <div className="space-y-1">
-                        <Label htmlFor="cuotas_minimas_descuento">Cuotas mínimas</Label>
+                        <Label htmlFor="cuotas_minimas_descuento">{c("Cuotas mínimas", "Minimum fees")}</Label>
                         <Input
                           id="cuotas_minimas_descuento"
                           type="number"
@@ -538,7 +742,7 @@ export default function ParametrizacionPage() {
                       </div>
 
                       <div className="space-y-1">
-                        <Label htmlFor="porcentaje_descuento">Porcentaje</Label>
+                        <Label htmlFor="porcentaje_descuento">{c("Porcentaje", "Percentage")}</Label>
                         <Input
                           id="porcentaje_descuento"
                           type="number"
@@ -564,12 +768,12 @@ export default function ParametrizacionPage() {
                           {savingDescuento ? (
                             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                           ) : null}
-                          Guardar descuento
+                          {c("Guardar descuento", "Save discount")}
                         </Button>
                       </div>
 
                       <div className="space-y-1 md:col-span-4">
-                        <Label htmlFor="descripcion_descuento">Mensaje interno</Label>
+                        <Label htmlFor="descripcion_descuento">{c("Mensaje interno", "Internal message")}</Label>
                         <Input
                           id="descripcion_descuento"
                           value={descuentoForm.descripcion}
@@ -579,32 +783,38 @@ export default function ParametrizacionPage() {
                               descripcion: event.target.value,
                             }))
                           }
-                          placeholder="Ejemplo: pagando 2 o más cuotas se aplica 10% de descuento"
+                          placeholder={c("Ejemplo: pagando 2 o más cuotas se aplica 10% de descuento", "Example: paying 2 or more fees applies a 10% discount")}
                         />
                       </div>
 
                       {Number(descuentoForm.porcentaje || 0) > 0 ? (
                         <div className="rounded-xl border border-cyan-200 bg-cyan-50 p-3 text-sm text-cyan-800 md:col-span-4">
                           {descuentoForm.activo
-                            ? `Mensaje al socio/admin: pagando ${descuentoForm.cuotas_minimas || 2} o más cuotas por adelantado obtiene ${descuentoForm.porcentaje || 0}% de descuento.`
-                            : "El porcentaje está configurado pero no se aplica porque el descuento está desactivado."}
+                            ? c(
+                                `Mensaje al socio/admin: pagando ${descuentoForm.cuotas_minimas || 2} o más cuotas por adelantado obtiene ${descuentoForm.porcentaje || 0}% de descuento.`,
+                                `Message to member/admin: paying ${descuentoForm.cuotas_minimas || 2} or more fees in advance gets a ${descuentoForm.porcentaje || 0}% discount.`
+                              )
+                            : c(
+                                "El porcentaje está configurado pero no se aplica porque el descuento está desactivado.",
+                                "The percentage is configured but not applied because the discount is disabled."
+                              )}
                         </div>
                       ) : null}
                     </form>
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
                   <CardHeader className="flex flex-col gap-3 border-b p-4 md:flex-row md:items-center md:justify-between">
                     <div>
-                      <h2 className="text-xl font-bold">Catálogos disponibles</h2>
+                      <h2 className="text-xl font-bold">{c("Catálogos disponibles", "Available catalogs")}</h2>
                       <p className="text-sm text-gray-500">
-                        Datos vivos de la base. Esta fase habilita creación, edición y activación/desactivación sin hard delete.
+                        {c("Datos vivos de la base. Esta fase habilita creación, edición y activación/desactivación sin hard delete.", "Live database data. This phase enables creation, editing, and activation/deactivation without hard delete.")}
                       </p>
                     </div>
                     <Button onClick={loadCatalogos} disabled={loadingCatalogos} className="bg-[#02a8e1] hover:bg-[#0288b1]">
                       {loadingCatalogos ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCcw className="mr-2 h-4 w-4" />}
-                      Actualizar catálogos
+                      {c("Actualizar catálogos", "Refresh catalogs")}
                     </Button>
                   </CardHeader>
                   <CardContent className="p-4 space-y-4">
@@ -622,7 +832,7 @@ export default function ParametrizacionPage() {
                     {loadingCatalogos && !catalogos.length ? (
                       <div className="flex items-center justify-center gap-2 rounded-xl border border-dashed p-8 text-sm text-gray-500">
                         <Loader2 className="h-4 w-4 animate-spin" />
-                        Cargando catálogos parametrizables...
+                        {c("Cargando catálogos parametrizables...", "Loading configurable catalogs...")}
                       </div>
                     ) : (
                       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -632,41 +842,41 @@ export default function ParametrizacionPage() {
                           const examples = catalogo.examples.length ? catalogo.examples : ui?.tags ?? [];
 
                           return (
-                            <div key={catalogo.key} className="flex flex-col rounded-2xl border bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md">
+                            <div key={catalogo.key} className="flex flex-col rounded-2xl border bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
                               <div className="flex items-start justify-between gap-3">
                                 <div className="rounded-xl bg-[#02a8e1]/10 p-2 text-[#02a8e1]">
                                   <Icon className="h-5 w-5" />
                                 </div>
                                 <div className="flex flex-wrap justify-end gap-2">
-                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${statusStyles[catalogo.status]}`}>{catalogo.status}</span>
-                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${priorityStyles[catalogo.priority]}`}>{catalogo.priority}</span>
+                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${statusStyles[catalogo.status] ?? statusStyles.Disponible}`}>{translateParametrizacionText(locale, catalogo.status)}</span>
+                                  <span className={`rounded-full border px-2 py-1 text-[11px] font-medium ${priorityStyles[catalogo.priority] ?? priorityStyles.Media}`}>{translateParametrizacionText(locale, catalogo.priority)}</span>
                                 </div>
                               </div>
 
-                              <h3 className="mt-4 text-lg font-bold text-gray-950">{catalogo.title}</h3>
-                              <p className="mt-2 text-sm leading-relaxed text-gray-500">{catalogo.description}</p>
+                              <h3 className="mt-4 text-lg font-bold text-gray-950 dark:text-gray-50">{translateParametrizacionText(locale, catalogo.title)}</h3>
+                              <p className="mt-2 text-sm leading-relaxed text-gray-500 dark:text-gray-400">{translateParametrizacionText(locale, catalogo.description)}</p>
 
                               <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs">
                                 <div className="rounded-xl bg-slate-50 p-2">
-                                  <p className="text-gray-500">Total</p>
-                                  <p className="text-lg font-bold text-gray-950">{catalogo.total}</p>
+                                  <p className="text-gray-500 dark:text-gray-400">{c("Total", "Total")}</p>
+                                  <p className="text-lg font-bold text-gray-950 dark:text-gray-50">{catalogo.total}</p>
                                 </div>
                                 <div className="rounded-xl bg-emerald-50 p-2">
-                                  <p className="text-emerald-600">Activos</p>
+                                  <p className="text-emerald-600">{c("Activos", "Active")}</p>
                                   <p className="text-lg font-bold text-emerald-700">{catalogo.activos}</p>
                                 </div>
                                 <div className="rounded-xl bg-amber-50 p-2">
-                                  <p className="text-amber-600">Inactivos</p>
+                                  <p className="text-amber-600">{c("Inactivos", "Inactive")}</p>
                                   <p className="text-lg font-bold text-amber-700">{catalogo.inactivos}</p>
                                 </div>
                               </div>
 
                               <div className="mt-4 space-y-2">
                                 <div className="flex items-center justify-between gap-2">
-                                  <p className="text-xs font-semibold uppercase text-gray-500">Registros</p>
+                                  <p className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">{c("Registros", "Records")}</p>
                                   {catalogo.editable && (
                                     <Button size="sm" onClick={() => openCreateDialog(catalogo)} className="h-8 bg-[#02a8e1] hover:bg-[#0288b1]">
-                                      <Plus className="mr-1 h-3.5 w-3.5" /> Nuevo
+                                      <Plus className="mr-1 h-3.5 w-3.5" /> {c("Nuevo", "New")}
                                     </Button>
                                   )}
                                 </div>
@@ -676,23 +886,27 @@ export default function ParametrizacionPage() {
                                     <div key={item.id} className="rounded-xl border bg-slate-50 p-3">
                                       <div className="flex items-start justify-between gap-2">
                                         <div>
-                                          <p className="text-sm font-semibold text-gray-950">{item.nombre}</p>
-                                          <p className="text-xs text-gray-500">{item.codigo}</p>
+                                          <p className="text-sm font-semibold text-gray-950 dark:text-gray-50">{translateParametrizacionText(locale, item.nombre)}</p>
+                                          <p className="text-xs text-gray-500 dark:text-gray-400">{item.codigo}</p>
                                         </div>
                                         <span className={`rounded-full px-2 py-1 text-[11px] font-medium ${item.activo ? "bg-emerald-100 text-emerald-700" : "bg-gray-200 text-gray-600"}`}>
-                                          {item.activo ? "Activo" : "Inactivo"}
+                                          {item.activo ? c("Activo", "Active") : c("Inactivo", "Inactive")}
                                         </span>
                                       </div>
 
-                                      {item.descripcion && <p className="mt-2 line-clamp-2 text-xs text-gray-500">{item.descripcion}</p>}
+                                      {item.descripcion && (
+                                        <p className="mt-2 line-clamp-2 text-xs text-gray-500 dark:text-gray-400">
+                                          {translateParametrizacionText(locale, item.descripcion)}
+                                        </p>
+                                      )}
 
                                       <div className="mt-3 flex flex-wrap gap-2">
                                         <Button size="sm" variant="outline" onClick={() => openEditDialog(catalogo, item)} className="h-8">
-                                          <Edit3 className="mr-1 h-3.5 w-3.5" /> Editar
+                                          <Edit3 className="mr-1 h-3.5 w-3.5" /> {c("Editar", "Edit")}
                                         </Button>
                                         <Button size="sm" variant="outline" onClick={() => handleToggleItem(catalogo, item)} className="h-8">
                                           {item.activo ? <ToggleRight className="mr-1 h-3.5 w-3.5" /> : <ToggleLeft className="mr-1 h-3.5 w-3.5" />}
-                                          {item.activo ? "Desactivar" : "Activar"}
+                                          {item.activo ? c("Desactivar", "Deactivate") : c("Activar", "Activate")}
                                         </Button>
                                       </div>
                                     </div>
@@ -702,7 +916,7 @@ export default function ParametrizacionPage() {
 
                               <div className="mt-4 flex flex-wrap gap-2">
                                 {examples.slice(0, 4).map((example) => (
-                                  <span key={example} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-600">{example}</span>
+                                  <span key={example} className="rounded-full bg-slate-100 px-2 py-1 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300">{translateParametrizacionText(locale, example)}</span>
                                 ))}
                               </div>
 
@@ -710,13 +924,13 @@ export default function ParametrizacionPage() {
                                 {ui?.href ? (
                                   <Button asChild variant="outline" className="w-full justify-between border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]">
                                     <Link href={ui.href}>
-                                      Ver módulo relacionado
+                                      {c("Ver módulo relacionado", "View related module")}
                                       <ArrowRight className="h-4 w-4" />
                                     </Link>
                                   </Button>
                                 ) : (
                                   <div className="flex items-center gap-2 rounded-xl bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
-                                    <CheckCircle2 className="h-4 w-4" /> Disponible para integración
+                                    <CheckCircle2 className="h-4 w-4" /> {c("Disponible para integración", "Available for integration")}
                                   </div>
                                 )}
                               </div>
@@ -737,63 +951,63 @@ export default function ParametrizacionPage() {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>{selectedItem ? "Editar registro" : "Nuevo registro"}</DialogTitle>
+            <DialogTitle>{selectedItem ? c("Editar registro", "Edit record") : c("Nuevo registro", "New record")}</DialogTitle>
             <DialogDescription>
-              {selectedCatalog?.title}. El sistema no elimina registros físicamente; se activan o desactivan.
+              {translateParametrizacionText(locale, selectedCatalog?.title)}. {c("El sistema no elimina registros físicamente; se activan o desactivan.", "The system does not physically delete records; they are activated or deactivated.")}
             </DialogDescription>
           </DialogHeader>
 
           <form onSubmit={handleSave} className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="catalogo-nombre">Nombre</Label>
+                <Label htmlFor="catalogo-nombre">{c("Nombre", "Name")}</Label>
                 <Input id="catalogo-nombre" value={formState.nombre} onChange={(event) => setFormState((prev) => ({ ...prev, nombre: event.target.value }))} required />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="catalogo-codigo">Código</Label>
+                <Label htmlFor="catalogo-codigo">{c("Código", "Code")}</Label>
                 <Input id="catalogo-codigo" value={formState.codigo} onChange={(event) => setFormState((prev) => ({ ...prev, codigo: event.target.value }))} required />
-                <p className="text-xs text-gray-500">Se normaliza a minúsculas, sin espacios ni acentos.</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">{c("Se normaliza a minúsculas, sin espacios ni acentos.", "It is normalized to lowercase, without spaces or accents.")}</p>
               </div>
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="catalogo-descripcion">Descripción</Label>
+              <Label htmlFor="catalogo-descripcion">{c("Descripción", "Description")}</Label>
               <textarea
                 id="catalogo-descripcion"
                 value={formState.descripcion}
                 onChange={(event) => setFormState((prev) => ({ ...prev, descripcion: event.target.value }))}
-                className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-950"
               />
             </div>
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="catalogo-orden">Orden</Label>
+                <Label htmlFor="catalogo-orden">{c("Orden", "Order")}</Label>
                 <Input id="catalogo-orden" type="number" min="0" value={formState.orden} onChange={(event) => setFormState((prev) => ({ ...prev, orden: event.target.value }))} />
               </div>
-              <div className="flex items-center gap-2 rounded-xl border p-3">
+              <div className="flex items-center gap-2 rounded-xl border p-3 dark:border-slate-700 dark:bg-slate-950">
                 <Checkbox checked={formState.activo} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, activo: checked === true }))} />
                 <div>
-                  <p className="text-sm font-medium">Activo</p>
-                  <p className="text-xs text-gray-500">Disponible para futuras integraciones.</p>
+                  <p className="text-sm font-medium">{c("Activo", "Active")}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{c("Disponible para futuras integraciones.", "Available for future integrations.")}</p>
                 </div>
               </div>
             </div>
 
             {isMedioPago && (
               <div className="grid gap-4 md:grid-cols-2">
-                <div className="flex items-center gap-2 rounded-xl border p-3">
+                <div className="flex items-center gap-2 rounded-xl border p-3 dark:border-slate-700 dark:bg-slate-950">
                   <Checkbox checked={formState.requiere_comprobante} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, requiere_comprobante: checked === true }))} />
                   <div>
-                    <p className="text-sm font-medium">Requiere comprobante</p>
-                    <p className="text-xs text-gray-500">Útil para transferencias, Stripe o tarjetas.</p>
+                    <p className="text-sm font-medium">{c("Requiere comprobante", "Requires receipt")}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">{c("Útil para transferencias, Stripe o tarjetas.", "Useful for transfers, Stripe, or cards.")}</p>
                   </div>
                 </div>
-                <div className="flex items-center gap-2 rounded-xl border p-3">
+                <div className="flex items-center gap-2 rounded-xl border p-3 dark:border-slate-700 dark:bg-slate-950">
                   <Checkbox checked={formState.es_online} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, es_online: checked === true }))} />
                   <div>
-                    <p className="text-sm font-medium">Es online</p>
-                    <p className="text-xs text-gray-500">Identifica medios digitales.</p>
+                    <p className="text-sm font-medium">{c("Es online", "Is online")}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">{c("Identifica medios digitales.", "Identifies digital methods.")}</p>
                   </div>
                 </div>
               </div>
@@ -802,21 +1016,21 @@ export default function ParametrizacionPage() {
             {isTipoMantenimiento && (
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
-                  <Label htmlFor="catalogo-frecuencia">Frecuencia en días</Label>
+                  <Label htmlFor="catalogo-frecuencia">{c("Frecuencia en días", "Frequency in days")}</Label>
                   <Input id="catalogo-frecuencia" type="number" min="1" value={formState.frecuencia_dias} onChange={(event) => setFormState((prev) => ({ ...prev, frecuencia_dias: event.target.value }))} />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="catalogo-alerta">Alerta anticipada en días</Label>
+                  <Label htmlFor="catalogo-alerta">{c("Alerta anticipada en días", "Early alert in days")}</Label>
                   <Input id="catalogo-alerta" type="number" min="0" value={formState.alerta_dias_anticipacion} onChange={(event) => setFormState((prev) => ({ ...prev, alerta_dias_anticipacion: event.target.value }))} />
                 </div>
               </div>
             )}
 
             <DialogFooter>
-              <Button type="button" variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>Cancelar</Button>
+              <Button type="button" variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>{c("Cancelar", "Cancel")}</Button>
               <Button type="submit" disabled={saving} className="bg-[#02a8e1] hover:bg-[#0288b1]">
                 {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                {selectedItem ? "Guardar cambios" : "Crear registro"}
+                {selectedItem ? c("Guardar cambios", "Save changes") : c("Crear registro", "Create record")}
               </Button>
             </DialogFooter>
           </form>

--- a/src/app/dashboard/perfil/page.tsx
+++ b/src/app/dashboard/perfil/page.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, type ComponentType } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, type ComponentType } from "react";
+import { useRouter } from "next/navigation";
 import {
   Bell,
   ClipboardList,
@@ -15,18 +15,22 @@ import {
   Dumbbell,
   TrendingUp,
   UserRound,
-} from 'lucide-react';
-import { useAuthStore } from '@/stores/authStore';
-import { AppHeader } from '@/components/header/AppHeader';
-import { AppFooter } from '@/components/footer/AppFooter';
-import { AppSidebar } from '@/components/sidebar/AppSidebar';
-import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
-import ProfileCard from '@/components/perfil/ProfileCard';
-import type { Usuario } from '@/interfaces/usuario.interface';
+} from "lucide-react";
+import { useAuthStore } from "@/stores/authStore";
+import { AppHeader } from "@/components/header/AppHeader";
+import { AppFooter } from "@/components/footer/AppFooter";
+import { AppSidebar } from "@/components/sidebar/AppSidebar";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import ProfileCard from "@/components/perfil/ProfileCard";
+import type { Usuario } from "@/interfaces/usuario.interface";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
 type QuickAction = {
-  title: string;
-  description: string;
+  titleEs: string;
+  titleEn: string;
+  descriptionEs: string;
+  descriptionEn: string;
   href: string;
   icon: ComponentType<{ className?: string }>;
   tone: string;
@@ -34,106 +38,144 @@ type QuickAction = {
 
 const socioActions: QuickAction[] = [
   {
-    title: 'Ficha médica',
-    description: 'Actualizá salud, apto y antecedentes.',
-    href: '/dashboard/ficha-medica',
+    titleEs: "Ficha médica",
+    titleEn: "Medical record",
+    descriptionEs: "Actualizá salud, apto y antecedentes.",
+    descriptionEn: "Update health status, clearance, and background.",
+    href: "/dashboard/ficha-medica",
     icon: HeartPulse,
-    tone: 'bg-rose-50 text-rose-700 border-rose-100 dark:bg-rose-950/60 dark:text-rose-100 dark:border-rose-700/70',
+    tone: "bg-rose-50 text-rose-700 border-rose-100 dark:bg-rose-950/60 dark:text-rose-100 dark:border-rose-700/70",
   },
   {
-    title: 'Rutinas',
-    description: 'Revisá tu plan de entrenamiento.',
-    href: '/dashboard/rutinas',
+    titleEs: "Rutinas",
+    titleEn: "Routines",
+    descriptionEs: "Revisá tu plan de entrenamiento.",
+    descriptionEn: "Review your training plan.",
+    href: "/dashboard/rutinas",
     icon: Dumbbell,
-    tone: 'bg-sky-50 text-sky-700 border-sky-100 dark:bg-sky-950/40 dark:text-sky-100 dark:border-sky-700/60',
+    tone: "bg-sky-50 text-sky-700 border-sky-100 dark:bg-sky-950/40 dark:text-sky-100 dark:border-sky-700/60",
   },
   {
-    title: 'Dietas',
-    description: 'Consultá tu alimentación asignada.',
-    href: '/dashboard/dietas',
+    titleEs: "Dietas",
+    titleEn: "Diets",
+    descriptionEs: "Consultá tu alimentación asignada.",
+    descriptionEn: "Check your assigned nutrition plan.",
+    href: "/dashboard/dietas",
     icon: Utensils,
-    tone: 'bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-100 dark:border-emerald-700/60',
+    tone: "bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-100 dark:border-emerald-700/60",
   },
   {
-    title: 'Evolución',
-    description: 'Mirá tus cambios físicos.',
-    href: '/dashboard/evolucion-fisica',
+    titleEs: "Evolución",
+    titleEn: "Physical evolution",
+    descriptionEs: "Mirá tus cambios físicos.",
+    descriptionEn: "Review your physical progress.",
+    href: "/dashboard/evolucion-fisica",
     icon: TrendingUp,
-    tone: 'bg-violet-50 text-violet-700 border-violet-100 dark:bg-violet-950/60 dark:text-violet-100 dark:border-violet-700/70',
+    tone: "bg-violet-50 text-violet-700 border-violet-100 dark:bg-violet-950/60 dark:text-violet-100 dark:border-violet-700/70",
   },
   {
-    title: 'Pagos',
-    description: 'Estado de cuota y recibos.',
-    href: '/dashboard/mi-cuenta/historial-pagos',
+    titleEs: "Pagos",
+    titleEn: "Payments",
+    descriptionEs: "Estado de cuota y recibos.",
+    descriptionEn: "Fee status and receipts.",
+    href: "/dashboard/mi-cuenta/historial-pagos",
     icon: CreditCard,
-    tone: 'bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-100 dark:border-amber-700/60',
+    tone: "bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-100 dark:border-amber-700/60",
   },
   {
-    title: 'Mensajes',
-    description: 'Contactá a administración.',
-    href: '/dashboard/mensajes',
+    titleEs: "Mensajes",
+    titleEn: "Messages",
+    descriptionEs: "Contactá a administración.",
+    descriptionEn: "Contact administration.",
+    href: "/dashboard/mensajes",
     icon: MessageCircle,
-    tone: 'bg-indigo-50 text-indigo-700 border-indigo-100 dark:bg-indigo-950/40 dark:text-indigo-100 dark:border-indigo-700/60',
+    tone: "bg-indigo-50 text-indigo-700 border-indigo-100 dark:bg-indigo-950/40 dark:text-indigo-100 dark:border-indigo-700/60",
   },
 ];
 
 const staffActions: QuickAction[] = [
   {
-    title: 'Preferencias',
-    description: 'Ajustes personales del panel.',
-    href: '/dashboard/settings/preferences',
+    titleEs: "Preferencias",
+    titleEn: "Preferences",
+    descriptionEs: "Ajustes personales del panel.",
+    descriptionEn: "Personal dashboard settings.",
+    href: "/dashboard/settings/preferences",
     icon: Settings,
-    tone: 'bg-sky-50 text-sky-700 border-sky-100 dark:bg-sky-950/40 dark:text-sky-100 dark:border-sky-700/60',
+    tone: "bg-sky-50 text-sky-700 border-sky-100 dark:bg-sky-950/40 dark:text-sky-100 dark:border-sky-700/60",
   },
   {
-    title: 'Contraseña',
-    description: 'Cambiá tu clave de acceso.',
-    href: '/auth/change-password',
+    titleEs: "Contraseña",
+    titleEn: "Password",
+    descriptionEs: "Cambiá tu clave de acceso.",
+    descriptionEn: "Change your access password.",
+    href: "/auth/change-password",
     icon: KeyRound,
-    tone: 'bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-100 dark:border-emerald-700/60',
+    tone: "bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-100 dark:border-emerald-700/60",
   },
   {
-    title: 'Notificaciones',
-    description: 'Revisá novedades del sistema.',
-    href: '/dashboard/notificaciones',
+    titleEs: "Notificaciones",
+    titleEn: "Notifications",
+    descriptionEs: "Revisá novedades del sistema.",
+    descriptionEn: "Review system updates.",
+    href: "/dashboard/notificaciones",
     icon: Bell,
-    tone: 'bg-violet-50 text-violet-700 border-violet-100 dark:bg-violet-950/60 dark:text-violet-100 dark:border-violet-700/70',
+    tone: "bg-violet-50 text-violet-700 border-violet-100 dark:bg-violet-950/60 dark:text-violet-100 dark:border-violet-700/70",
   },
   {
-    title: 'Dashboard',
-    description: 'Volver al inicio operativo.',
-    href: '/dashboard',
+    titleEs: "Dashboard",
+    titleEn: "Dashboard",
+    descriptionEs: "Volver al inicio operativo.",
+    descriptionEn: "Return to the operational home.",
+    href: "/dashboard",
     icon: ClipboardList,
-    tone: 'bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-100 dark:border-amber-700/60',
+    tone: "bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-100 dark:border-amber-700/60",
   },
 ];
 
-function roleLabel(rol?: string | null) {
-  if (rol === 'socio') return 'Socio';
-  if (rol === 'admin') return 'Administrador';
-  if (rol === 'usuario') return 'Usuario interno';
-  return 'Usuario';
+function profileTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
 }
 
-function QuickActionCard({ action }: { action: QuickAction }) {
+function roleLabel(locale: GymMasterLocale, rol?: string | null) {
+  if (rol === "socio") return profileTx(locale, "Socio", "Member");
+  if (rol === "admin")
+    return profileTx(locale, "Administrador", "Administrator");
+  if (rol === "usuario")
+    return profileTx(locale, "Usuario interno", "Internal user");
+  return profileTx(locale, "Usuario", "User");
+}
+
+function QuickActionCard({
+  action,
+  locale,
+}: {
+  action: QuickAction;
+  locale: GymMasterLocale;
+}) {
   const Icon = action.icon;
+  const title = profileTx(locale, action.titleEs, action.titleEn);
+  const description = profileTx(
+    locale,
+    action.descriptionEs,
+    action.descriptionEn,
+  );
 
   return (
     <a
       href={action.href}
       className={`group flex min-h-[116px] flex-col justify-between rounded-3xl border p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md active:scale-[0.99] ${action.tone}`}
     >
-      <div className='flex items-center justify-between gap-3'>
-        <span className='rounded-2xl bg-white/70 p-2 shadow-sm ring-1 ring-black/5 dark:bg-slate-950/40'>
-          <Icon className='h-5 w-5' />
+      <div className="flex items-center justify-between gap-3">
+        <span className="rounded-2xl bg-white/70 p-2 shadow-sm ring-1 ring-black/5 dark:bg-slate-950/40">
+          <Icon className="h-5 w-5" />
         </span>
-        <span className='text-[11px] font-bold uppercase tracking-[0.18em] text-current/90'>
-          Abrir
+        <span className="text-[11px] font-bold uppercase tracking-[0.18em] text-current/90">
+          {profileTx(locale, "Abrir", "Open")}
         </span>
       </div>
-      <div className='mt-4'>
-        <h3 className='text-base font-black leading-tight'>{action.title}</h3>
-        <p className='mt-1 text-xs leading-5 text-current/90'>{action.description}</p>
+      <div className="mt-4">
+        <h3 className="text-base font-black leading-tight">{title}</h3>
+        <p className="mt-1 text-xs leading-5 text-current/90">{description}</p>
       </div>
     </a>
   );
@@ -143,6 +185,8 @@ export default function PerfilPage() {
   const { isAuthenticated, initializeAuth, isInitialized, user } =
     useAuthStore() as any;
   const router = useRouter();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => profileTx(locale, es, en);
 
   useEffect(() => {
     initializeAuth();
@@ -150,61 +194,65 @@ export default function PerfilPage() {
 
   useEffect(() => {
     if (isInitialized && !isAuthenticated) {
-      router.push('/auth/login');
+      router.push("/auth/login");
     }
   }, [isInitialized, isAuthenticated, router]);
 
   const profileUser: Partial<Usuario> = useMemo(
     () => ({
-      id: user?.id || user?.sub || '',
-      nombre: user?.nombre || user?.nombre_completo || '',
-      email: user?.email || user?.correo || '',
-      creado_en: user?.creado_en || user?.created_at || user?.createdAt || '',
+      id: user?.id || user?.sub || "",
+      nombre: user?.nombre || user?.nombre_completo || "",
+      email: user?.email || user?.correo || "",
+      creado_en: user?.creado_en || user?.created_at || user?.createdAt || "",
       foto: user?.foto || user?.avatar || user?.image || null,
-      rol: user?.rol || user?.role || '',
+      rol: user?.rol || user?.role || "",
       dni: user?.dni ?? null,
       must_change_password: Boolean(user?.must_change_password),
       password_actualizado_en: user?.password_actualizado_en ?? null,
       ultimo_login_en: user?.ultimo_login_en ?? null,
     }),
-    [user]
+    [user],
   );
 
   if (!isInitialized || !isAuthenticated) {
     return null;
   }
 
-  const isSocio = profileUser.rol === 'socio';
+  const isSocio = profileUser.rol === "socio";
   const actions = isSocio ? socioActions : staffActions;
 
   return (
     <SidebarProvider>
-      <div className='flex min-h-screen w-full'>
+      <div className="flex min-h-screen w-full">
         <AppSidebar />
-        <SidebarInset className='!grid !min-h-[100dvh] grid-rows-[auto_minmax(0,1fr)_auto]'>
-          <AppHeader title='Mi perfil' />
-          <section className='min-h-0 space-y-5 bg-gradient-to-b from-sky-50/70 via-background to-background px-4 py-4 sm:px-6 md:space-y-6 md:p-6 dark:from-sky-950/10'>
-            <div className='mx-auto w-full max-w-5xl space-y-5 md:space-y-6'>
-              <div className='overflow-hidden rounded-[2rem] border border-sky-100 bg-white shadow-sm dark:border-sky-900/60 dark:bg-slate-950/80'>
-                <div className='relative isolate p-5 sm:p-6 md:p-8'>
-                  <div className='absolute -right-12 -top-12 h-36 w-36 rounded-full bg-sky-200/40 blur-3xl dark:bg-sky-700/20' />
-                  <div className='absolute -bottom-16 -left-16 h-40 w-40 rounded-full bg-emerald-200/35 blur-3xl dark:bg-emerald-700/15' />
-                  <div className='relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
-                    <div className='min-w-0'>
-                      <p className='inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-sky-700 ring-1 ring-sky-100 dark:bg-sky-950/40 dark:text-sky-200 dark:ring-sky-900/70'>
-                        <UserRound className='h-3.5 w-3.5' />
-                        Perfil personal
+        <SidebarInset className="!grid !min-h-[100dvh] grid-rows-[auto_minmax(0,1fr)_auto]">
+          <AppHeader title={c("Mi perfil", "My profile")} />
+          <section className="min-h-0 space-y-5 bg-gradient-to-b from-sky-50/70 via-background to-background px-4 py-4 sm:px-6 md:space-y-6 md:p-6 dark:from-sky-950/10">
+            <div className="mx-auto w-full max-w-5xl space-y-5 md:space-y-6">
+              <div className="overflow-hidden rounded-[2rem] border border-sky-100 bg-white shadow-sm dark:border-sky-900/60 dark:bg-slate-950/80">
+                <div className="relative isolate p-5 sm:p-6 md:p-8">
+                  <div className="absolute -right-12 -top-12 h-36 w-36 rounded-full bg-sky-200/40 blur-3xl dark:bg-sky-700/20" />
+                  <div className="absolute -bottom-16 -left-16 h-40 w-40 rounded-full bg-emerald-200/35 blur-3xl dark:bg-emerald-700/15" />
+                  <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0">
+                      <p className="inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-sky-700 ring-1 ring-sky-100 dark:bg-sky-950/40 dark:text-sky-200 dark:ring-sky-900/70">
+                        <UserRound className="h-3.5 w-3.5" />
+                        {c("Perfil personal", "Personal profile")}
                       </p>
-                      <h1 className='mt-3 text-2xl font-black leading-tight text-slate-950 sm:text-3xl dark:text-white'>
-                        {profileUser.nombre || 'Mi cuenta'}
+                      <h1 className="mt-3 text-2xl font-black leading-tight text-slate-950 sm:text-3xl dark:text-white">
+                        {profileUser.nombre || c("Mi cuenta", "My account")}
                       </h1>
-                      <p className='mt-2 max-w-2xl text-sm leading-6 text-muted-foreground'>
-                        Revisá tus datos principales, actualizá tu foto y accedé rápido a las secciones más importantes de tu cuenta.
+                      <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                        {c(
+                          "Revisá tus datos principales, actualizá tu foto y accedé rápido a las secciones más importantes de tu cuenta.",
+                          "Review your main details, update your photo, and quickly access the most important sections of your account.",
+                        )}
                       </p>
                     </div>
-                    <div className='flex items-center gap-2 rounded-2xl border border-emerald-100 bg-emerald-50 px-3 py-2 text-sm font-bold text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/20 dark:text-emerald-200'>
-                      <ShieldCheck className='h-4 w-4' />
-                      Cuenta activa · {roleLabel(profileUser.rol)}
+                    <div className="flex items-center gap-2 rounded-2xl border border-emerald-100 bg-emerald-50 px-3 py-2 text-sm font-bold text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/20 dark:text-emerald-200">
+                      <ShieldCheck className="h-4 w-4" />
+                      {c("Cuenta activa", "Active account")} ·{" "}
+                      {roleLabel(locale, profileUser.rol)}
                     </div>
                   </div>
                 </div>
@@ -212,30 +260,47 @@ export default function PerfilPage() {
 
               <ProfileCard user={profileUser} size={128} />
 
-              <div className='rounded-[2rem] border border-border bg-white p-4 shadow-sm dark:bg-slate-950/80 sm:p-5'>
-                <div className='mb-4 flex items-center justify-between gap-3'>
+              <div className="rounded-[2rem] border border-border bg-white p-4 shadow-sm dark:bg-slate-950/80 sm:p-5">
+                <div className="mb-4 flex items-center justify-between gap-3">
                   <div>
-                    <h2 className='text-lg font-black'>Accesos rápidos</h2>
-                    <p className='mt-1 text-sm text-muted-foreground'>
-                      Atajos útiles para completar tu perfil y continuar usando Gym Master desde el celular.
+                    <h2 className="text-lg font-black">
+                      {c("Accesos rápidos", "Quick access")}
+                    </h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {c(
+                        "Atajos útiles para completar tu perfil y continuar usando Gym Master desde el celular.",
+                        "Useful shortcuts to complete your profile and keep using Gym Master from your phone.",
+                      )}
                     </p>
                   </div>
                 </div>
 
-                <div className='grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6'>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">
                   {actions.map((action) => (
-                    <QuickActionCard key={action.href} action={action} />
+                    <QuickActionCard
+                      key={action.href}
+                      action={action}
+                      locale={locale}
+                    />
                   ))}
                 </div>
               </div>
 
-              <div className='rounded-[2rem] border border-amber-100 bg-amber-50/80 p-4 text-sm leading-6 text-amber-900 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-100 sm:p-5'>
-                <div className='flex items-start gap-3'>
-                  <ShieldCheck className='mt-0.5 h-5 w-5 shrink-0' />
+              <div className="rounded-[2rem] border border-amber-100 bg-amber-50/80 p-4 text-sm leading-6 text-amber-900 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-100 sm:p-5">
+                <div className="flex items-start gap-3">
+                  <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
                   <div>
-                    <p className='font-bold'>Recomendación de seguridad</p>
-                    <p className='mt-1'>
-                      Si compartís este dispositivo o cambiaste tu clave inicial recientemente, usá “Cambiar contraseña” desde Preferencias o desde el engranaje superior.
+                    <p className="font-bold">
+                      {c(
+                        "Recomendación de seguridad",
+                        "Security recommendation",
+                      )}
+                    </p>
+                    <p className="mt-1">
+                      {c(
+                        "Si compartís este dispositivo o cambiaste tu clave inicial recientemente, usá “Cambiar contraseña” desde Preferencias o desde el engranaje superior.",
+                        "If you share this device or recently changed your initial password, use “Change password” from Preferences or from the top gear menu.",
+                      )}
                     </p>
                   </div>
                 </div>

--- a/src/app/dashboard/respaldo-negocio/page.tsx
+++ b/src/app/dashboard/respaldo-negocio/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Archive, CheckCircle2, Download, FileJson, FileSpreadsheet, RefreshCw, ShieldCheck } from 'lucide-react';
+import { Archive, FileJson, FileSpreadsheet, RefreshCw, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import { AppFooter } from '@/components/footer/AppFooter';
 import { AppHeader } from '@/components/header/AppHeader';
@@ -10,6 +10,8 @@ import { AppSidebar } from '@/components/sidebar/AppSidebar';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import {
   downloadRespaldoNegocio,
   fetchRespaldoNegocioMeta,
@@ -19,15 +21,160 @@ import {
 import { useAuthStore } from '@/stores/authStore';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
 
-function estadoLabel(estado: string) {
-  if (estado === 'completado') return 'Completado';
-  if (estado === 'generando') return 'Generando';
-  if (estado === 'error') return 'Error';
+function backupTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+type ModulePresentation = {
+  labelEs: string;
+  labelEn: string;
+  descriptionEs: string;
+  descriptionEn: string;
+};
+
+const BACKUP_MODULE_PRESENTATION: Record<string, ModulePresentation> = {
+  gimnasio_parametrizacion: {
+    labelEs: 'Datos del gimnasio',
+    labelEn: 'Gym data',
+    descriptionEs: 'Parametrización comercial, legal y visual del gimnasio cliente.',
+    descriptionEn: 'Commercial, legal, and visual configuration for the client gym.',
+  },
+  socios: {
+    labelEs: 'Socios',
+    labelEn: 'Members',
+    descriptionEs: 'Datos operativos de socios, contacto, estado y datos de emergencia.',
+    descriptionEn: 'Operational member data, contact details, status, and emergency information.',
+  },
+  usuarios: {
+    labelEs: 'Usuarios internos',
+    labelEn: 'Internal users',
+    descriptionEs: 'Identidades operativas sin contraseña ni hash.',
+    descriptionEn: 'Operational identities without passwords or hashes.',
+  },
+  empleados: {
+    labelEs: 'Empleados',
+    labelEn: 'Employees',
+    descriptionEs: 'Perfiles laborales internos del gimnasio.',
+    descriptionEn: 'Internal employment profiles for the gym.',
+  },
+  empleados_sueldos: {
+    labelEs: 'Sueldos',
+    labelEn: 'Salaries',
+    descriptionEs: 'Liquidaciones y pagos de sueldos de empleados.',
+    descriptionEn: 'Employee salary settlements and payments.',
+  },
+  cuotas: {
+    labelEs: 'Cuotas',
+    labelEn: 'Fees',
+    descriptionEs: 'Precios y vigencias de cuotas configuradas.',
+    descriptionEn: 'Configured fee prices and validity periods.',
+  },
+  pagos: {
+    labelEs: 'Pagos',
+    labelEn: 'Payments',
+    descriptionEs: 'Pagos de cuotas, períodos cubiertos y descuentos aplicados.',
+    descriptionEn: 'Fee payments, covered periods, and applied discounts.',
+  },
+  asistencias: {
+    labelEs: 'Asistencias',
+    labelEn: 'Attendances',
+    descriptionEs: 'Registros de ingreso y egreso de socios.',
+    descriptionEn: 'Member check-in and check-out records.',
+  },
+  ventas: {
+    labelEs: 'Ventas',
+    labelEn: 'Sales',
+    descriptionEs: 'Ventas de productos/servicios a socios, visitantes o consumidor final.',
+    descriptionEn: 'Product/service sales to members, visitors, or final customers.',
+  },
+  venta_detalle: {
+    labelEs: 'Detalle de ventas',
+    labelEn: 'Sales details',
+    descriptionEs: 'Ítems vendidos por operación comercial.',
+    descriptionEn: 'Items sold per commercial transaction.',
+  },
+  compras: {
+    labelEs: 'Compras',
+    labelEn: 'Purchases',
+    descriptionEs: 'Compras a proveedores y comprobantes asociados.',
+    descriptionEn: 'Supplier purchases and related receipts.',
+  },
+  compra_detalle: {
+    labelEs: 'Detalle de compras',
+    labelEn: 'Purchase details',
+    descriptionEs: 'Productos comprados, cantidades y costos unitarios.',
+    descriptionEn: 'Purchased products, quantities, and unit costs.',
+  },
+  productos: {
+    labelEs: 'Productos / stock',
+    labelEn: 'Products / stock',
+    descriptionEs: 'Catálogo comercial de productos, stock y precios vigentes.',
+    descriptionEn: 'Commercial product catalog, stock, and current prices.',
+  },
+  proveedores: {
+    labelEs: 'Proveedores',
+    labelEn: 'Suppliers',
+    descriptionEs: 'Datos comerciales y de contacto de proveedores.',
+    descriptionEn: 'Supplier commercial and contact data.',
+  },
+  servicios: {
+    labelEs: 'Servicios',
+    labelEn: 'Services',
+    descriptionEs: 'Servicios comerciales adicionales ofrecidos por el gimnasio.',
+    descriptionEn: 'Additional commercial services offered by the gym.',
+  },
+  gastos_egresos: {
+    labelEs: 'Gastos / egresos',
+    labelEn: 'Expenses / outflows',
+    descriptionEs: 'Gastos operativos, vencimientos y comprobantes.',
+    descriptionEn: 'Operating expenses, due dates, and receipts.',
+  },
+  mensajes_socios: {
+    labelEs: 'Mensajes de socios',
+    labelEn: 'Member messages',
+    descriptionEs: 'Consultas, reclamos y respuestas administrativas.',
+    descriptionEn: 'Queries, complaints, and administrative replies.',
+  },
+  tickets_soporte: {
+    labelEs: 'Tickets Dragon Pyramid',
+    labelEn: 'Dragon Pyramid tickets',
+    descriptionEs: 'Tickets enviados por el gimnasio a soporte Dragon Pyramid.',
+    descriptionEn: 'Tickets sent by the gym to Dragon Pyramid support.',
+  },
+};
+
+function getModulePresentation(modulo: RespaldoModulo): ModulePresentation {
+  return (
+    BACKUP_MODULE_PRESENTATION[modulo.key] ?? {
+      labelEs: modulo.label,
+      labelEn: modulo.label,
+      descriptionEs: modulo.description,
+      descriptionEn: modulo.description,
+    }
+  );
+}
+
+function getModuleLabel(locale: GymMasterLocale, modulo: RespaldoModulo) {
+  const presentation = getModulePresentation(modulo);
+  return locale === 'en' ? presentation.labelEn : presentation.labelEs;
+}
+
+function getModuleDescription(locale: GymMasterLocale, modulo: RespaldoModulo) {
+  const presentation = getModulePresentation(modulo);
+  return locale === 'en' ? presentation.descriptionEn : presentation.descriptionEs;
+}
+
+function estadoLabel(estado: string, locale: GymMasterLocale) {
+  if (estado === 'completado') return backupTx(locale, 'Completado', 'Completed');
+  if (estado === 'generando') return backupTx(locale, 'Generando', 'Generating');
+  if (estado === 'error') return backupTx(locale, 'Error', 'Error');
   return estado;
 }
 
 export default function RespaldoNegocioPage() {
   const router = useRouter();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => backupTx(locale, es, en);
   const { isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
   const [modulos, setModulos] = useState<RespaldoModulo[]>([]);
   const [historial, setHistorial] = useState<RespaldoHistorialItem[]>([]);
@@ -51,7 +198,7 @@ export default function RespaldoNegocioPage() {
       setHistorial(data.historial || []);
       setSelectedModules((current) => (current.length ? current : (data.modulos || []).map((item) => item.key)));
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'No se pudo cargar respaldo de negocio';
+      const message = error instanceof Error ? error.message : c('No se pudo cargar respaldo de negocio', 'Could not load business backup');
       toast.error(message);
     } finally {
       setLoading(false);
@@ -79,17 +226,17 @@ export default function RespaldoNegocioPage() {
 
   const handleExport = async (format: 'xlsx' | 'json') => {
     if (!selectedModules.length) {
-      toast.error('Seleccioná al menos un módulo para exportar.');
+      toast.error(c('Seleccioná al menos un módulo para exportar.', 'Select at least one module to export.'));
       return;
     }
 
     setExporting(format);
     try {
       await downloadRespaldoNegocio(format, selectedModules);
-      toast.success('Respaldo generado correctamente.');
+      toast.success(c('Respaldo generado correctamente.', 'Backup generated successfully.'));
       await loadData();
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'No se pudo generar el respaldo';
+      const message = error instanceof Error ? error.message : c('No se pudo generar el respaldo', 'Could not generate the backup');
       toast.error(message);
     } finally {
       setExporting(null);
@@ -102,67 +249,70 @@ export default function RespaldoNegocioPage() {
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <AppHeader title='Respaldo / Exportación' />
+        <AppHeader title={c('Respaldo / Exportación', 'Backup / Export')} />
         <main className='min-h-screen p-4 md:p-6 bg-gradient-to-b from-white to-slate-50 dark:from-slate-950 dark:to-slate-900'>
           <section className='mx-auto max-w-7xl space-y-6'>
-            <Card>
+            <Card className='border-slate-200 bg-white/95 shadow-sm dark:border-slate-800 dark:bg-slate-950/90'>
               <CardHeader className='space-y-3'>
                 <div className='flex flex-col gap-3 md:flex-row md:items-start md:justify-between'>
                   <div>
-                    <div className='flex items-center gap-2 text-sm font-semibold text-[#02a8e1]'>
+                    <div className='flex items-center gap-2 text-sm font-semibold text-[#02a8e1] dark:text-cyan-300'>
                       <ShieldCheck className='h-4 w-4' />
-                      Exportación segura de datos operativos
+                      {c('Exportación segura de datos operativos', 'Secure operational data export')}
                     </div>
-                    <h1 className='mt-2 text-2xl font-bold'>Respaldo del negocio</h1>
-                    <p className='mt-2 max-w-3xl text-sm text-muted-foreground'>
-                      Descargá los datos operativos del gimnasio en Excel o JSON. Esta exportación excluye contraseñas, tokens, secretos, migraciones privadas, datasets propietarios y know-how interno de Dragon Pyramid.
+                    <h1 className='mt-2 text-2xl font-bold text-slate-950 dark:text-slate-50'>{c('Respaldo del negocio', 'Business backup')}</h1>
+                    <p className='mt-2 max-w-3xl text-sm text-muted-foreground dark:text-slate-300'>
+                      {c(
+                        'Descargá los datos operativos del gimnasio en Excel o JSON. Esta exportación excluye contraseñas, tokens, secretos, migraciones privadas, datasets propietarios y know-how interno de Dragon Pyramid.',
+                        'Download the gym operational data in Excel or JSON. This export excludes passwords, tokens, secrets, private migrations, proprietary datasets, and Dragon Pyramid internal know-how.'
+                      )}
                     </p>
                   </div>
 
                   <div className='flex flex-wrap gap-2'>
                     <Button type='button' variant='outline' onClick={loadData} disabled={loading}>
-                      <RefreshCw className='mr-2 h-4 w-4' /> Actualizar
+                      <RefreshCw className='mr-2 h-4 w-4' /> {c('Actualizar', 'Refresh')}
                     </Button>
                     <Button type='button' variant='outline' onClick={() => handleExport('json')} disabled={Boolean(exporting)}>
-                      <FileJson className='mr-2 h-4 w-4' /> {exporting === 'json' ? 'Generando...' : 'JSON'}
+                      <FileJson className='mr-2 h-4 w-4' /> {exporting === 'json' ? c('Generando...', 'Generating...') : 'JSON'}
                     </Button>
-                    <Button type='button' onClick={() => handleExport('xlsx')} disabled={Boolean(exporting)} className='bg-[#02a8e1] hover:bg-[#028fc0]'>
-                      <FileSpreadsheet className='mr-2 h-4 w-4' /> {exporting === 'xlsx' ? 'Generando...' : 'Excel'}
+                    <Button type='button' onClick={() => handleExport('xlsx')} disabled={Boolean(exporting)} className='bg-[#02a8e1] hover:bg-[#028fc0] dark:bg-cyan-600 dark:hover:bg-cyan-500'>
+                      <FileSpreadsheet className='mr-2 h-4 w-4' /> {exporting === 'xlsx' ? c('Generando...', 'Generating...') : 'Excel'}
                     </Button>
                   </div>
                 </div>
               </CardHeader>
 
               <CardContent className='grid gap-4 md:grid-cols-3'>
-                <div className='rounded-xl border bg-white p-4 shadow-sm dark:bg-slate-950'>
-                  <p className='text-xs text-muted-foreground'>Módulos disponibles</p>
-                  <p className='mt-2 text-3xl font-bold'>{modulos.length}</p>
+                <div className='rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/80'>
+                  <p className='text-xs text-muted-foreground dark:text-slate-400'>{c('Módulos disponibles', 'Available modules')}</p>
+                  <p className='mt-2 text-3xl font-bold text-slate-950 dark:text-slate-50'>{modulos.length}</p>
                 </div>
-                <div className='rounded-xl border bg-white p-4 shadow-sm dark:bg-slate-950'>
-                  <p className='text-xs text-muted-foreground'>Seleccionados</p>
-                  <p className='mt-2 text-3xl font-bold'>{selectedCount}</p>
+                <div className='rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/80'>
+                  <p className='text-xs text-muted-foreground dark:text-slate-400'>{c('Seleccionados', 'Selected')}</p>
+                  <p className='mt-2 text-3xl font-bold text-slate-950 dark:text-slate-50'>{selectedCount}</p>
                 </div>
-                <div className='rounded-xl border bg-white p-4 shadow-sm dark:bg-slate-950'>
-                  <p className='text-xs text-muted-foreground'>Última exportación</p>
-                  <p className='mt-2 text-sm font-semibold'>{lastExport ? formatFrontendDateTime(lastExport.creado_en) : 'Sin registros'}</p>
+                <div className='rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/80'>
+                  <p className='text-xs text-muted-foreground dark:text-slate-400'>{c('Última exportación', 'Last export')}</p>
+                  <p className='mt-2 text-sm font-semibold text-slate-950 dark:text-slate-50'>{lastExport ? formatFrontendDateTime(lastExport.creado_en) : c('Sin registros', 'No records')}</p>
                 </div>
               </CardContent>
             </Card>
 
             <div className='grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(360px,0.8fr)]'>
-              <Card>
+              <Card className='border-slate-200 bg-white/95 shadow-sm dark:border-slate-800 dark:bg-slate-950/90'>
                 <CardHeader className='flex flex-row items-center justify-between gap-3'>
                   <div>
-                    <h2 className='text-xl font-semibold'>Módulos exportables</h2>
-                    <p className='text-sm text-muted-foreground'>Seleccioná qué datos del negocio querés incluir.</p>
+                    <h2 className='text-xl font-semibold text-slate-950 dark:text-slate-50'>{c('Módulos exportables', 'Exportable modules')}</h2>
+                    <p className='text-sm text-muted-foreground dark:text-slate-400'>{c('Seleccioná qué datos del negocio querés incluir.', 'Select which business data you want to include.')}</p>
                   </div>
                   <Button type='button' variant='outline' onClick={toggleAll}>
-                    {allSelected ? 'Deseleccionar todos' : 'Seleccionar todos'}
+                    {allSelected ? c('Deseleccionar todos', 'Deselect all') : c('Seleccionar todos', 'Select all')}
                   </Button>
                 </CardHeader>
                 <CardContent>
                   {loading ? (
-                    <p className='text-sm text-muted-foreground'>Cargando módulos...</p>
+                    <p className='text-sm text-muted-foreground dark:text-slate-400'>{c('Cargando módulos...', 'Loading modules...')}</p>
                   ) : (
                     <div className='grid gap-3 md:grid-cols-2'>
                       {modulos.map((modulo) => {
@@ -170,7 +320,7 @@ export default function RespaldoNegocioPage() {
                         return (
                           <label
                             key={modulo.key}
-                            className={`flex cursor-pointer gap-3 rounded-xl border p-4 transition ${checked ? 'border-[#02a8e1] bg-[#e6f7fd]' : 'bg-white hover:bg-slate-50 dark:bg-slate-950 dark:hover:bg-slate-900'}`}
+                            className={`flex cursor-pointer gap-3 rounded-xl border p-4 transition ${checked ? 'border-[#02a8e1] bg-[#e6f7fd] dark:border-cyan-400/70 dark:bg-cyan-950/40' : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-900'}`}
                           >
                             <input
                               type='checkbox'
@@ -179,8 +329,8 @@ export default function RespaldoNegocioPage() {
                               className='mt-1 h-4 w-4 accent-[#02a8e1]'
                             />
                             <span>
-                              <span className='block font-semibold'>{modulo.label}</span>
-                              <span className='mt-1 block text-xs leading-5 text-muted-foreground'>{modulo.description}</span>
+                              <span className='block font-semibold text-slate-950 dark:text-slate-50'>{getModuleLabel(locale, modulo)}</span>
+                              <span className='mt-1 block text-xs leading-5 text-muted-foreground dark:text-slate-400'>{getModuleDescription(locale, modulo)}</span>
                             </span>
                           </label>
                         );
@@ -190,36 +340,36 @@ export default function RespaldoNegocioPage() {
                 </CardContent>
               </Card>
 
-              <Card>
+              <Card className='border-slate-200 bg-white/95 shadow-sm dark:border-slate-800 dark:bg-slate-950/90'>
                 <CardHeader>
-                  <h2 className='text-xl font-semibold'>Historial reciente</h2>
-                  <p className='text-sm text-muted-foreground'>Auditoría de las últimas exportaciones realizadas.</p>
+                  <h2 className='text-xl font-semibold text-slate-950 dark:text-slate-50'>{c('Historial reciente', 'Recent history')}</h2>
+                  <p className='text-sm text-muted-foreground dark:text-slate-400'>{c('Auditoría de las últimas exportaciones realizadas.', 'Audit log of the latest exports.')}</p>
                 </CardHeader>
                 <CardContent>
                   {!historial.length ? (
-                    <div className='rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground'>
+                    <div className='rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-muted-foreground dark:border-slate-700 dark:text-slate-400'>
                       <Archive className='mx-auto mb-2 h-8 w-8 opacity-60' />
-                      Todavía no hay exportaciones registradas.
+                      {c('Todavía no hay exportaciones registradas.', 'No exports registered yet.')}
                     </div>
                   ) : (
                     <div className='space-y-3'>
                       {historial.map((item) => (
-                        <article key={item.id} className='rounded-xl border bg-white p-3 text-sm shadow-sm dark:bg-slate-950'>
+                        <article key={item.id} className='rounded-xl border border-slate-200 bg-white p-3 text-sm shadow-sm dark:border-slate-800 dark:bg-slate-900/80'>
                           <div className='flex items-start justify-between gap-3'>
                             <div>
-                              <p className='font-semibold'>{item.archivo_nombre || 'Respaldo generado'}</p>
-                              <p className='text-xs text-muted-foreground'>{formatFrontendDateTime(item.creado_en)}</p>
+                              <p className='font-semibold text-slate-950 dark:text-slate-50'>{item.archivo_nombre || c('Respaldo generado', 'Generated backup')}</p>
+                              <p className='text-xs text-muted-foreground dark:text-slate-400'>{formatFrontendDateTime(item.creado_en)}</p>
                             </div>
-                            <span className={`rounded-full px-2 py-1 text-xs font-medium ${item.estado === 'completado' ? 'bg-emerald-50 text-emerald-700' : item.estado === 'error' ? 'bg-red-50 text-red-700' : 'bg-amber-50 text-amber-700'}`}>
-                              {estadoLabel(item.estado)}
+                            <span className={`rounded-full px-2 py-1 text-xs font-medium ${item.estado === 'completado' ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300' : item.estado === 'error' ? 'bg-red-50 text-red-700 dark:bg-red-950/60 dark:text-red-300' : 'bg-amber-50 text-amber-700 dark:bg-amber-950/60 dark:text-amber-300'}`}>
+                              {estadoLabel(item.estado, locale)}
                             </span>
                           </div>
-                          <div className='mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground'>
-                            <span>Formato: {item.formato.toUpperCase()}</span>
-                            <span>Registros: {item.registros_totales}</span>
-                            <span className='col-span-2'>Módulos: {item.modulos?.length ?? 0}</span>
+                          <div className='mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground dark:text-slate-400'>
+                            <span>{c('Formato', 'Format')}: {item.formato.toUpperCase()}</span>
+                            <span>{c('Registros', 'Records')}: {item.registros_totales}</span>
+                            <span className='col-span-2'>{c('Módulos', 'Modules')}: {item.modulos?.length ?? 0}</span>
                           </div>
-                          {item.error && <p className='mt-2 text-xs text-red-600'>{item.error}</p>}
+                          {item.error && <p className='mt-2 text-xs text-red-600 dark:text-red-300'>{item.error}</p>}
                         </article>
                       ))}
                     </div>

--- a/src/app/dashboard/soporte-dragon-pyramid/page.tsx
+++ b/src/app/dashboard/soporte-dragon-pyramid/page.tsx
@@ -38,44 +38,97 @@ import {
   getSoporteTickets,
 } from '@/services/apiClient';
 import { useAuthStore } from '@/stores/authStore';
+import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import { formatFrontendDateTime } from '@/utils/dateFormat';
 
-const categorias: Array<{ value: SoporteTicketCategoria; label: string }> = [
-  { value: 'fallas', label: 'Fallas' },
-  { value: 'dudas', label: 'Dudas' },
-  { value: 'problemas', label: 'Problemas' },
-  { value: 'sugerencias', label: 'Sugerencias' },
-  { value: 'otros', label: 'Otros' },
-];
-
-const prioridades: Array<{ value: SoporteTicketPrioridad; label: string }> = [
-  { value: 'baja', label: 'Baja' },
-  { value: 'media', label: 'Media' },
-  { value: 'alta', label: 'Alta' },
-  { value: 'critica', label: 'Crítica' },
-];
-
-const estados: Array<{ value: SoporteTicketEstado | 'todos'; label: string }> = [
-  { value: 'todos', label: 'Todos' },
-  { value: 'pendiente', label: 'Pendientes' },
-  { value: 'en_revision', label: 'En revisión' },
-  { value: 'respondido', label: 'Respondidos' },
-  { value: 'cerrado', label: 'Cerrados' },
-];
-
-const estadoLabel: Record<SoporteTicketEstado, string> = {
-  pendiente: 'Pendiente',
-  en_revision: 'En revisión',
-  respondido: 'Respondido',
-  cerrado: 'Cerrado',
+type LocalizedText = {
+  es: string;
+  en: string;
 };
 
-const prioridadLabel: Record<SoporteTicketPrioridad, string> = {
-  baja: 'Baja',
-  media: 'Media',
-  alta: 'Alta',
-  critica: 'Crítica',
+const categorias: SoporteTicketCategoria[] = ['fallas', 'dudas', 'problemas', 'sugerencias', 'otros'];
+
+const prioridades: SoporteTicketPrioridad[] = ['baja', 'media', 'alta', 'critica'];
+
+const estados: Array<SoporteTicketEstado | 'todos'> = ['todos', 'pendiente', 'en_revision', 'respondido', 'cerrado'];
+
+const categoriaLabel: Record<SoporteTicketCategoria, LocalizedText> = {
+  fallas: { es: 'Fallas', en: 'Failures' },
+  dudas: { es: 'Dudas', en: 'Questions' },
+  problemas: { es: 'Problemas', en: 'Issues' },
+  sugerencias: { es: 'Sugerencias', en: 'Suggestions' },
+  otros: { es: 'Otros', en: 'Other' },
 };
+
+const estadoFilterLabel: Record<SoporteTicketEstado | 'todos', LocalizedText> = {
+  todos: { es: 'Todos', en: 'All' },
+  pendiente: { es: 'Pendientes', en: 'Pending' },
+  en_revision: { es: 'En revisión', en: 'Under review' },
+  respondido: { es: 'Respondidos', en: 'Responded' },
+  cerrado: { es: 'Cerrados', en: 'Closed' },
+};
+
+const estadoLabel: Record<SoporteTicketEstado, LocalizedText> = {
+  pendiente: { es: 'Pendiente', en: 'Pending' },
+  en_revision: { es: 'En revisión', en: 'Under review' },
+  respondido: { es: 'Respondido', en: 'Responded' },
+  cerrado: { es: 'Cerrado', en: 'Closed' },
+};
+
+const prioridadLabel: Record<SoporteTicketPrioridad, LocalizedText> = {
+  baja: { es: 'Baja', en: 'Low' },
+  media: { es: 'Media', en: 'Medium' },
+  alta: { es: 'Alta', en: 'High' },
+  critica: { es: 'Crítica', en: 'Critical' },
+};
+
+function supportTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function localizedLabel<T extends string>(locale: GymMasterLocale, labels: Record<T, LocalizedText>, value: T) {
+  return labels[value]?.[locale] ?? value;
+}
+
+function getCategoriaLabel(locale: GymMasterLocale, value: SoporteTicketCategoria) {
+  return localizedLabel(locale, categoriaLabel, value);
+}
+
+function getEstadoLabel(locale: GymMasterLocale, value: SoporteTicketEstado) {
+  return localizedLabel(locale, estadoLabel, value);
+}
+
+function getEstadoFilterLabel(locale: GymMasterLocale, value: SoporteTicketEstado | 'todos') {
+  return localizedLabel(locale, estadoFilterLabel, value);
+}
+
+function getPrioridadLabel(locale: GymMasterLocale, value: SoporteTicketPrioridad) {
+  return localizedLabel(locale, prioridadLabel, value);
+}
+
+function getEmailStatusLabel(locale: GymMasterLocale, ticket: SoporteTicket) {
+  if (ticket.email_notificacion_enviado) {
+    return supportTx(locale, 'enviado', 'sent');
+  }
+
+  return ticket.email_notificacion_error || supportTx(locale, 'pendiente/no configurado', 'pending/not configured');
+}
+
+function translateEventType(locale: GymMasterLocale, value?: string | null) {
+  if (!value) return supportTx(locale, 'Evento', 'Event');
+
+  const normalized = value.toLowerCase().trim();
+  const translations: Record<string, LocalizedText> = {
+    creado: { es: 'Creado', en: 'Created' },
+    comentario: { es: 'Comentario', en: 'Comment' },
+    respuesta: { es: 'Respuesta', en: 'Reply' },
+    estado: { es: 'Estado', en: 'Status' },
+    cierre: { es: 'Cierre', en: 'Closure' },
+  };
+
+  return translations[normalized]?.[locale] ?? value;
+}
 
 const prioridadClass: Record<SoporteTicketPrioridad, string> = {
   baja: 'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200',
@@ -113,11 +166,13 @@ function isStaleTicket(ticket: SoporteTicket) {
   return isOpenTicket(ticket) && getTicketAgeHours(ticket) >= 48;
 }
 
-function getFormattedDate(value?: string | null) {
-  return value ? formatFrontendDateTime(value) : 'Sin definir';
+function getFormattedDate(locale: GymMasterLocale, value?: string | null) {
+  return value ? formatFrontendDateTime(value) : supportTx(locale, 'Sin definir', 'Undefined');
 }
 
 export default function SoporteDragonPyramidPage() {
+  const { locale } = useI18n();
+  const c = useCallback((es: string, en: string) => supportTx(locale, es, en), [locale]);
   const { isAuthenticated, initializeAuth, isInitialized, user } = useAuthStore();
   const [tickets, setTickets] = useState<SoporteTicket[]>([]);
   const [selected, setSelected] = useState<SoporteTicket | null>(null);
@@ -140,7 +195,7 @@ export default function SoporteDragonPyramidPage() {
         estado: estadoFilter,
         q: searchTerm.trim(),
       });
-      if (!response.ok) throw new Error(response.error || 'No se pudieron cargar los tickets');
+      if (!response.ok) throw new Error(response.error || c('No se pudieron cargar los tickets', 'Could not load tickets'));
       const nextTickets = response.data ?? [];
       setTickets(nextTickets);
       setSelected((current) => {
@@ -149,11 +204,11 @@ export default function SoporteDragonPyramidPage() {
       });
     } catch (error) {
       setTickets([]);
-      toast.error(error instanceof Error ? error.message : 'Error al cargar tickets');
+      toast.error(error instanceof Error ? error.message : c('Error al cargar tickets', 'Error loading tickets'));
     } finally {
       setLoading(false);
     }
-  }, [estadoFilter, searchTerm]);
+  }, [c, estadoFilter, searchTerm]);
 
   useEffect(() => {
     if (isAuthenticated) loadTickets();
@@ -178,38 +233,40 @@ export default function SoporteDragonPyramidPage() {
   const supportHealth = useMemo(() => {
     if (totals.criticos > 0 || totals.vencidos > 0) {
       return {
-        label: 'Atención prioritaria',
-        description: 'Hay tickets críticos o con más de 48 horas abiertos.',
+        label: c('Atención prioritaria', 'Priority attention'),
+        description: c('Hay tickets críticos o con más de 48 horas abiertos.', 'There are critical tickets or tickets open for more than 48 hours.'),
         tone: 'danger',
       };
     }
 
     if (totals.abiertos > 0 || totals.emailPendiente > 0) {
       return {
-        label: 'Seguimiento activo',
-        description: 'Hay tickets abiertos o notificaciones de email pendientes de confirmar.',
+        label: c('Seguimiento activo', 'Active follow-up'),
+        description: c('Hay tickets abiertos o notificaciones de email pendientes de confirmar.', 'There are open tickets or email notifications pending confirmation.'),
         tone: 'warning',
       };
     }
 
     return {
-      label: 'Mesa estable',
-      description: 'No hay tickets abiertos que requieran intervención inmediata.',
+      label: c('Mesa estable', 'Stable desk'),
+      description: c('No hay tickets abiertos que requieran intervención inmediata.', 'There are no open tickets requiring immediate intervention.'),
       tone: 'success',
     };
-  }, [totals]);
+  }, [c, totals]);
 
   const nextAction = useMemo(() => {
     const critical = tickets.find((ticket) => isOpenTicket(ticket) && ticket.prioridad === 'critica');
-    if (critical) return `Priorizar ${critical.codigo}: ${critical.asunto}`;
+    if (critical) return `${c('Priorizar', 'Prioritize')} ${critical.codigo}: ${critical.asunto}`;
 
     const stale = tickets.find(isStaleTicket);
-    if (stale) return `Actualizar seguimiento de ${stale.codigo}; lleva ${getTicketAgeHours(stale)} h abierto.`;
+    if (stale) {
+      return `${c('Actualizar seguimiento de', 'Update follow-up for')} ${stale.codigo}; ${c('lleva', 'it has been')} ${getTicketAgeHours(stale)} h ${c('abierto.', 'open.')}`;
+    }
 
-    if (totals.emailPendiente > 0) return 'Revisar configuración de email de soporte Dragon Pyramid.';
-    if (totals.abiertos > 0) return 'Mantener seguimiento diario de tickets abiertos.';
-    return 'Registrar nuevos incidentes con captura, pasos y usuario afectado cuando ocurran.';
-  }, [tickets, totals.abiertos, totals.emailPendiente]);
+    if (totals.emailPendiente > 0) return c('Revisar configuración de email de soporte Dragon Pyramid.', 'Review Dragon Pyramid support email settings.');
+    if (totals.abiertos > 0) return c('Mantener seguimiento diario de tickets abiertos.', 'Keep daily follow-up on open tickets.');
+    return c('Registrar nuevos incidentes con captura, pasos y usuario afectado cuando ocurran.', 'Log new incidents with screenshots, steps, and affected user whenever they happen.');
+  }, [c, tickets, totals.abiertos, totals.emailPendiente]);
 
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
@@ -222,12 +279,12 @@ export default function SoporteDragonPyramidPage() {
     event.preventDefault();
 
     if (!form.asunto.trim()) {
-      toast.error('El asunto es obligatorio.');
+      toast.error(c('El asunto es obligatorio.', 'Subject is required.'));
       return;
     }
 
     if (!form.descripcion.trim()) {
-      toast.error('La descripción es obligatoria.');
+      toast.error(c('La descripción es obligatoria.', 'Description is required.'));
       return;
     }
 
@@ -242,15 +299,15 @@ export default function SoporteDragonPyramidPage() {
       });
 
       if (!response.ok || !response.data) {
-        throw new Error(response.error || 'No se pudo crear el ticket');
+        throw new Error(response.error || c('No se pudo crear el ticket', 'Could not create the ticket'));
       }
 
-      toast.success('Ticket enviado a Dragon Pyramid');
+      toast.success(c('Ticket enviado a Dragon Pyramid', 'Ticket sent to Dragon Pyramid'));
       setForm(initialForm);
       setSelected(response.data);
       await loadTickets();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Error al crear ticket');
+      toast.error(error instanceof Error ? error.message : c('Error al crear ticket', 'Error creating ticket'));
     } finally {
       setSaving(false);
     }
@@ -266,15 +323,15 @@ export default function SoporteDragonPyramidPage() {
     setSaving(true);
     try {
       const response = await actualizarSoporteTicket(selected.id, payload);
-      if (!response.ok || !response.data) throw new Error(response.error || 'No se pudo actualizar el ticket');
-      toast.success('Ticket actualizado');
+      if (!response.ok || !response.data) throw new Error(response.error || c('No se pudo actualizar el ticket', 'Could not update the ticket'));
+      toast.success(c('Ticket actualizado', 'Ticket updated'));
       const detail = await getSoporteTicket(selected.id);
       setSelected(detail.ok && detail.data ? detail.data : response.data);
       setComentario('');
       setRespuesta('');
       await loadTickets();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Error al actualizar ticket');
+      toast.error(error instanceof Error ? error.message : c('Error al actualizar ticket', 'Error updating ticket'));
     } finally {
       setSaving(false);
     }
@@ -287,7 +344,7 @@ export default function SoporteDragonPyramidPage() {
   };
 
   if (!isInitialized) {
-    return <div className='flex min-h-screen items-center justify-center text-sm text-muted-foreground'>Cargando soporte...</div>;
+    return <div className='flex min-h-screen items-center justify-center text-sm text-muted-foreground'>{c('Cargando soporte...', 'Loading support...')}</div>;
   }
 
   if (!isAuthenticated) return null;
@@ -297,7 +354,7 @@ export default function SoporteDragonPyramidPage() {
       <div className='flex h-[100dvh] max-h-[100dvh] w-full overflow-hidden bg-slate-50 dark:bg-slate-950'>
         <AppSidebar />
         <SidebarInset className='grid h-[100dvh] max-h-[100dvh] min-w-0 grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden'>
-          <AppHeader title='Soporte Dragon Pyramid' />
+          <AppHeader title={c('Soporte Dragon Pyramid', 'Dragon Pyramid support')} />
           <main className='min-h-0 overflow-y-auto overflow-x-hidden px-4 py-5 sm:px-6 lg:px-8'>
             <div className='mx-auto flex w-full max-w-7xl flex-col gap-6 pb-6'>
               <section className='overflow-hidden rounded-3xl border border-sky-500/30 bg-slate-950 text-white shadow-xl dark:border-sky-400/30'>
@@ -305,25 +362,25 @@ export default function SoporteDragonPyramidPage() {
                   <div className='space-y-4'>
                     <span className='inline-flex w-fit items-center gap-2 rounded-full border border-cyan-300/40 bg-cyan-400/10 px-3 py-1 text-xs font-black uppercase tracking-[0.22em] text-cyan-100'>
                       <Headphones className='h-4 w-4' />
-                      Mesa de ayuda interna
+                      {c('Mesa de ayuda interna', 'Internal help desk')}
                     </span>
                     <div>
-                      <h1 className='text-3xl font-black tracking-tight md:text-4xl'>Soporte Dragon Pyramid</h1>
+                      <h1 className='text-3xl font-black tracking-tight md:text-4xl'>{c('Soporte Dragon Pyramid', 'Dragon Pyramid support')}</h1>
                       <p className='mt-3 max-w-3xl text-sm leading-6 text-slate-200 md:text-base'>
-                        Registrá incidencias, dudas o mejoras del gimnasio cliente y mantené seguimiento operativo con trazabilidad de estados, prioridad, email y respuesta.
+                        {c('Registrá incidencias, dudas o mejoras del gimnasio cliente y mantené seguimiento operativo con trazabilidad de estados, prioridad, email y respuesta.', 'Log incidents, questions, or improvements from the client gym and keep operational follow-up with status, priority, email, and reply traceability.')}
                       </p>
                     </div>
                   </div>
                   <div className='grid gap-3 sm:grid-cols-2 lg:w-[360px]'>
                     <div className='rounded-2xl border border-white/10 bg-white/10 p-4'>
-                      <p className='text-xs uppercase tracking-[0.18em] text-cyan-100'>Estado</p>
+                      <p className='text-xs uppercase tracking-[0.18em] text-cyan-100'>{c('Estado', 'Status')}</p>
                       <p className='mt-2 text-xl font-black'>{supportHealth.label}</p>
                       <p className='mt-1 text-xs text-slate-200'>{supportHealth.description}</p>
                     </div>
                     <div className='rounded-2xl border border-white/10 bg-white/10 p-4'>
-                      <p className='text-xs uppercase tracking-[0.18em] text-cyan-100'>Tickets abiertos</p>
+                      <p className='text-xs uppercase tracking-[0.18em] text-cyan-100'>{c('Tickets abiertos', 'Open tickets')}</p>
                       <p className='mt-2 text-3xl font-black'>{totals.abiertos}</p>
-                      <p className='mt-1 text-xs text-slate-200'>{totals.criticos} críticos</p>
+                      <p className='mt-1 text-xs text-slate-200'>{totals.criticos} {c('críticos', 'critical')}</p>
                     </div>
                   </div>
                 </div>
@@ -334,7 +391,7 @@ export default function SoporteDragonPyramidPage() {
                   <CardContent className='flex items-center gap-3 p-5'>
                     <LifeBuoy className='h-9 w-9 text-sky-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Tickets totales</p>
+                      <p className='text-sm text-muted-foreground'>{c('Tickets totales', 'Total tickets')}</p>
                       <p className='text-3xl font-black'>{totals.total}</p>
                     </div>
                   </CardContent>
@@ -343,7 +400,7 @@ export default function SoporteDragonPyramidPage() {
                   <CardContent className='flex items-center gap-3 p-5'>
                     <MessageSquarePlus className='h-9 w-9 text-amber-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Abiertos</p>
+                      <p className='text-sm text-muted-foreground'>{c('Abiertos', 'Open')}</p>
                       <p className='text-3xl font-black'>{totals.abiertos}</p>
                     </div>
                   </CardContent>
@@ -352,7 +409,7 @@ export default function SoporteDragonPyramidPage() {
                   <CardContent className='flex items-center gap-3 p-5'>
                     <AlertTriangle className='h-9 w-9 text-red-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Críticos / +48 h</p>
+                      <p className='text-sm text-muted-foreground'>{c('Críticos / +48 h', 'Critical / +48 h')}</p>
                       <p className='text-3xl font-black'>{totals.criticos + totals.vencidos}</p>
                     </div>
                   </CardContent>
@@ -361,7 +418,7 @@ export default function SoporteDragonPyramidPage() {
                   <CardContent className='flex items-center gap-3 p-5'>
                     <CheckCircle2 className='h-9 w-9 text-emerald-600' />
                     <div>
-                      <p className='text-sm text-muted-foreground'>Cerrados</p>
+                      <p className='text-sm text-muted-foreground'>{c('Cerrados', 'Closed')}</p>
                       <p className='text-3xl font-black'>{totals.cerrados}</p>
                     </div>
                   </CardContent>
@@ -374,17 +431,17 @@ export default function SoporteDragonPyramidPage() {
                     <div className='flex items-center gap-3'>
                       <ShieldCheck className='h-6 w-6 text-cyan-600 dark:text-cyan-300' />
                       <div>
-                        <h2 className='font-black'>Lectura ejecutiva de soporte</h2>
-                        <p className='text-sm text-muted-foreground'>Priorización para no perder incidencias importantes.</p>
+                        <h2 className='font-black'>{c('Lectura ejecutiva de soporte', 'Executive support reading')}</h2>
+                        <p className='text-sm text-muted-foreground'>{c('Priorización para no perder incidencias importantes.', 'Prioritization to avoid missing important incidents.')}</p>
                       </div>
                     </div>
                     <div className='grid gap-3 sm:grid-cols-3'>
                       <div className='rounded-xl border bg-white p-3 dark:border-slate-800 dark:bg-slate-950'>
-                        <p className='text-xs uppercase text-muted-foreground'>En revisión</p>
+                        <p className='text-xs uppercase text-muted-foreground'>{c('En revisión', 'Under review')}</p>
                         <p className='text-2xl font-black'>{totals.enRevision}</p>
                       </div>
                       <div className='rounded-xl border bg-white p-3 dark:border-slate-800 dark:bg-slate-950'>
-                        <p className='text-xs uppercase text-muted-foreground'>Email pendiente</p>
+                        <p className='text-xs uppercase text-muted-foreground'>{c('Email pendiente', 'Pending email')}</p>
                         <p className='text-2xl font-black'>{totals.emailPendiente}</p>
                       </div>
                       <div className='rounded-xl border bg-white p-3 dark:border-slate-800 dark:bg-slate-950'>
@@ -393,7 +450,7 @@ export default function SoporteDragonPyramidPage() {
                       </div>
                     </div>
                     <div className='rounded-xl border border-cyan-200 bg-white p-4 text-sm dark:border-cyan-900 dark:bg-slate-950'>
-                      <p className='font-bold'>Próximo paso recomendado</p>
+                      <p className='font-bold'>{c('Próximo paso recomendado', 'Recommended next step')}</p>
                       <p className='mt-1 text-muted-foreground'>{nextAction}</p>
                     </div>
                   </CardContent>
@@ -403,18 +460,18 @@ export default function SoporteDragonPyramidPage() {
                   <CardContent className='grid gap-4 p-5 md:grid-cols-3'>
                     <div className='rounded-xl border border-dashed p-4 dark:border-slate-700'>
                       <TimerReset className='mb-3 h-6 w-6 text-sky-600' />
-                      <p className='font-bold'>Triage rápido</p>
-                      <p className='mt-1 text-sm text-muted-foreground'>Clasificá por prioridad y categoría para que Dragon Pyramid reciba contexto accionable.</p>
+                      <p className='font-bold'>{c('Triage rápido', 'Quick triage')}</p>
+                      <p className='mt-1 text-sm text-muted-foreground'>{c('Clasificá por prioridad y categoría para que Dragon Pyramid reciba contexto accionable.', 'Classify by priority and category so Dragon Pyramid receives actionable context.')}</p>
                     </div>
                     <div className='rounded-xl border border-dashed p-4 dark:border-slate-700'>
                       <MailWarning className='mb-3 h-6 w-6 text-amber-600' />
-                      <p className='font-bold'>Email de soporte</p>
-                      <p className='mt-1 text-sm text-muted-foreground'>Si no hay destinatario configurado, el ticket queda registrado y visible para seguimiento.</p>
+                      <p className='font-bold'>{c('Email de soporte', 'Support email')}</p>
+                      <p className='mt-1 text-sm text-muted-foreground'>{c('Si no hay destinatario configurado, el ticket queda registrado y visible para seguimiento.', 'If no recipient is configured, the ticket remains logged and visible for follow-up.')}</p>
                     </div>
                     <div className='rounded-xl border border-dashed p-4 dark:border-slate-700'>
                       <Sparkles className='mb-3 h-6 w-6 text-fuchsia-600' />
-                      <p className='font-bold'>Trazabilidad</p>
-                      <p className='mt-1 text-sm text-muted-foreground'>Cada comentario, respuesta y cambio de estado queda en historial del ticket.</p>
+                      <p className='font-bold'>{c('Trazabilidad', 'Traceability')}</p>
+                      <p className='mt-1 text-sm text-muted-foreground'>{c('Cada comentario, respuesta y cambio de estado queda en historial del ticket.', 'Every comment, reply, and status change remains in the ticket history.')}</p>
                     </div>
                   </CardContent>
                 </Card>
@@ -423,14 +480,14 @@ export default function SoporteDragonPyramidPage() {
               <div className='grid gap-6 xl:grid-cols-[0.85fr_1.15fr]'>
                 <Card className='bg-white dark:border-slate-800 dark:bg-slate-900'>
                   <CardHeader className='border-b p-5 dark:border-slate-800'>
-                    <h2 className='text-xl font-black'>Nuevo ticket</h2>
-                    <p className='text-sm text-muted-foreground'>Reportá fallas, dudas, problemas o sugerencias al soporte de Dragon Pyramid.</p>
+                    <h2 className='text-xl font-black'>{c('Nuevo ticket', 'New ticket')}</h2>
+                    <p className='text-sm text-muted-foreground'>{c('Reportá fallas, dudas, problemas o sugerencias al soporte de Dragon Pyramid.', 'Report failures, questions, issues, or suggestions to Dragon Pyramid support.')}</p>
                   </CardHeader>
                   <CardContent className='p-5'>
                     <form className='space-y-4' onSubmit={handleCreate}>
                       <div className='grid gap-3 md:grid-cols-2'>
                         <div className='space-y-2'>
-                          <Label htmlFor='categoria'>Categoría</Label>
+                          <Label htmlFor='categoria'>{c('Categoría', 'Category')}</Label>
                           <select
                             id='categoria'
                             name='categoria'
@@ -439,12 +496,12 @@ export default function SoporteDragonPyramidPage() {
                             onChange={handleChange}
                           >
                             {categorias.map((categoria) => (
-                              <option key={categoria.value} value={categoria.value}>{categoria.label}</option>
+                              <option key={categoria} value={categoria}>{getCategoriaLabel(locale, categoria)}</option>
                             ))}
                           </select>
                         </div>
                         <div className='space-y-2'>
-                          <Label htmlFor='prioridad'>Prioridad</Label>
+                          <Label htmlFor='prioridad'>{c('Prioridad', 'Priority')}</Label>
                           <select
                             id='prioridad'
                             name='prioridad'
@@ -453,25 +510,25 @@ export default function SoporteDragonPyramidPage() {
                             onChange={handleChange}
                           >
                             {prioridades.map((prioridad) => (
-                              <option key={prioridad.value} value={prioridad.value}>{prioridad.label}</option>
+                              <option key={prioridad} value={prioridad}>{getPrioridadLabel(locale, prioridad)}</option>
                             ))}
                           </select>
                         </div>
                       </div>
 
                       <div className='space-y-2'>
-                        <Label htmlFor='asunto'>Asunto</Label>
+                        <Label htmlFor='asunto'>{c('Asunto', 'Subject')}</Label>
                         <Input
                           id='asunto'
                           name='asunto'
                           value={form.asunto}
                           onChange={handleChange}
-                          placeholder='Ejemplo: error al registrar pagos manuales'
+                          placeholder={c('Ejemplo: error al registrar pagos manuales', 'Example: error when registering manual payments')}
                         />
                       </div>
 
                       <div className='space-y-2'>
-                        <Label htmlFor='descripcion'>Descripción</Label>
+                        <Label htmlFor='descripcion'>{c('Descripción', 'Description')}</Label>
                         <textarea
                           id='descripcion'
                           name='descripcion'
@@ -479,12 +536,12 @@ export default function SoporteDragonPyramidPage() {
                           value={form.descripcion}
                           onChange={handleChange}
                           className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                          placeholder='Describí qué pasó, qué usuario lo reportó, pasos para reproducirlo y cualquier dato relevante.'
+                          placeholder={c('Describí qué pasó, qué usuario lo reportó, pasos para reproducirlo y cualquier dato relevante.', 'Describe what happened, which user reported it, steps to reproduce it, and any relevant details.')}
                         />
                       </div>
 
                       <div className='space-y-2'>
-                        <Label htmlFor='adjunto_url'>Adjunto / captura URL opcional</Label>
+                        <Label htmlFor='adjunto_url'>{c('Adjunto / captura URL opcional', 'Optional attachment / screenshot URL')}</Label>
                         <Input
                           id='adjunto_url'
                           name='adjunto_url'
@@ -495,12 +552,12 @@ export default function SoporteDragonPyramidPage() {
                       </div>
 
                       <div className='rounded-lg bg-muted p-3 text-xs text-muted-foreground'>
-                        Usuario emisor: {user?.nombre ?? user?.email ?? 'Usuario actual'}. El sistema enviará notificación por email si el soporte de Dragon Pyramid está configurado.
+                        {c('Usuario emisor:', 'Sender user:')} {user?.nombre ?? user?.email ?? c('Usuario actual', 'Current user')}. {c('El sistema enviará notificación por email si el soporte de Dragon Pyramid está configurado.', 'The system will send an email notification if Dragon Pyramid support is configured.')}
                       </div>
 
                       <Button type='submit' disabled={saving} className='w-full gap-2'>
                         <Send className='h-4 w-4' />
-                        {saving ? 'Enviando...' : 'Enviar ticket'}
+                        {saving ? c('Enviando...', 'Sending...') : c('Enviar ticket', 'Send ticket')}
                       </Button>
                     </form>
                   </CardContent>
@@ -510,8 +567,8 @@ export default function SoporteDragonPyramidPage() {
                   <CardHeader className='border-b p-5 dark:border-slate-800'>
                     <div className='flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between'>
                       <div>
-                        <h2 className='text-xl font-black'>Tickets enviados</h2>
-                        <p className='text-sm text-muted-foreground'>Seguimiento y trazabilidad de tickets enviados a Dragon Pyramid.</p>
+                        <h2 className='text-xl font-black'>{c('Tickets enviados', 'Sent tickets')}</h2>
+                        <p className='text-sm text-muted-foreground'>{c('Seguimiento y trazabilidad de tickets enviados a Dragon Pyramid.', 'Follow-up and traceability for tickets sent to Dragon Pyramid.')}</p>
                       </div>
                       <form className='flex flex-col gap-2 sm:flex-row sm:flex-wrap' onSubmit={handleSearchSubmit}>
                         <select
@@ -520,7 +577,7 @@ export default function SoporteDragonPyramidPage() {
                           className='h-10 rounded-md border border-input bg-background px-3 text-sm'
                         >
                           {estados.map((estado) => (
-                            <option key={estado.value} value={estado.value}>{estado.label}</option>
+                            <option key={estado} value={estado}>{getEstadoFilterLabel(locale, estado)}</option>
                           ))}
                         </select>
                         <div className='relative min-w-0 sm:w-64'>
@@ -528,15 +585,15 @@ export default function SoporteDragonPyramidPage() {
                           <Input
                             type='search'
                             className='w-full pl-8'
-                            placeholder='Buscar ticket...'
+                            placeholder={c('Buscar ticket...', 'Search ticket...')}
                             value={searchTerm}
                             onChange={(event) => setSearchTerm(event.target.value)}
                           />
                         </div>
-                        <Button type='submit' variant='outline'>Buscar</Button>
+                        <Button type='submit' variant='outline'>{c('Buscar', 'Search')}</Button>
                         <Button type='button' variant='outline' className='gap-2' onClick={loadTickets} disabled={loading}>
                           <RefreshCcw className='h-4 w-4' />
-                          Actualizar
+                          {c('Actualizar', 'Refresh')}
                         </Button>
                       </form>
                     </div>
@@ -544,9 +601,9 @@ export default function SoporteDragonPyramidPage() {
                   <CardContent className='grid gap-4 p-5 xl:grid-cols-[0.95fr_1.05fr]'>
                     <div className='max-h-[680px] space-y-3 overflow-y-auto pr-1'>
                       {loading ? (
-                        <div className='py-8 text-center text-muted-foreground'>Cargando tickets...</div>
+                        <div className='py-8 text-center text-muted-foreground'>{c('Cargando tickets...', 'Loading tickets...')}</div>
                       ) : tickets.length === 0 ? (
-                        <div className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>No hay tickets para el filtro seleccionado.</div>
+                        <div className='rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground'>{c('No hay tickets para el filtro seleccionado.', 'There are no tickets for the selected filter.')}</div>
                       ) : (
                         tickets.map((ticket) => (
                           <button
@@ -558,22 +615,22 @@ export default function SoporteDragonPyramidPage() {
                             <div className='flex flex-wrap items-start justify-between gap-3'>
                               <div className='min-w-0'>
                                 <h3 className='break-words font-bold'>{ticket.asunto}</h3>
-                                <p className='text-xs text-muted-foreground'>{ticket.codigo} · {getFormattedDate(ticket.creado_en)}</p>
+                                <p className='text-xs text-muted-foreground'>{ticket.codigo} · {getFormattedDate(locale, ticket.creado_en)}</p>
                               </div>
-                              <span className={`rounded-full border px-3 py-1 text-xs font-bold ${estadoClass[ticket.estado]}`}>{estadoLabel[ticket.estado]}</span>
+                              <span className={`rounded-full border px-3 py-1 text-xs font-bold ${estadoClass[ticket.estado]}`}>{getEstadoLabel(locale, ticket.estado)}</span>
                             </div>
                             <p className='mt-2 line-clamp-2 text-sm text-muted-foreground'>{ticket.descripcion}</p>
                             <div className='mt-3 flex flex-wrap gap-2 text-xs'>
-                              <span className='rounded-full bg-muted px-2 py-1'>{ticket.categoria}</span>
-                              <span className={`rounded-full border px-2 py-1 font-bold ${prioridadClass[ticket.prioridad]}`}>Prioridad {prioridadLabel[ticket.prioridad]}</span>
+                              <span className='rounded-full bg-muted px-2 py-1'>{getCategoriaLabel(locale, ticket.categoria)}</span>
+                              <span className={`rounded-full border px-2 py-1 font-bold ${prioridadClass[ticket.prioridad]}`}>{c('Prioridad', 'Priority')} {getPrioridadLabel(locale, ticket.prioridad)}</span>
                               {isStaleTicket(ticket) && (
                                 <span className='inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-1 font-bold text-red-700 dark:bg-red-950/50 dark:text-red-200'>
-                                  <Clock3 className='h-3 w-3' /> +48 h abierto
+                                  <Clock3 className='h-3 w-3' /> +48 h {c('abierto', 'open')}
                                 </span>
                               )}
                               {!ticket.email_notificacion_enviado && (
                                 <span className='inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 font-bold text-amber-700 dark:bg-amber-950/50 dark:text-amber-200'>
-                                  <MailWarning className='h-3 w-3' /> Email no confirmado
+                                  <MailWarning className='h-3 w-3' /> {c('Email no confirmado', 'Email not confirmed')}
                                 </span>
                               )}
                             </div>
@@ -591,29 +648,29 @@ export default function SoporteDragonPyramidPage() {
                               <h3 className='text-lg font-black'>{selected.codigo}</h3>
                               <p className='text-sm text-muted-foreground'>{selected.asunto}</p>
                             </div>
-                            <span className={`rounded-full border px-3 py-1 text-xs font-bold ${estadoClass[selected.estado]}`}>{estadoLabel[selected.estado]}</span>
+                            <span className={`rounded-full border px-3 py-1 text-xs font-bold ${estadoClass[selected.estado]}`}>{getEstadoLabel(locale, selected.estado)}</span>
                           </div>
                           <div className='grid gap-2 text-sm md:grid-cols-2'>
-                            <p><strong>Prioridad:</strong> {prioridadLabel[selected.prioridad]}</p>
-                            <p><strong>Categoría:</strong> {selected.categoria}</p>
-                            <p><strong>Creado:</strong> {getFormattedDate(selected.creado_en)}</p>
-                            <p><strong>Actualizado:</strong> {getFormattedDate(selected.actualizado_en)}</p>
-                            <p className='md:col-span-2'><strong>Email soporte:</strong> {selected.email_notificacion_enviado ? 'enviado' : selected.email_notificacion_error || 'pendiente/no configurado'}</p>
+                            <p><strong>{c('Prioridad:', 'Priority:')}</strong> {getPrioridadLabel(locale, selected.prioridad)}</p>
+                            <p><strong>{c('Categoría:', 'Category:')}</strong> {getCategoriaLabel(locale, selected.categoria)}</p>
+                            <p><strong>{c('Creado:', 'Created:')}</strong> {getFormattedDate(locale, selected.creado_en)}</p>
+                            <p><strong>{c('Actualizado:', 'Updated:')}</strong> {getFormattedDate(locale, selected.actualizado_en)}</p>
+                            <p className='md:col-span-2'><strong>{c('Email soporte:', 'Support email:')}</strong> {getEmailStatusLabel(locale, selected)}</p>
                           </div>
                           <div className='rounded-lg bg-muted p-3 text-sm whitespace-pre-wrap'>{selected.descripcion}</div>
                           {selected.adjunto_url && (
-                            <a href={selected.adjunto_url} target='_blank' rel='noreferrer' className='text-sm font-bold text-primary underline'>Abrir adjunto / captura</a>
+                            <a href={selected.adjunto_url} target='_blank' rel='noreferrer' className='text-sm font-bold text-primary underline'>{c('Abrir adjunto / captura', 'Open attachment / screenshot')}</a>
                           )}
 
                           <div className='space-y-2'>
-                            <Label htmlFor='comentario'>Comentario interno / seguimiento</Label>
+                            <Label htmlFor='comentario'>{c('Comentario interno / seguimiento', 'Internal comment / follow-up')}</Label>
                             <textarea
                               id='comentario'
                               rows={3}
                               value={comentario}
                               onChange={(event) => setComentario(event.target.value)}
                               className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                              placeholder='Agregar nota de seguimiento...'
+                              placeholder={c('Agregar nota de seguimiento...', 'Add follow-up note...')}
                             />
                             <Button
                               type='button'
@@ -621,53 +678,53 @@ export default function SoporteDragonPyramidPage() {
                               disabled={saving || !comentario.trim()}
                               onClick={() => handleUpdateTicket({ comentario })}
                             >
-                              Guardar comentario
+                              {c('Guardar comentario', 'Save comment')}
                             </Button>
                           </div>
 
                           <div className='space-y-2'>
-                            <Label htmlFor='respuesta'>Respuesta / resolución</Label>
+                            <Label htmlFor='respuesta'>{c('Respuesta / resolución', 'Reply / resolution')}</Label>
                             <textarea
                               id='respuesta'
                               rows={3}
                               value={respuesta}
                               onChange={(event) => setRespuesta(event.target.value)}
                               className='w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                              placeholder='Registrar respuesta o resolución recibida de Dragon Pyramid...'
+                              placeholder={c('Registrar respuesta o resolución recibida de Dragon Pyramid...', 'Log reply or resolution received from Dragon Pyramid...')}
                             />
                             <Button
                               type='button'
                               disabled={saving || !respuesta.trim()}
                               onClick={() => handleUpdateTicket({ respuesta })}
                             >
-                              Marcar respondido
+                              {c('Marcar respondido', 'Mark as responded')}
                             </Button>
                           </div>
 
                           <div className='flex flex-wrap gap-2'>
-                            <Button type='button' variant='outline' disabled={saving || selected.estado === 'en_revision'} onClick={() => handleUpdateTicket({ estado: 'en_revision' })}>En revisión</Button>
-                            <Button type='button' variant='outline' disabled={saving || selected.estado === 'cerrado'} onClick={() => handleUpdateTicket({ estado: 'cerrado' })}>Cerrar</Button>
+                            <Button type='button' variant='outline' disabled={saving || selected.estado === 'en_revision'} onClick={() => handleUpdateTicket({ estado: 'en_revision' })}>{c('En revisión', 'Under review')}</Button>
+                            <Button type='button' variant='outline' disabled={saving || selected.estado === 'cerrado'} onClick={() => handleUpdateTicket({ estado: 'cerrado' })}>{c('Cerrar', 'Close')}</Button>
                           </div>
 
                           <div className='space-y-2 border-t pt-4 dark:border-slate-800'>
-                            <h4 className='font-black'>Historial</h4>
+                            <h4 className='font-black'>{c('Historial', 'History')}</h4>
                             {selected.eventos && selected.eventos.length > 0 ? (
                               selected.eventos.map((evento) => (
                                 <div key={evento.id} className='rounded-lg border bg-background p-3 text-sm dark:border-slate-800'>
                                   <div className='flex flex-wrap justify-between gap-2'>
-                                    <span className='font-bold'>{evento.tipo}</span>
-                                    <span className='text-xs text-muted-foreground'>{getFormattedDate(evento.creado_en)}</span>
+                                    <span className='font-bold'>{translateEventType(locale, evento.tipo)}</span>
+                                    <span className='text-xs text-muted-foreground'>{getFormattedDate(locale, evento.creado_en)}</span>
                                   </div>
-                                  <p className='mt-1 whitespace-pre-wrap text-muted-foreground'>{evento.mensaje || 'Evento sin detalle.'}</p>
+                                  <p className='mt-1 whitespace-pre-wrap text-muted-foreground'>{evento.mensaje || c('Evento sin detalle.', 'Event without details.')}</p>
                                 </div>
                               ))
                             ) : (
-                              <p className='text-sm text-muted-foreground'>El historial se verá al abrir el detalle después de crear o actualizar el ticket.</p>
+                              <p className='text-sm text-muted-foreground'>{c('El historial se verá al abrir el detalle después de crear o actualizar el ticket.', 'The history will appear when opening the details after creating or updating the ticket.')}</p>
                             )}
                           </div>
                         </div>
                       ) : (
-                        <div className='flex min-h-[320px] items-center justify-center rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground dark:border-slate-800'>Seleccioná un ticket para ver detalle e historial.</div>
+                        <div className='flex min-h-[320px] items-center justify-center rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground dark:border-slate-800'>{c('Seleccioná un ticket para ver detalle e historial.', 'Select a ticket to view details and history.')}</div>
                       )}
                     </div>
                   </CardContent>

--- a/src/app/dashboard/usuarios/page.tsx
+++ b/src/app/dashboard/usuarios/page.tsx
@@ -31,13 +31,37 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { PaginationControls } from "@/components/ui/PaginationControls";
 import { downloadCommercialReportPdf } from "@/utils/commercialReportPdf";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
 const USUARIOS_PAGE_SIZE = 10;
+
+function usersTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function translateUserStatusFilter(locale: GymMasterLocale, value: string) {
+  if (value === "todos") return usersTx(locale, "Todos", "All");
+  if (value === "activos") return usersTx(locale, "Activos", "Active");
+  return usersTx(locale, "Inactivos", "Inactive");
+}
+
+function translateRoleForExport(locale: GymMasterLocale, role?: string | null) {
+  if (locale !== "en") return role || "-";
+  const normalized = String(role || "").toLowerCase();
+  if (normalized === "socio") return "Member";
+  if (normalized === "usuario") return "Internal user";
+  if (normalized === "admin") return "Admin";
+  return role || "-";
+}
+
 
 export default function UsuariosPage() {
   const { isAuthenticated, initializeAuth, isInitialized } =
     useAuthStore();
   const router = useRouter();
+  const { locale } = useI18n();
+  const c = useCallback((es: string, en: string) => usersTx(locale, es, en), [locale]);
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
   const [filteredUsuarios, setFilteredUsuarios] = useState<Usuario[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
@@ -70,25 +94,25 @@ export default function UsuariosPage() {
   const handleDownloadPdf = async () => {
     try {
       await downloadCommercialReportPdf({
-        title: "Listado de Usuarios",
-        subtitle: "Reporte de usuarios internos, socios y administradores.",
+        title: c("Listado de Usuarios", "Users list"),
+        subtitle: c("Reporte de usuarios internos, socios y administradores.", "Report of internal users, members, and administrators."),
         fileName: "listado-usuarios-gym-master",
         rows: filteredUsuarios,
         metrics: [
-          { label: "Usuarios filtrados", value: filteredUsuarios.length },
-          { label: "Activos", value: filteredUsuarios.filter((u) => u.activo).length },
-          { label: "Inactivos", value: filteredUsuarios.filter((u) => !u.activo).length },
+          { label: c("Usuarios filtrados", "Filtered users"), value: filteredUsuarios.length },
+          { label: c("Activos", "Active"), value: filteredUsuarios.filter((u) => u.activo).length },
+          { label: c("Inactivos", "Inactive"), value: filteredUsuarios.filter((u) => !u.activo).length },
         ],
-        filtersLabel: `Estado: ${filtroLabel}${searchTerm.trim() ? ` · Búsqueda: ${searchTerm.trim()}` : ""}`,
+        filtersLabel: `${c("Estado", "Status")}: ${filtroLabel}${searchTerm.trim() ? ` · ${c("Búsqueda", "Search")}: ${searchTerm.trim()}` : ""}`,
         columns: [
-          { header: "Nombre", width: 46, getValue: (u) => u.nombre },
+          { header: c("Nombre", "Name"), width: 46, getValue: (u) => u.nombre },
           { header: "Email", width: 58, getValue: (u) => u.email },
-          { header: "Rol", width: 28, getValue: (u) => u.rol },
-          { header: "Estado", width: 24, getValue: (u) => (u.activo ? "Activo" : "Inactivo") },
+          { header: c("Rol", "Role"), width: 28, getValue: (u) => translateRoleForExport(locale, u.rol) },
+          { header: c("Estado", "Status"), width: 24, getValue: (u) => (u.activo ? c("Activo", "Active") : c("Inactivo", "Inactive")) },
         ],
       });
     } catch {
-      toast.error("No se pudo generar el PDF de usuarios");
+      toast.error(c("No se pudo generar el PDF de usuarios", "Could not generate the users PDF"));
     }
   };
 
@@ -98,10 +122,10 @@ export default function UsuariosPage() {
 
     worksheet.columns = [
       { header: "ID", key: "id", width: 30 },
-      { header: "Nombre", key: "nombre", width: 30 },
+      { header: c("Nombre", "Name"), key: "nombre", width: 30 },
       { header: "Email", key: "email", width: 30 },
-      { header: "Rol", key: "rol", width: 20 },
-      { header: "Activo", key: "activo", width: 10 },
+      { header: c("Rol", "Role"), key: "rol", width: 20 },
+      { header: c("Activo", "Active"), key: "activo", width: 10 },
     ];
 
     filteredUsuarios.forEach((u) => {
@@ -109,8 +133,8 @@ export default function UsuariosPage() {
         id: u.id,
         nombre: u.nombre,
         email: u.email,
-        rol: u.rol,
-        activo: u.activo ? "Sí" : "No",
+        rol: translateRoleForExport(locale, u.rol),
+        activo: u.activo ? c("Sí", "Yes") : c("No", "No"),
       });
     });
 
@@ -129,22 +153,22 @@ export default function UsuariosPage() {
   const toggleUsuarioActivo = async (usuario: Usuario) => {
     const confirmar = window.confirm(
       usuario.activo
-        ? "¿Está seguro de desactivar al usuario?"
-        : "¿Está seguro de activar al usuario?"
+        ? c("¿Está seguro de desactivar al usuario?", "Are you sure you want to deactivate this user?")
+        : c("¿Está seguro de activar al usuario?", "Are you sure you want to activate this user?")
     );
     if (!confirmar) return;
 
     try {
       if (usuario.activo) {
         await deactivateUsuarioApi(usuario.id);
-        toast.success("Usuario desactivado correctamente");
+        toast.success(c("Usuario desactivado correctamente", "User deactivated successfully"));
       } else {
         await updateUsuarioApi(usuario.id, { activo: true });
-        toast.success("Usuario activado correctamente");
+        toast.success(c("Usuario activado correctamente", "User activated successfully"));
       }
       await loadUsuarios();
     } catch (error: unknown) {
-      toast.error("Error al actualizar estado del usuario");
+      toast.error(c("Error al actualizar estado del usuario", "Error updating user status"));
     }
   };
 
@@ -191,15 +215,10 @@ export default function UsuariosPage() {
     }
   }, [currentPage, totalPages]);
 
-  const filtroLabel =
-    filtroActivo === "todos"
-      ? "Todos"
-      : filtroActivo === "activos"
-      ? "Activos"
-      : "Inactivos";
+  const filtroLabel = translateUserStatusFilter(locale, filtroActivo);
 
   if (!isInitialized) {
-    return <div>Cargando...</div>;
+    return <div>{c("Cargando...", "Loading...")}</div>;
   }
 
   if (!isAuthenticated) {
@@ -211,11 +230,11 @@ export default function UsuariosPage() {
       <div className="flex w-full min-h-screen">
         <AppSidebar />
         <SidebarInset>
-          <AppHeader title="Usuarios" />
+          <AppHeader title={c("Usuarios", "Users")} />
           <main className="flex-1 p-6 space-y-6">
-            <Card className="w-full">
-              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap">
-                <h2 className="text-xl font-bold">Listado de Usuarios</h2>
+            <Card className="w-full dark:border-slate-800 dark:bg-slate-950/70">
+              <CardHeader className="flex flex-wrap items-center justify-between gap-4 p-4 border-b md:flex-nowrap dark:border-slate-800">
+                <h2 className="text-xl font-bold">{c("Listado de Usuarios", "Users list")}</h2>
                 <div className="flex flex-wrap items-center w-full gap-2 md:w-auto">
                   <div className="flex items-center flex-grow gap-2 md:flex-grow-0">
                     <DropdownMenu>
@@ -231,7 +250,7 @@ export default function UsuariosPage() {
                             filtroActivo === "todos" ? "font-bold" : ""
                           }
                         >
-                          Todos
+                          {c("Todos", "All")}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onSelect={() => setFiltroActivo("activos")}
@@ -239,7 +258,7 @@ export default function UsuariosPage() {
                             filtroActivo === "activos" ? "font-bold" : ""
                           }
                         >
-                          Activos
+                          {c("Activos", "Active")}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onSelect={() => setFiltroActivo("inactivos")}
@@ -247,7 +266,7 @@ export default function UsuariosPage() {
                             filtroActivo === "inactivos" ? "font-bold" : ""
                           }
                         >
-                          Inactivos
+                          {c("Inactivos", "Inactive")}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
@@ -255,7 +274,7 @@ export default function UsuariosPage() {
                       <Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
                       <Input
                         type="search"
-                        placeholder="Buscar por nombre, email..."
+                        placeholder={c("Buscar por nombre, email...", "Search by name, email...")}
                         className="pl-8 sm:w-[300px] md:w-[200px] lg:w-[300px] w-full"
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
@@ -268,7 +287,7 @@ export default function UsuariosPage() {
                     className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <FileText className="w-4 h-4" />
-                    <span className="hidden sm:inline">Descargar PDF</span>
+                    <span className="hidden sm:inline">{c("Descargar PDF", "Download PDF")}</span>
                   </Button>
                   <Button
                     variant="outline"
@@ -276,14 +295,14 @@ export default function UsuariosPage() {
                     className="flex items-center gap-2 bg-white border-[#02a8e1] text-[#02a8e1] hover:bg-[#e6f7fd]"
                   >
                     <FileSpreadsheet className="w-4 h-4" />
-                    <span className="hidden sm:inline">Exportar</span>
+                    <span className="hidden sm:inline">{c("Exportar", "Export")}</span>
                   </Button>
                   <Button
                     onClick={() => setOpenModal(true)}
                     className="bg-[#02a8e1] hover:bg-[#0288b1]"
                   >
-                    <span className="hidden sm:inline">Añadir Usuario</span>
-                    <span className="sm:hidden">Añadir</span>
+                    <span className="hidden sm:inline">{c("Añadir Usuario", "Add user")}</span>
+                    <span className="sm:hidden">{c("Añadir", "Add")}</span>
                   </Button>
                 </div>
               </CardHeader>
@@ -309,7 +328,7 @@ export default function UsuariosPage() {
                   totalItems={totalUsuarios}
                   pageSize={USUARIOS_PAGE_SIZE}
                   onPageChange={setCurrentPage}
-                  itemLabel="usuarios"
+                  itemLabel={c("usuarios", "users")}
                 />
               </CardContent>
             </Card>

--- a/src/components/forms/AvisosForm.tsx
+++ b/src/components/forms/AvisosForm.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { createAviso } from "@/services/avisoService";
 import { CreateAvisoDto } from "@/interfaces/aviso.interface";
 import TextEditor from "@/components/ui/TextEditor";
+import { useI18n } from "@/i18n/I18nProvider";
 
 const emptyForm: CreateAvisoDto = {
   titulo: "",
@@ -19,6 +20,8 @@ const emptyForm: CreateAvisoDto = {
 };
 
 export default function AvisosForm({ onCreated }: { onCreated?: () => void }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => (locale === "en" ? en : es);
   const [form, setForm] = useState<CreateAvisoDto>(emptyForm);
   const [loading, setLoading] = useState(false);
 
@@ -53,33 +56,35 @@ export default function AvisosForm({ onCreated }: { onCreated?: () => void }) {
     <form onSubmit={handleSubmit} className="grid grid-cols-1 gap-4">
       <QaFileNameBadge file="src/components/forms/AvisosForm.tsx" />
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="titulo">Título</Label>
+        <Label htmlFor="titulo">{c("Título", "Title")}</Label>
         <Input
           id="titulo"
           name="titulo"
-          placeholder="Ingrese título"
+          placeholder={c("Ingrese título", "Enter title")}
           value={form.titulo}
           onChange={handleChange}
           required
+          className="dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="mensaje">Mensaje</Label>
+        <Label htmlFor="mensaje">{c("Mensaje", "Message")}</Label>
         <TextEditor value={form.mensaje} onChange={handleMensajeChange} />
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="tipo">Tipo</Label>
+        <Label htmlFor="tipo">{c("Tipo", "Type")}</Label>
         <Input
           id="tipo"
           name="tipo"
-          placeholder="Tipo de aviso"
+          placeholder={c("Tipo de aviso", "Notice type")}
           value={form.tipo}
           onChange={handleChange}
           required
+          className="dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="fecha_envio">Fecha de envío</Label>
+        <Label htmlFor="fecha_envio">{c("Fecha de envío", "Send date")}</Label>
         <Input
           id="fecha_envio"
           name="fecha_envio"
@@ -87,6 +92,7 @@ export default function AvisosForm({ onCreated }: { onCreated?: () => void }) {
           value={form.fecha_envio}
           onChange={handleChange}
           required
+          className="dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
         />
       </div>
       <div className="flex items-center gap-2">
@@ -96,11 +102,12 @@ export default function AvisosForm({ onCreated }: { onCreated?: () => void }) {
           type="checkbox"
           checked={form.enviar_email}
           onChange={handleChange}
+          className="rounded border-slate-300 text-sky-600 focus:ring-sky-500"
         />
-        <Label htmlFor="enviar_email">Enviar por email</Label>
+        <Label htmlFor="enviar_email">{c("Enviar por email", "Send by email")}</Label>
       </div>
       <Button type="submit" className="justify-self-end" disabled={loading}>
-        {loading ? "Enviando..." : "Enviar Aviso"}
+        {loading ? c("Enviando...", "Sending...") : c("Enviar aviso", "Send notice")}
       </Button>
     </form>
   );

--- a/src/components/forms/UserForm.tsx
+++ b/src/components/forms/UserForm.tsx
@@ -23,6 +23,7 @@ import { buildInitialPasswordFromDni, getPasswordPolicyChecks } from '@/utils/pa
 import { useCatalogosParametrizables } from '@/hooks/useCatalogosParametrizables';
 import type { CatalogoParametrizableItem, CatalogoParametrizableKey } from '@/interfaces/parametrizacion.interface';
 import { useI18n } from '@/i18n/I18nProvider';
+import type { GymMasterLocale } from '@/i18n/config';
 import { translateNavigationGroup, translateNavigationItem } from '@/i18n/navigationLabels';
 
 export interface UserFormProps {
@@ -121,6 +122,70 @@ const fallbackHorarios = [
   makeFallbackCatalogItem('rotativo_a_coordinar', 'Rotativo / a coordinar', null, 50),
 ];
 
+
+function userFormTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+const CATALOG_LABELS_EN: Record<string, string> = {
+  'Mensual': 'Monthly',
+  'Pago mensual fijo.': 'Fixed monthly payment.',
+  'Por hora': 'Hourly',
+  'Pago por hora trabajada o clase.': 'Payment per worked hour or class.',
+  'Jornal': 'Daily wage',
+  'Pago por jornada.': 'Payment per workday.',
+  'Eventual': 'Temporary',
+  'Contratación temporal o suplencia.': 'Temporary hiring or replacement.',
+  'Pasantía': 'Internship',
+  'Práctica o pasantía formativa.': 'Training internship or practice.',
+  'Otro': 'Other',
+  'Modalidad no catalogada.': 'Uncatalogued modality.',
+  'Recepción y caja': 'Reception and cash desk',
+  'Atención al socio y cobros.': 'Member service and payments.',
+  'Administración': 'Administration',
+  'Gestión administrativa general.': 'General administrative management.',
+  'Entrenador de sala': 'Floor trainer',
+  'Rutinas y supervisión de entrenamiento.': 'Routines and training supervision.',
+  'Personal trainer': 'Personal trainer',
+  'Entrenamiento personalizado.': 'Personalized training.',
+  'Mantenimiento': 'Maintenance',
+  'Mantenimiento preventivo/correctivo.': 'Preventive/corrective maintenance.',
+  'Limpieza': 'Cleaning',
+  'Higiene general del gimnasio.': 'General gym cleaning.',
+  'Bar / snack': 'Bar / snack',
+  'Atención de bebidas, café y suplementos.': 'Beverages, coffee, and supplements service.',
+  'Recepción': 'Reception',
+  'Entrenamiento': 'Training',
+  'Mañana': 'Morning',
+  'Turno mañana.': 'Morning shift.',
+  'Tarde': 'Afternoon',
+  'Turno tarde.': 'Afternoon shift.',
+  'Noche': 'Night',
+  'Turno noche.': 'Night shift.',
+  'Rotativo': 'Rotating',
+  'Turno variable.': 'Variable shift.',
+  'Fin de semana': 'Weekend',
+  'Sábados, domingos o feriados.': 'Saturdays, Sundays, or holidays.',
+  'Lunes a viernes 08:00-16:00': 'Monday to Friday 08:00-16:00',
+  'Lunes a viernes 14:00-22:00': 'Monday to Friday 14:00-22:00',
+  'Lunes a sábado 07:00-13:00': 'Monday to Saturday 07:00-13:00',
+  'Lunes a sábado 16:00-22:00': 'Monday to Saturday 16:00-22:00',
+  'Rotativo / a coordinar': 'Rotating / to be coordinated',
+};
+
+function translateCatalogText(locale: GymMasterLocale, value?: string | null) {
+  if (!value) return '';
+  if (locale !== 'en') return value;
+  return CATALOG_LABELS_EN[value] ?? value;
+}
+
+function translateRoleOption(locale: GymMasterLocale, role: string) {
+  if (role === 'socio') return userFormTx(locale, 'Socio', 'Member');
+  if (role === 'admin') return userFormTx(locale, 'Administrador', 'Administrator');
+  if (role === 'usuario') return userFormTx(locale, 'Usuario interno', 'Internal user');
+  return role;
+}
+
 function getCatalogItems(
   catalogos: ReturnType<typeof useCatalogosParametrizables>['catalogos'],
   key: CatalogoParametrizableKey,
@@ -145,12 +210,14 @@ function CalendarDateInput({
   value,
   onChange,
   required = false,
+  locale,
 }: {
   id: string;
   name: string;
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   required?: boolean;
+  locale: GymMasterLocale;
 }) {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -182,8 +249,8 @@ function CalendarDateInput({
         type='button'
         onClick={openNativePicker}
         className='absolute inset-y-0 right-0 flex w-10 items-center justify-center rounded-r-md text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
-        aria-label='Abrir calendario'
-        title='Abrir calendario'
+        aria-label={userFormTx(locale, 'Abrir calendario', 'Open calendar')}
+        title={userFormTx(locale, 'Abrir calendario', 'Open calendar')}
       >
         <CalendarDays className='h-4 w-4' />
       </button>
@@ -206,7 +273,8 @@ export default function UserForm({
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const { catalogos } = useCatalogosParametrizables();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
+  const c = (es: string, en: string) => userFormTx(locale, es, en);
 
   const tiposContratacion = useMemo(
     () => getCatalogItems(catalogos, 'empleado_tipo_contratacion', fallbackTiposContratacion),
@@ -306,13 +374,13 @@ export default function UserForm({
     try {
       if (isPasswordRequired) {
         if (!isPasswordValid) {
-          toast.error('La contraseña debe tener mínimo 8 caracteres, mayúscula, minúscula, número y símbolo.');
+          toast.error(c('La contraseña debe tener mínimo 8 caracteres, mayúscula, minúscula, número y símbolo.', 'Password must have at least 8 characters, uppercase, lowercase, number, and symbol.'));
           setLoading(false);
           return;
         }
 
         if (!passwordsMatch) {
-          toast.error('La confirmación de contraseña no coincide.');
+          toast.error(c('La confirmación de contraseña no coincide.', 'Password confirmation does not match.'));
           setLoading(false);
           return;
         }
@@ -331,7 +399,7 @@ export default function UserForm({
         };
 
         await updateUsuarioApi(usuario.id, updateData);
-        toast.success('Usuario actualizado exitosamente.');
+        toast.success(c('Usuario actualizado exitosamente.', 'User updated successfully.'));
       } else {
         const rol = form.rol || 'socio';
         const useInitialPassword = form.use_initial_password;
@@ -377,27 +445,27 @@ export default function UserForm({
         };
 
         if (useInitialPassword && !form.dni.trim()) {
-          toast.error('El DNI es obligatorio para generar la contraseña inicial.');
+          toast.error(c('El DNI es obligatorio para generar la contraseña inicial.', 'ID is required to generate the initial password.'));
           setLoading(false);
           return;
         }
 
         if (!useInitialPassword && !createData.password) {
           toast.error(
-            'La contraseña es obligatoria para crear un nuevo usuario.'
+            c('La contraseña es obligatoria para crear un nuevo usuario.', 'Password is required to create a new user.')
           );
           setLoading(false);
           return;
         }
 
         if (rol === 'socio' && !form.dni.trim()) {
-          toast.error('El DNI es obligatorio para crear un usuario socio.');
+          toast.error(c('El DNI es obligatorio para crear un usuario socio.', 'ID is required to create a member user.'));
           setLoading(false);
           return;
         }
 
         if (rol === 'usuario' && !form.dni.trim()) {
-          toast.error('El DNI es obligatorio para crear un usuario interno/empleado.');
+          toast.error(c('El DNI es obligatorio para crear un usuario interno/empleado.', 'ID is required to create an internal user/employee.'));
           setLoading(false);
           return;
         }
@@ -405,17 +473,17 @@ export default function UserForm({
         await createUsuarioApi(createData);
         toast.success(
           useInitialPassword
-            ? `Usuario creado. Contraseña inicial: ${initialPassword}`
-            : 'Usuario creado exitosamente.'
+            ? `${c('Usuario creado. Contraseña inicial:', 'User created. Initial password:')} ${initialPassword}`
+            : c('Usuario creado exitosamente.', 'User created successfully.')
         );
       }
       setForm(emptyForm);
       onCreated();
     } catch (error: any) {
-      let msg = error.message || 'Error al guardar el usuario.';
+      let msg = error.message || c('Error al guardar el usuario.', 'Error saving the user.');
       if (msg.includes('value too long')) {
         msg =
-          'Uno de los campos excede la cantidad máxima de caracteres permitidos.';
+          c('Uno de los campos excede la cantidad máxima de caracteres permitidos.', 'One of the fields exceeds the maximum allowed character length.');
       }
       toast.error(msg);
     } finally {
@@ -441,15 +509,15 @@ export default function UserForm({
   return (
     <form
       onSubmit={handleSubmit}
-      className='grid grid-cols-1 gap-4 md:grid-cols-2'
+      className='grid grid-cols-1 gap-4 md:grid-cols-2 dark:text-slate-100'
     >
       <QaFileNameBadge file="src/components/forms/UserForm.tsx" />
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='nombre'>Nombre</Label>
+        <Label htmlFor='nombre'>{c('Nombre', 'Name')}</Label>
         <Input
           id='nombre'
           name='nombre'
-          placeholder='Ingrese nombre'
+          placeholder={c('Ingrese nombre', 'Enter name')}
           value={form.nombre}
           onChange={handleChange}
           required
@@ -462,7 +530,7 @@ export default function UserForm({
           id='email'
           name='email'
           type='email'
-          placeholder='Ingrese correo electrónico'
+          placeholder={c('Ingrese correo electrónico', 'Enter email address')}
           value={form.email}
           onChange={handleChange}
           required
@@ -470,7 +538,7 @@ export default function UserForm({
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='rol'>Rol</Label>
+        <Label htmlFor='rol'>{c('Rol', 'Role')}</Label>
         <select
           id='rol'
           name='rol'
@@ -478,9 +546,9 @@ export default function UserForm({
           onChange={handleChange}
           className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
         >
-          <option value='socio'>Socio</option>
-          <option value='admin'>Administrador</option>
-          <option value='usuario'>Usuario interno</option>
+          <option value='socio'>{translateRoleOption(locale, 'socio')}</option>
+          <option value='admin'>{translateRoleOption(locale, 'admin')}</option>
+          <option value='usuario'>{translateRoleOption(locale, 'usuario')}</option>
         </select>
       </div>
 
@@ -490,7 +558,7 @@ export default function UserForm({
           <Input
             id='dni'
             name='dni'
-            placeholder='Ingrese DNI para contraseña inicial'
+            placeholder={c('Ingrese ID para contraseña inicial', 'Enter ID for initial password')}
             value={form.dni}
             onChange={handleChange}
             required={isSocio || isInternalUser || isInitialPasswordMode}
@@ -499,27 +567,27 @@ export default function UserForm({
       )}
 
       {!usuario && isSocio && (
-        <div className='col-span-full rounded-lg border bg-muted/20 p-4'>
+        <div className='col-span-full rounded-lg border bg-muted/20 p-4 dark:border-slate-800 dark:bg-slate-900/40'>
           <div className='mb-3'>
-            <h3 className='text-base font-semibold'>Datos operativos del socio</h3>
+            <h3 className='text-base font-semibold'>{c('Datos operativos del socio', 'Member operational data')}</h3>
             <p className='text-sm text-muted-foreground'>
-              Estos datos crean el perfil de socio vinculado al usuario. Después se pueden revisar o modificar desde el menú Socios.
+              {c('Estos datos crean el perfil de socio vinculado al usuario. Después se pueden revisar o modificar desde el menú Socios.', 'These details create the member profile linked to the user. They can later be reviewed or edited from the Members menu.')}
             </p>
           </div>
-          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 dark:text-slate-100'>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='telefono'>Teléfono</Label>
+              <Label htmlFor='telefono'>{c('Teléfono', 'Phone')}</Label>
               <Input
                 id='telefono'
                 name='telefono'
-                placeholder='Ingrese teléfono'
+                placeholder={c('Ingrese teléfono', 'Enter phone')}
                 value={form.telefono}
                 onChange={handleChange}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='sexo'>Sexo</Label>
+              <Label htmlFor='sexo'>{c('Sexo', 'Sex')}</Label>
               <select
                 id='sexo'
                 name='sexo'
@@ -527,93 +595,95 @@ export default function UserForm({
                 onChange={handleChange}
                 className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
               >
-                <option value=''>Seleccionar</option>
-                <option value='M'>Masculino</option>
-                <option value='F'>Femenino</option>
+                <option value=''>{c('Seleccionar', 'Select')}</option>
+                <option value='M'>{c('Masculino', 'Male')}</option>
+                <option value='F'>{c('Femenino', 'Female')}</option>
               </select>
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='fecnac'>Fecha de nacimiento</Label>
+              <Label htmlFor='fecnac'>{c('Fecha de nacimiento', 'Birth date')}</Label>
               <CalendarDateInput
                 id='fecnac'
                 name='fecnac'
                 value={form.fecnac}
                 onChange={handleChange}
+                locale={locale}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='fecha_alta'>Fecha de alta</Label>
+              <Label htmlFor='fecha_alta'>{c('Fecha de alta', 'Registration date')}</Label>
               <CalendarDateInput
                 id='fecha_alta'
                 name='fecha_alta'
                 value={form.fecha_alta}
                 onChange={handleChange}
+                locale={locale}
               />
             </div>
 
             <div className='flex flex-col gap-1.5 md:col-span-2'>
-              <Label htmlFor='direccion'>Dirección</Label>
+              <Label htmlFor='direccion'>{c('Dirección', 'Address')}</Label>
               <Input
                 id='direccion'
                 name='direccion'
-                placeholder='Ingrese dirección'
+                placeholder={c('Ingrese dirección', 'Enter address')}
                 value={form.direccion}
                 onChange={handleChange}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='ciudad'>Ciudad</Label>
+              <Label htmlFor='ciudad'>{c('Ciudad', 'City')}</Label>
               <Input
                 id='ciudad'
                 name='ciudad'
-                placeholder='Ingrese ciudad'
+                placeholder={c('Ingrese ciudad', 'Enter city')}
                 value={form.ciudad}
                 onChange={handleChange}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='provincia'>Provincia</Label>
+              <Label htmlFor='provincia'>{c('Provincia', 'Province')}</Label>
               <Input
                 id='provincia'
                 name='provincia'
-                placeholder='Ingrese provincia'
+                placeholder={c('Ingrese provincia', 'Enter province')}
                 value={form.provincia}
                 onChange={handleChange}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='pais'>País</Label>
+              <Label htmlFor='pais'>{c('País', 'Country')}</Label>
               <Input
                 id='pais'
                 name='pais'
-                placeholder='Ingrese país'
+                placeholder={c('Ingrese país', 'Enter country')}
                 value={form.pais}
                 onChange={handleChange}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='contacto_emergencia_nombre'>Contacto de emergencia</Label>
+              <Label htmlFor='contacto_emergencia_nombre'>{c('Contacto de emergencia', 'Emergency contact')}</Label>
               <Input
                 id='contacto_emergencia_nombre'
                 name='contacto_emergencia_nombre'
-                placeholder='Nombre del contacto'
+                placeholder={c('Nombre del contacto', 'Contact name')}
                 value={form.contacto_emergencia_nombre}
                 onChange={handleChange}
               />
             </div>
 
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='contacto_emergencia_telefono'>Teléfono de emergencia</Label>
+              <Label htmlFor='contacto_emergencia_telefono'>{c('Teléfono de emergencia', 'Emergency phone')}</Label>
               <Input
                 id='contacto_emergencia_telefono'
                 name='contacto_emergencia_telefono'
-                placeholder='Teléfono para urgencias'
+                placeholder={c('Teléfono para urgencias', 'Emergency phone')}
                 value={form.contacto_emergencia_telefono}
                 onChange={handleChange}
               />
@@ -623,36 +693,36 @@ export default function UserForm({
       )}
 
       {!usuario && isInternalUser && (
-        <div className='col-span-full rounded-lg border bg-muted/20 p-4'>
+        <div className='col-span-full rounded-lg border bg-muted/20 p-4 dark:border-slate-800 dark:bg-slate-900/40'>
           <div className='mb-3'>
-            <h3 className='text-base font-semibold'>Datos laborales del empleado</h3>
+            <h3 className='text-base font-semibold'>{c('Datos laborales del empleado', 'Employee work data')}</h3>
             <p className='text-sm text-muted-foreground'>
-              Estos datos crean el perfil laboral vinculado al usuario interno. Después se pueden revisar o modificar desde el menú Empleados.
+              {c('Estos datos crean el perfil laboral vinculado al usuario interno. Después se pueden revisar o modificar desde el menú Empleados.', 'These details create the work profile linked to the internal user. They can later be reviewed or edited from the Employees menu.')}
             </p>
           </div>
-          <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 dark:text-slate-100'>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='telefono'>Teléfono</Label>
-              <Input id='telefono' name='telefono' placeholder='Ingrese teléfono' value={form.telefono} onChange={handleChange} />
+              <Label htmlFor='telefono'>{c('Teléfono', 'Phone')}</Label>
+              <Input id='telefono' name='telefono' placeholder={c('Ingrese teléfono', 'Enter phone')} value={form.telefono} onChange={handleChange} />
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='fecnac'>Fecha de nacimiento</Label>
-              <CalendarDateInput id='fecnac' name='fecnac' value={form.fecnac} onChange={handleChange} />
+              <Label htmlFor='fecnac'>{c('Fecha de nacimiento', 'Birth date')}</Label>
+              <CalendarDateInput id='fecnac' name='fecnac' value={form.fecnac} onChange={handleChange} locale={locale} />
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='fecha_alta'>Fecha de alta laboral</Label>
-              <CalendarDateInput id='fecha_alta' name='fecha_alta' value={form.fecha_alta} onChange={handleChange} />
+              <Label htmlFor='fecha_alta'>{c('Fecha de alta laboral', 'Work registration date')}</Label>
+              <CalendarDateInput id='fecha_alta' name='fecha_alta' value={form.fecha_alta} onChange={handleChange} locale={locale} />
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='fecha_inicio'>Fecha de inicio</Label>
-              <CalendarDateInput id='fecha_inicio' name='fecha_inicio' value={form.fecha_inicio} onChange={handleChange} />
+              <Label htmlFor='fecha_inicio'>{c('Fecha de inicio', 'Start date')}</Label>
+              <CalendarDateInput id='fecha_inicio' name='fecha_inicio' value={form.fecha_inicio} onChange={handleChange} locale={locale} />
             </div>
             <div className='flex flex-col gap-1.5 md:col-span-2'>
-              <Label htmlFor='direccion'>Dirección</Label>
-              <Input id='direccion' name='direccion' placeholder='Ingrese dirección' value={form.direccion} onChange={handleChange} />
+              <Label htmlFor='direccion'>{c('Dirección', 'Address')}</Label>
+              <Input id='direccion' name='direccion' placeholder={c('Ingrese dirección', 'Enter address')} value={form.direccion} onChange={handleChange} />
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='puesto'>Puesto / responsabilidad</Label>
+              <Label htmlFor='puesto'>{c('Puesto / responsabilidad', 'Position / responsibility')}</Label>
               <select
                 id='puesto'
                 name='puesto'
@@ -660,16 +730,16 @@ export default function UserForm({
                 onChange={handleChange}
                 className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
               >
-                <option value=''>Seleccionar puesto</option>
+                <option value=''>{c('Seleccionar puesto', 'Select position')}</option>
                 {puestos.map((item) => (
                   <option key={item.id} value={catalogValue(item)}>
-                    {item.nombre}
+                    {translateCatalogText(locale, item.nombre)}
                   </option>
                 ))}
               </select>
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='area'>Área</Label>
+              <Label htmlFor='area'>{c('Área', 'Area')}</Label>
               <select
                 id='area'
                 name='area'
@@ -677,16 +747,16 @@ export default function UserForm({
                 onChange={handleChange}
                 className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
               >
-                <option value=''>Seleccionar área</option>
+                <option value=''>{c('Seleccionar área', 'Select area')}</option>
                 {areas.map((item) => (
                   <option key={item.id} value={catalogValue(item)}>
-                    {item.nombre}
+                    {translateCatalogText(locale, item.nombre)}
                   </option>
                 ))}
               </select>
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='tipo_contratacion'>Tipo de contratación</Label>
+              <Label htmlFor='tipo_contratacion'>{c('Tipo de contratación', 'Contract type')}</Label>
               <select
                 id='tipo_contratacion'
                 name='tipo_contratacion'
@@ -694,16 +764,16 @@ export default function UserForm({
                 onChange={handleChange}
                 className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
               >
-                <option value=''>Seleccionar tipo</option>
+                <option value=''>{c('Seleccionar tipo', 'Select type')}</option>
                 {tiposContratacion.map((item) => (
                   <option key={item.id} value={item.codigo}>
-                    {item.nombre}
+                    {translateCatalogText(locale, item.nombre)}
                   </option>
                 ))}
               </select>
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='turno'>Turno</Label>
+              <Label htmlFor='turno'>{c('Turno', 'Shift')}</Label>
               <select
                 id='turno'
                 name='turno'
@@ -711,24 +781,24 @@ export default function UserForm({
                 onChange={handleChange}
                 className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
               >
-                <option value=''>Seleccionar turno</option>
+                <option value=''>{c('Seleccionar turno', 'Select shift')}</option>
                 {turnos.map((item) => (
                   <option key={item.id} value={catalogValue(item)}>
-                    {item.nombre}
+                    {translateCatalogText(locale, item.nombre)}
                   </option>
                 ))}
               </select>
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='sueldo_base'>Sueldo base</Label>
+              <Label htmlFor='sueldo_base'>{c('Sueldo base', 'Base salary')}</Label>
               <Input id='sueldo_base' name='sueldo_base' type='number' min='0' step='0.01' value={form.sueldo_base} onChange={handleChange} />
             </div>
             <div className='flex flex-col gap-1.5'>
-              <Label htmlFor='fecha_fin'>Fecha de fin</Label>
-              <CalendarDateInput id='fecha_fin' name='fecha_fin' value={form.fecha_fin} onChange={handleChange} />
+              <Label htmlFor='fecha_fin'>{c('Fecha de fin', 'End date')}</Label>
+              <CalendarDateInput id='fecha_fin' name='fecha_fin' value={form.fecha_fin} onChange={handleChange} locale={locale} />
             </div>
             <div className='flex flex-col gap-1.5 md:col-span-2'>
-              <Label htmlFor='horarios_texto'>Horario / disponibilidad</Label>
+              <Label htmlFor='horarios_texto'>{c('Horario / disponibilidad', 'Schedule / availability')}</Label>
               <select
                 id='horarios_texto'
                 name='horarios_texto'
@@ -736,17 +806,17 @@ export default function UserForm({
                 onChange={handleChange}
                 className='flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
               >
-                <option value=''>Seleccionar horario o disponibilidad</option>
+                <option value=''>{c('Seleccionar horario o disponibilidad', 'Select schedule or availability')}</option>
                 {horariosDisponibilidad.map((item) => (
                   <option key={item.id} value={catalogValue(item)}>
-                    {item.nombre}
+                    {translateCatalogText(locale, item.nombre)}
                   </option>
                 ))}
               </select>
             </div>
             <div className='flex flex-col gap-1.5 md:col-span-2'>
-              <Label htmlFor='observaciones'>Observaciones laborales</Label>
-              <Input id='observaciones' name='observaciones' placeholder='Notas internas del empleado' value={form.observaciones} onChange={handleChange} />
+              <Label htmlFor='observaciones'>{c('Observaciones laborales', 'Work notes')}</Label>
+              <Input id='observaciones' name='observaciones' placeholder={c('Notas internas del empleado', 'Internal employee notes')} value={form.observaciones} onChange={handleChange} />
             </div>
           </div>
         </div>
@@ -768,11 +838,11 @@ export default function UserForm({
             />
             <span>
               <span className='font-medium'>
-                Usar contraseña inicial automática
+                {c('Usar contraseña inicial automática', 'Use automatic initial password')}
               </span>
               <span className='block text-xs'>
-                Patrón: <strong>{initialPasswordPreview}</strong>. En el primer
-                ingreso el usuario deberá cambiarla obligatoriamente.
+                {c('Patrón:', 'Pattern:')} <strong>{initialPasswordPreview}</strong>.{' '}
+                {c('En el primer ingreso el usuario deberá cambiarla obligatoriamente.', 'On first login the user must change it obligatorily.')}
               </span>
             </span>
           </label>
@@ -782,14 +852,14 @@ export default function UserForm({
       {!isInitialPasswordMode && (
         <>
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='password'>Contraseña</Label>
+        <Label htmlFor='password'>{c('Contraseña', 'Password')}</Label>
         <div className='relative'>
           <Input
             id='password'
             name='password'
             type={showPassword ? 'text' : 'password'}
             placeholder={
-              usuario ? 'Dejar vacío para no cambiar' : 'Ingrese contraseña'
+              usuario ? c('Dejar vacío para no cambiar', 'Leave empty to keep unchanged') : c('Ingrese contraseña', 'Enter password')
             }
             value={form.password}
             onChange={handleChange}
@@ -800,8 +870,8 @@ export default function UserForm({
             type='button'
             onClick={() => setShowPassword((prev) => !prev)}
             className='absolute inset-y-0 right-0 flex w-10 items-center justify-center rounded-r-md text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
-            aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-            title={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+            aria-label={showPassword ? c('Ocultar contraseña', 'Hide password') : c('Mostrar contraseña', 'Show password')}
+            title={showPassword ? c('Ocultar contraseña', 'Hide password') : c('Mostrar contraseña', 'Show password')}
           >
             {showPassword ? <EyeOff className='h-4 w-4' /> : <Eye className='h-4 w-4' />}
           </button>
@@ -809,13 +879,13 @@ export default function UserForm({
       </div>
 
       <div className='flex flex-col gap-1.5'>
-        <Label htmlFor='confirmPassword'>Confirmar contraseña</Label>
+        <Label htmlFor='confirmPassword'>{c('Confirmar contraseña', 'Confirm password')}</Label>
         <div className='relative'>
           <Input
             id='confirmPassword'
             name='confirmPassword'
             type={showConfirmPassword ? 'text' : 'password'}
-            placeholder={usuario ? 'Repetir solo si cambia contraseña' : 'Repita la contraseña'}
+            placeholder={usuario ? c('Repetir solo si cambia contraseña', 'Repeat only if password changes') : c('Repita la contraseña', 'Repeat password')}
             value={form.confirmPassword}
             onChange={handleChange}
             required={!usuario}
@@ -825,8 +895,8 @@ export default function UserForm({
             type='button'
             onClick={() => setShowConfirmPassword((prev) => !prev)}
             className='absolute inset-y-0 right-0 flex w-10 items-center justify-center rounded-r-md text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
-            aria-label={showConfirmPassword ? 'Ocultar confirmación de contraseña' : 'Mostrar confirmación de contraseña'}
-            title={showConfirmPassword ? 'Ocultar confirmación de contraseña' : 'Mostrar confirmación de contraseña'}
+            aria-label={showConfirmPassword ? c('Ocultar confirmación de contraseña', 'Hide password confirmation') : c('Mostrar confirmación de contraseña', 'Show password confirmation')}
+            title={showConfirmPassword ? c('Ocultar confirmación de contraseña', 'Hide password confirmation') : c('Mostrar confirmación de contraseña', 'Show password confirmation')}
           >
             {showConfirmPassword ? <EyeOff className='h-4 w-4' /> : <Eye className='h-4 w-4' />}
           </button>
@@ -838,19 +908,19 @@ export default function UserForm({
 
       {showPasswordRules && (
         <div className='col-span-full rounded-md border bg-muted/20 p-3 text-sm'>
-          <p className='mb-2 font-medium'>Requisitos de contraseña</p>
+          <p className='mb-2 font-medium'>{c('Requisitos de contraseña', 'Password requirements')}</p>
           <div className='grid gap-1 md:grid-cols-2'>
-            <span className={passwordChecks.minLength ? 'text-emerald-600' : 'text-red-600'}>• Mínimo 8 caracteres</span>
-            <span className={passwordChecks.uppercase ? 'text-emerald-600' : 'text-red-600'}>• Al menos una mayúscula</span>
-            <span className={passwordChecks.lowercase ? 'text-emerald-600' : 'text-red-600'}>• Al menos una minúscula</span>
-            <span className={passwordChecks.number ? 'text-emerald-600' : 'text-red-600'}>• Al menos un número</span>
-            <span className={passwordChecks.symbol ? 'text-emerald-600' : 'text-red-600'}>• Al menos un símbolo</span>
-            <span className={passwordsMatch ? 'text-emerald-600' : 'text-red-600'}>• Ambas contraseñas coinciden</span>
+            <span className={passwordChecks.minLength ? 'text-emerald-600' : 'text-red-600'}>{c('• Mínimo 8 caracteres', '• Minimum 8 characters')}</span>
+            <span className={passwordChecks.uppercase ? 'text-emerald-600' : 'text-red-600'}>{c('• Al menos una mayúscula', '• At least one uppercase letter')}</span>
+            <span className={passwordChecks.lowercase ? 'text-emerald-600' : 'text-red-600'}>{c('• Al menos una minúscula', '• At least one lowercase letter')}</span>
+            <span className={passwordChecks.number ? 'text-emerald-600' : 'text-red-600'}>{c('• Al menos un número', '• At least one number')}</span>
+            <span className={passwordChecks.symbol ? 'text-emerald-600' : 'text-red-600'}>{c('• Al menos un símbolo', '• At least one symbol')}</span>
+            <span className={passwordsMatch ? 'text-emerald-600' : 'text-red-600'}>{c('• Ambas contraseñas coinciden', '• Both passwords match')}</span>
           </div>
         </div>
       )}
 
-      <div className='col-span-full rounded-lg border bg-muted/20 p-4'>
+      <div className='col-span-full rounded-lg border bg-muted/20 p-4 dark:border-slate-800 dark:bg-slate-900/40'>
         <div className='mb-3'>
           <h3 className='text-base font-semibold'>{t('users.form.menuPermissions.title')}</h3>
           <p className='text-sm text-muted-foreground'>
@@ -871,7 +941,7 @@ export default function UserForm({
             )}
             <div className='grid gap-4 md:grid-cols-2'>
               {availablePermissions.map((group) => (
-              <div key={group.group} className='rounded-md border bg-background p-3'>
+              <div key={group.group} className='rounded-md border bg-background p-3 dark:border-slate-800 dark:bg-slate-950/60'>
                 <p className='mb-2 text-sm font-semibold'>{translateNavigationGroup(group.group, t)}</p>
                 <div className='space-y-2'>
                   {group.items.map((item) => {
@@ -910,15 +980,15 @@ export default function UserForm({
           className='text-gray-800 bg-gray-200 hover:bg-gray-300'
           disabled={loading}
         >
-          Cancelar
+          {c('Cancelar', 'Cancel')}
         </Button>
 
         <Button type='submit' disabled={loading}>
           {loading
-            ? 'Guardando...'
+            ? c('Guardando...', 'Saving...')
             : usuario
-            ? 'Actualizar Usuario'
-            : 'Crear Usuario'}
+            ? c('Actualizar Usuario', 'Update User')
+            : c('Crear Usuario', 'Create User')}
         </Button>
       </div>
     </form>

--- a/src/components/modal/AvisosModal.tsx
+++ b/src/components/modal/AvisosModal.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import AvisosForm from "../forms/AvisosForm";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function AvisosModal({
   open,
@@ -20,16 +21,19 @@ export default function AvisosModal({
   onCreated: () => void;
   aviso?: any | null;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => (locale === "en" ? en : es);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-5xl sm:max-w-4xl">
+      <DialogContent className="w-full max-w-5xl border-slate-200 bg-white text-slate-950 sm:max-w-4xl dark:border-slate-800 dark:bg-slate-900 dark:text-slate-50">
         <QaFileNameBadge file="src/components/modal/AvisosModal.tsx" />
         <DialogHeader>
           <div className="flex items-center justify-between w-full gap-4">
-            <DialogTitle>{aviso ? "Editar Aviso" : "Nuevo Aviso"}</DialogTitle>
+            <DialogTitle>{aviso ? c("Editar aviso", "Edit notice") : c("Nuevo aviso", "New notice")}</DialogTitle>
           </div>
         </DialogHeader>
-        <AvisosForm />
+        <AvisosForm onCreated={onCreated} />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/modal/AvisosModalView.tsx
+++ b/src/components/modal/AvisosModalView.tsx
@@ -8,7 +8,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Aviso } from "@/interfaces/aviso.interface";
-import { formatFrontendDateTime, formatFrontendDate } from '@/utils/dateFormat';
+import { formatFrontendDateTime } from "@/utils/dateFormat";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function AvisosModalView({
   open,
@@ -19,15 +20,18 @@ export default function AvisosModalView({
   onClose: () => void;
   aviso?: Aviso | null;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => (locale === "en" ? en : es);
+
   if (!aviso) return null;
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="!max-w-[90vw] sm:!max-w-[800px] !w-full bg-background text-foreground">
+      <DialogContent className="!max-w-[90vw] sm:!max-w-[800px] !w-full border-slate-200 bg-white text-slate-950 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-50">
         <QaFileNameBadge file="src/components/modal/AvisosModalView.tsx" />
         <DialogHeader>
           <DialogTitle className="text-xl font-semibold text-foreground">
-            Detalle Aviso
+            {c("Detalle del aviso", "Notice details")}
           </DialogTitle>
           <div className="text-sm text-right text-muted-foreground">
             {formatFrontendDateTime(new Date())}
@@ -36,23 +40,23 @@ export default function AvisosModalView({
         <div className="grid grid-cols-1 gap-6 mt-4 md:grid-cols-2">
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Asunto</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
+              <label className="text-sm font-medium">{c("Asunto", "Subject")}</label>
+              <div className="p-2 border rounded-md border-slate-200 bg-slate-50 text-foreground dark:border-slate-700 dark:bg-slate-950">
                 {aviso.titulo || "-"}
               </div>
             </div>
           </div>
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Fecha de envío</label>
-              <div className="p-2 border rounded-md bg-muted text-foreground">
+              <label className="text-sm font-medium">{c("Fecha de envío", "Send date")}</label>
+              <div className="p-2 border rounded-md border-slate-200 bg-slate-50 text-foreground dark:border-slate-700 dark:bg-slate-950">
                 {aviso.fecha_envio || "-"}
               </div>
             </div>
           </div>
           <div className="space-y-2 md:col-span-2">
-            <label className="text-sm font-medium">Mensaje</label>
-            <div className="p-2 break-words whitespace-pre-line border rounded-md bg-muted text-foreground">
+            <label className="text-sm font-medium">{c("Mensaje", "Message")}</label>
+            <div className="p-2 break-words whitespace-pre-line border rounded-md border-slate-200 bg-slate-50 text-foreground dark:border-slate-700 dark:bg-slate-950">
               {aviso.mensaje || "-"}
             </div>
           </div>

--- a/src/components/modal/UserModal.tsx
+++ b/src/components/modal/UserModal.tsx
@@ -10,6 +10,7 @@ import {
 import UserForm from "../forms/UserForm";
 import FechaHora from "@/components/ui/FechaHora";
 import { Usuario } from "@/interfaces/usuario.interface";
+import { useI18n } from "@/i18n/I18nProvider";
 
 export default function UserModal({
   open,
@@ -22,14 +23,17 @@ export default function UserModal({
   onCreated: () => void;
   usuario?: Usuario | null;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => (locale === "en" ? en : es);
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-5xl sm:max-w-4xl">
+      <DialogContent className="w-full max-w-5xl sm:max-w-4xl dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100">
         <QaFileNameBadge file="src/components/modal/UserModal.tsx" />
         <DialogHeader>
           <div className="flex gap-4 justify-between items-center w-full">
             <DialogTitle>
-              {usuario ? "Editar Usuario" : "Nuevo Usuario"}{" "}
+              {usuario ? c("Editar Usuario", "Edit User") : c("Nuevo Usuario", "New User")}{" "}
             </DialogTitle>
             <FechaHora />
           </div>

--- a/src/components/modal/UserViewModal.tsx
+++ b/src/components/modal/UserViewModal.tsx
@@ -9,6 +9,22 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Usuario } from "@/interfaces/usuario.interface";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
+
+
+function userViewTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function translateUserRole(locale: GymMasterLocale, role?: string | null) {
+  if (locale !== "en") return role || "-";
+  const normalized = String(role || "").toLowerCase();
+  if (normalized === "socio") return "Member";
+  if (normalized === "usuario") return "Internal user";
+  if (normalized === "admin") return "Admin";
+  return role || "-";
+}
 
 export default function UserViewModal({
   open,
@@ -19,6 +35,9 @@ export default function UserViewModal({
   onClose: () => void;
   usuario?: Usuario | null;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => userViewTx(locale, es, en);
+
   if (!open || !usuario) return null;
 
   return (
@@ -27,7 +46,7 @@ export default function UserViewModal({
         <QaFileNameBadge file="src/components/modal/UserViewModal.tsx" />
         <DialogHeader>
           <DialogTitle className="text-foreground">
-            Detalles del Usuario
+            {c("Detalles del Usuario", "User details")}
           </DialogTitle>
         </DialogHeader>
         <div className="mt-4 space-y-3">
@@ -35,24 +54,24 @@ export default function UserViewModal({
             <strong>ID:</strong> {usuario.id}
           </p>
           <p className="text-foreground">
-            <strong>Nombre:</strong> {usuario.nombre}
+            <strong>{c("Nombre", "Name")}:</strong> {usuario.nombre}
           </p>
           <p className="text-foreground">
             <strong>Email:</strong> {usuario.email}
           </p>
           <p className="text-foreground">
-            <strong>Rol:</strong> {usuario.rol}
+            <strong>{c("Rol", "Role")}:</strong> {translateUserRole(locale, usuario.rol)}
           </p>
           <p className="text-foreground">
-            <strong>Permisos:</strong>{' '}
+            <strong>{c("Permisos", "Permissions")}:</strong>{' '}
             {usuario.rol === 'admin'
-              ? 'Control total'
+              ? c('Control total', 'Full control')
               : Array.isArray(usuario.permisos_menu)
-              ? `${usuario.permisos_menu.length} módulos habilitados`
-              : 'Permisos por defecto'}
+              ? `${usuario.permisos_menu.length} ${c('módulos habilitados', 'enabled modules')}`
+              : c('Permisos por defecto', 'Default permissions')}
           </p>
           <p className="text-foreground">
-            <strong>Estado:</strong>{" "}
+            <strong>{c("Estado", "Status")}:</strong>{" "}
             <span
               className={`px-2 py-1 rounded-full text-xs font-semibold ${
                 usuario.activo
@@ -60,12 +79,12 @@ export default function UserViewModal({
                   : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
               }`}
             >
-              {usuario.activo ? "Activo" : "Deshabilitado"}
+              {usuario.activo ? c("Activo", "Active") : c("Deshabilitado", "Disabled")}
             </span>
           </p>
         </div>
         <div className="flex justify-end mt-6">
-          <Button onClick={onClose}>Cerrar</Button>
+          <Button onClick={onClose}>{c("Cerrar", "Close")}</Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/perfil/ProfileCard.tsx
+++ b/src/components/perfil/ProfileCard.tsx
@@ -1,16 +1,30 @@
-'use client';
+"use client";
 
-import { CalendarDays, CheckCircle2, Mail, ShieldCheck, UserRound } from 'lucide-react';
-import ProfileImage from './ProfileImage';
-import ProfileDetails from './ProfileDetails';
-import type { Usuario } from '@/interfaces/usuario.interface';
-import { useAuthStore } from '@/stores/authStore';
+import {
+  CalendarDays,
+  CheckCircle2,
+  Mail,
+  ShieldCheck,
+  UserRound,
+} from "lucide-react";
+import ProfileImage from "./ProfileImage";
+import ProfileDetails from "./ProfileDetails";
+import type { Usuario } from "@/interfaces/usuario.interface";
+import { useAuthStore } from "@/stores/authStore";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
-function roleLabel(rol?: string | null) {
-  if (rol === 'socio') return 'Socio';
-  if (rol === 'admin') return 'Administrador';
-  if (rol === 'usuario') return 'Usuario interno';
-  return 'Usuario';
+function profileCardTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function roleLabel(locale: GymMasterLocale, rol?: string | null) {
+  if (rol === "socio") return profileCardTx(locale, "Socio", "Member");
+  if (rol === "admin")
+    return profileCardTx(locale, "Administrador", "Administrator");
+  if (rol === "usuario")
+    return profileCardTx(locale, "Usuario interno", "Internal user");
+  return profileCardTx(locale, "Usuario", "User");
 }
 
 export default function ProfileCard({
@@ -21,6 +35,8 @@ export default function ProfileCard({
   size?: number;
 }) {
   const updateUser = useAuthStore((state) => state.updateUser);
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => profileCardTx(locale, es, en);
 
   const handlePhotoUpload = (data: any) => {
     const url = data?.url || data?.foto || data?.path || null;
@@ -29,80 +45,105 @@ export default function ProfileCard({
     }
   };
 
-  const userName = user?.nombre?.trim() || 'Usuario';
-  const userEmail = user?.email?.trim() || 'Email no disponible';
+  const userName = user?.nombre?.trim() || c("Usuario", "User");
+  const userEmail =
+    user?.email?.trim() || c("Email no disponible", "Email unavailable");
 
   return (
-    <div className='w-full overflow-hidden rounded-[2rem] border border-border bg-white shadow-sm dark:bg-slate-950/80'>
-      <div className='grid gap-0 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]'>
-        <div className='relative overflow-hidden bg-gradient-to-br from-slate-950 via-sky-950 to-emerald-950 p-5 text-white sm:p-6'>
-          <div className='absolute -right-12 -top-12 h-36 w-36 rounded-full bg-sky-400/25 blur-3xl' />
-          <div className='absolute -bottom-14 -left-14 h-40 w-40 rounded-full bg-emerald-400/20 blur-3xl' />
+    <div className="w-full overflow-hidden rounded-[2rem] border border-border bg-white shadow-sm dark:bg-slate-950/80">
+      <div className="grid gap-0 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <div className="relative overflow-hidden bg-gradient-to-br from-slate-950 via-sky-950 to-emerald-950 p-5 text-white sm:p-6">
+          <div className="absolute -right-12 -top-12 h-36 w-36 rounded-full bg-sky-400/25 blur-3xl" />
+          <div className="absolute -bottom-14 -left-14 h-40 w-40 rounded-full bg-emerald-400/20 blur-3xl" />
 
-          <div className='relative flex flex-col items-center gap-4 text-center'>
+          <div className="relative flex flex-col items-center gap-4 text-center">
             <ProfileImage
               src={user?.foto ?? null}
               alt={userName}
               size={size}
               onUpload={handlePhotoUpload}
-              tone='onDark'
+              tone="onDark"
             />
 
-            <div className='min-w-0'>
-              <p className='text-xs font-bold uppercase tracking-[0.22em] text-sky-200'>
-                Foto de perfil
+            <div className="min-w-0">
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-sky-200">
+                {c("Foto de perfil", "Profile photo")}
               </p>
-              <h2 className='mt-2 break-words text-2xl font-black leading-tight sm:text-3xl'>
+              <h2 className="mt-2 break-words text-2xl font-black leading-tight sm:text-3xl">
                 {userName}
               </h2>
-              <p className='mt-2 break-words text-sm text-slate-100/95'>{userEmail}</p>
+              <p className="mt-2 break-words text-sm text-slate-100/95">
+                {userEmail}
+              </p>
             </div>
 
-            <div className='grid w-full grid-cols-2 gap-2 text-left'>
-              <div className='rounded-2xl bg-white/10 p-3 ring-1 ring-white/10'>
-                <div className='flex items-center gap-2 text-sky-100'>
-                  <UserRound className='h-4 w-4' />
-                  <span className='text-[11px] font-bold uppercase tracking-[0.18em]'>Rol</span>
+            <div className="grid w-full grid-cols-2 gap-2 text-left">
+              <div className="rounded-2xl bg-white/10 p-3 ring-1 ring-white/10">
+                <div className="flex items-center gap-2 text-sky-100">
+                  <UserRound className="h-4 w-4" />
+                  <span className="text-[11px] font-bold uppercase tracking-[0.18em]">
+                    {c("Rol", "Role")}
+                  </span>
                 </div>
-                <p className='mt-2 text-sm font-bold'>{roleLabel(user?.rol)}</p>
+                <p className="mt-2 text-sm font-bold">
+                  {roleLabel(locale, user?.rol)}
+                </p>
               </div>
-              <div className='rounded-2xl bg-white/10 p-3 ring-1 ring-white/10'>
-                <div className='flex items-center gap-2 text-emerald-100'>
-                  <CheckCircle2 className='h-4 w-4' />
-                  <span className='text-[11px] font-bold uppercase tracking-[0.18em]'>Estado</span>
+              <div className="rounded-2xl bg-white/10 p-3 ring-1 ring-white/10">
+                <div className="flex items-center gap-2 text-emerald-100">
+                  <CheckCircle2 className="h-4 w-4" />
+                  <span className="text-[11px] font-bold uppercase tracking-[0.18em]">
+                    {c("Estado", "Status")}
+                  </span>
                 </div>
-                <p className='mt-2 text-sm font-bold'>Activo</p>
+                <p className="mt-2 text-sm font-bold">
+                  {c("Activo", "Active")}
+                </p>
               </div>
             </div>
           </div>
         </div>
 
-        <div className='p-4 sm:p-6'>
-          <div className='mb-4 grid gap-3 sm:grid-cols-2'>
-            <div className='rounded-2xl border border-slate-100 bg-slate-50 p-4 dark:border-slate-700/70 dark:bg-slate-900'>
-              <div className='flex items-center gap-2 text-slate-600 dark:text-slate-200'>
-                <Mail className='h-4 w-4' />
-                <span className='text-xs font-bold uppercase tracking-[0.18em]'>Contacto</span>
+        <div className="p-4 sm:p-6">
+          <div className="mb-4 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4 dark:border-slate-700/70 dark:bg-slate-900">
+              <div className="flex items-center gap-2 text-slate-600 dark:text-slate-200">
+                <Mail className="h-4 w-4" />
+                <span className="text-xs font-bold uppercase tracking-[0.18em]">
+                  {c("Contacto", "Contact")}
+                </span>
               </div>
-              <p className='mt-2 break-words text-sm font-semibold text-slate-900 dark:text-slate-100'>{userEmail}</p>
+              <p className="mt-2 break-words text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {userEmail}
+              </p>
             </div>
 
-            <div className='rounded-2xl border border-slate-100 bg-slate-50 p-4 dark:border-slate-700/70 dark:bg-slate-900'>
-              <div className='flex items-center gap-2 text-slate-600 dark:text-slate-200'>
-                <CalendarDays className='h-4 w-4' />
-                <span className='text-xs font-bold uppercase tracking-[0.18em]'>Cuenta</span>
+            <div className="rounded-2xl border border-slate-100 bg-slate-50 p-4 dark:border-slate-700/70 dark:bg-slate-900">
+              <div className="flex items-center gap-2 text-slate-600 dark:text-slate-200">
+                <CalendarDays className="h-4 w-4" />
+                <span className="text-xs font-bold uppercase tracking-[0.18em]">
+                  {c("Cuenta", "Account")}
+                </span>
               </div>
-              <p className='mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100'>Datos principales y seguridad</p>
+              <p className="mt-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {c(
+                  "Datos principales y seguridad",
+                  "Main details and security",
+                )}
+              </p>
             </div>
           </div>
 
           <ProfileDetails user={user} />
 
-          <div className='mt-5 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm leading-6 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/20 dark:text-emerald-100'>
-            <div className='flex items-start gap-3'>
-              <ShieldCheck className='mt-0.5 h-5 w-5 shrink-0' />
+          <div className="mt-5 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-sm leading-6 text-emerald-900 dark:border-emerald-900/60 dark:bg-emerald-950/20 dark:text-emerald-100">
+            <div className="flex items-start gap-3">
+              <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0" />
               <p>
-                Mantené tu foto y datos actualizados para que el gimnasio pueda identificarte mejor en asistencia, rutinas, dietas y evolución física.
+                {c(
+                  "Mantené tu foto y datos actualizados para que el gimnasio pueda identificarte mejor en asistencia, rutinas, dietas y evolución física.",
+                  "Keep your photo and details updated so the gym can identify you better for attendance, routines, diets, and physical evolution.",
+                )}
               </p>
             </div>
           </div>

--- a/src/components/perfil/ProfileDetails.tsx
+++ b/src/components/perfil/ProfileDetails.tsx
@@ -1,41 +1,61 @@
-'use client';
+"use client";
 
-import type { ComponentType } from 'react';
-import { CalendarClock, Fingerprint, KeyRound, Mail, ShieldCheck, UserRound } from 'lucide-react';
-import type { Usuario } from '@/interfaces/usuario.interface';
-import { formatFrontendDate } from '@/utils/dateFormat';
+import type { ComponentType } from "react";
+import {
+  CalendarClock,
+  Fingerprint,
+  KeyRound,
+  Mail,
+  ShieldCheck,
+  UserRound,
+} from "lucide-react";
+import type { Usuario } from "@/interfaces/usuario.interface";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
+import { formatFrontendDate } from "@/utils/dateFormat";
 
-function formatDate(d?: string | Date | null) {
-  if (!d) return 'No registrado';
-  const date = typeof d === 'string' ? new Date(d) : d;
-  if (!date || isNaN(date.getTime())) return 'No registrado';
+function profileDetailsTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function formatDate(locale: GymMasterLocale, d?: string | Date | null) {
+  const fallback = profileDetailsTx(locale, "No registrado", "Not registered");
+  if (!d) return fallback;
+  const date = typeof d === "string" ? new Date(d) : d;
+  if (!date || isNaN(date.getTime())) return fallback;
   return formatFrontendDate(date);
 }
 
-function roleLabel(rol?: string | null) {
-  if (rol === 'socio') return 'Socio';
-  if (rol === 'admin') return 'Administrador';
-  if (rol === 'usuario') return 'Usuario interno';
-  return 'Usuario';
+function roleLabel(locale: GymMasterLocale, rol?: string | null) {
+  if (rol === "socio") return profileDetailsTx(locale, "Socio", "Member");
+  if (rol === "admin")
+    return profileDetailsTx(locale, "Administrador", "Administrator");
+  if (rol === "usuario")
+    return profileDetailsTx(locale, "Usuario interno", "Internal user");
+  return profileDetailsTx(locale, "Usuario", "User");
 }
 
 function DetailItem({
   icon: Icon,
   label,
   value,
+  fallback,
 }: {
   icon: ComponentType<{ className?: string }>;
   label: string;
   value?: string | number | null;
+  fallback: string;
 }) {
   return (
-    <div className='rounded-2xl border border-border bg-background p-4 shadow-sm'>
-      <div className='flex items-center gap-2 text-muted-foreground'>
-        <Icon className='h-4 w-4' />
-        <span className='text-[11px] font-bold uppercase tracking-[0.18em]'>{label}</span>
+    <div className="rounded-2xl border border-border bg-background p-4 shadow-sm">
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <Icon className="h-4 w-4" />
+        <span className="text-[11px] font-bold uppercase tracking-[0.18em]">
+          {label}
+        </span>
       </div>
-      <p className='mt-2 break-words text-sm font-semibold text-foreground'>
-        {value || 'No registrado'}
+      <p className="mt-2 break-words text-sm font-semibold text-foreground">
+        {value || fallback}
       </p>
     </div>
   );
@@ -46,28 +66,67 @@ export default function ProfileDetails({
 }: {
   user?: Partial<Usuario> | null;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => profileDetailsTx(locale, es, en);
+  const notRegistered = c("No registrado", "Not registered");
+
   const passwordStatus = user?.must_change_password
-    ? 'Cambio pendiente'
+    ? c("Cambio pendiente", "Change pending")
     : user?.password_actualizado_en
-      ? `Actualizada: ${formatDate(user.password_actualizado_en)}`
-      : 'Sin cambio reciente registrado';
+      ? `${c("Actualizada", "Updated")}: ${formatDate(locale, user.password_actualizado_en)}`
+      : c("Sin cambio reciente registrado", "No recent change registered");
 
   return (
-    <div className='space-y-4'>
+    <div className="space-y-4">
       <div>
-        <h3 className='text-lg font-black text-foreground'>Datos de cuenta</h3>
-        <p className='mt-1 text-sm leading-6 text-muted-foreground'>
-          Información principal de tu usuario dentro de Gym Master.
+        <h3 className="text-lg font-black text-foreground">
+          {c("Datos de cuenta", "Account details")}
+        </h3>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+          {c(
+            "Información principal de tu usuario dentro de Gym Master.",
+            "Main information for your Gym Master user account.",
+          )}
         </p>
       </div>
 
-      <div className='grid gap-3 sm:grid-cols-2'>
-        <DetailItem icon={UserRound} label='Nombre' value={user?.nombre} />
-        <DetailItem icon={Mail} label='Email' value={user?.email} />
-        <DetailItem icon={ShieldCheck} label='Rol' value={roleLabel(user?.rol)} />
-        <DetailItem icon={Fingerprint} label='DNI' value={user?.dni ?? null} />
-        <DetailItem icon={CalendarClock} label='Alta de cuenta' value={formatDate(user?.creado_en)} />
-        <DetailItem icon={KeyRound} label='Contraseña' value={passwordStatus} />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <DetailItem
+          icon={UserRound}
+          label={c("Nombre", "Name")}
+          value={user?.nombre}
+          fallback={notRegistered}
+        />
+        <DetailItem
+          icon={Mail}
+          label="Email"
+          value={user?.email}
+          fallback={notRegistered}
+        />
+        <DetailItem
+          icon={ShieldCheck}
+          label={c("Rol", "Role")}
+          value={roleLabel(locale, user?.rol)}
+          fallback={notRegistered}
+        />
+        <DetailItem
+          icon={Fingerprint}
+          label="ID"
+          value={user?.dni ?? null}
+          fallback={notRegistered}
+        />
+        <DetailItem
+          icon={CalendarClock}
+          label={c("Alta de cuenta", "Account registration")}
+          value={formatDate(locale, user?.creado_en)}
+          fallback={notRegistered}
+        />
+        <DetailItem
+          icon={KeyRound}
+          label={c("Contraseña", "Password")}
+          value={passwordStatus}
+          fallback={notRegistered}
+        />
       </div>
     </div>
   );

--- a/src/components/perfil/ProfileImage.tsx
+++ b/src/components/perfil/ProfileImage.tsx
@@ -1,12 +1,18 @@
-'use client';
+"use client";
 
-import { useEffect, useRef, useState } from 'react';
-import { Camera, ImagePlus, RotateCcw, Save, X } from 'lucide-react';
-import { uploadFile } from '@/services/apiClient';
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Camera, ImagePlus, RotateCcw, Save, X } from "lucide-react";
+import { uploadFile } from "@/services/apiClient";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
 
 const MAX_FILE_SIZE_MB = 5;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
-const DEFAULT_PROFILE_IMAGE = '/gm_logo.svg';
+const DEFAULT_PROFILE_IMAGE = "/gm_logo.svg";
+
+function profileImageTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
 
 export default function ProfileImage({
   foto,
@@ -16,7 +22,7 @@ export default function ProfileImage({
   onUpload,
   showButton = true,
   onClick,
-  tone = 'default',
+  tone = "default",
 }: {
   foto?: string | null;
   src?: string | null;
@@ -25,10 +31,10 @@ export default function ProfileImage({
   onUpload?: (data: any) => void;
   showButton?: boolean;
   onClick?: () => void;
-  tone?: 'default' | 'onDark';
+  tone?: "default" | "onDark";
 }) {
   const [currentSrc, setCurrentSrc] = useState<string | null>(
-    foto ?? src ?? null
+    foto ?? src ?? null,
   );
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
   const [imageLoadError, setImageLoadError] = useState(false);
@@ -38,7 +44,7 @@ export default function ProfileImage({
   const [cameraLoading, setCameraLoading] = useState(false);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [message, setMessage] = useState<{
-    type: 'error' | 'success';
+    type: "error" | "success";
     text: string;
   } | null>(null);
 
@@ -47,6 +53,11 @@ export default function ProfileImage({
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const { locale } = useI18n();
+  const c = useCallback(
+    (es: string, en: string) => profileImageTx(locale, es, en),
+    [locale],
+  );
 
   useEffect(() => {
     setCurrentSrc(foto ?? src ?? null);
@@ -66,9 +77,14 @@ export default function ProfileImage({
 
     videoRef.current.srcObject = streamRef.current;
     void videoRef.current.play().catch(() => {
-      setCameraError('No se pudo iniciar la vista previa de la cámara.');
+      setCameraError(
+        c(
+          "No se pudo iniciar la vista previa de la cámara.",
+          "Could not start the camera preview.",
+        ),
+      );
     });
-  }, [cameraOpen]);
+  }, [cameraOpen, c]);
 
   useEffect(() => {
     return () => {
@@ -78,22 +94,25 @@ export default function ProfileImage({
   }, []);
 
   const validateFile = (file: File | null) => {
-    if (!file) return 'No se seleccionó archivo.';
+    if (!file) return c("No se seleccionó archivo.", "No file selected.");
     if (file.size > MAX_FILE_SIZE_BYTES) {
-      return `La imagen debe ser menor a ${MAX_FILE_SIZE_MB}MB.`;
+      return `${c("La imagen debe ser menor a", "Image must be smaller than")} ${MAX_FILE_SIZE_MB}MB.`;
     }
 
     const validTypes = /^image\/(png|jpe?g|webp|gif|svg\+xml|heic|heif)$/i;
     if (!validTypes.test(file.type)) {
-      return 'Formato no válido. Usá PNG, JPG, WEBP, GIF, HEIC o HEIF.';
+      return c(
+        "Formato no válido. Usá PNG, JPG, WEBP, GIF, HEIC o HEIF.",
+        "Invalid format. Use PNG, JPG, WEBP, GIF, HEIC, or HEIF.",
+      );
     }
 
     return null;
   };
 
   const resetInputs = () => {
-    if (galleryInputRef.current) galleryInputRef.current.value = '';
-    if (cameraInputRef.current) cameraInputRef.current.value = '';
+    if (galleryInputRef.current) galleryInputRef.current.value = "";
+    if (cameraInputRef.current) cameraInputRef.current.value = "";
   };
 
   const clearPreview = () => {
@@ -111,7 +130,7 @@ export default function ProfileImage({
     const validationError = validateFile(file);
     if (validationError) {
       clearPreview();
-      setMessage({ type: 'error', text: validationError });
+      setMessage({ type: "error", text: validationError });
       return;
     }
 
@@ -144,10 +163,16 @@ export default function ProfileImage({
     setMessage(null);
     setCameraError(null);
 
-    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.mediaDevices?.getUserMedia
+    ) {
       setMessage({
-        type: 'error',
-        text: 'Tu navegador no permite abrir la cámara desde la web. Se abrirá el selector de cámara/galería del dispositivo.',
+        type: "error",
+        text: c(
+          "Tu navegador no permite abrir la cámara desde la web. Se abrirá el selector de cámara/galería del dispositivo.",
+          "Your browser does not allow opening the camera from the web. The device camera/gallery selector will open.",
+        ),
       });
       cameraInputRef.current?.click();
       return;
@@ -161,7 +186,7 @@ export default function ProfileImage({
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: false,
         video: {
-          facingMode: 'user',
+          facingMode: "user",
           width: { ideal: 720 },
           height: { ideal: 720 },
         },
@@ -171,12 +196,18 @@ export default function ProfileImage({
       setCameraOpen(true);
     } catch (error) {
       const browserMessage =
-        error instanceof Error && error.name === 'NotAllowedError'
-          ? 'Permiso de cámara denegado. Revisá los permisos del navegador.'
-          : 'No se pudo abrir la cámara. Se abrirá el selector del dispositivo como alternativa.';
+        error instanceof Error && error.name === "NotAllowedError"
+          ? c(
+              "Permiso de cámara denegado. Revisá los permisos del navegador.",
+              "Camera permission denied. Check your browser permissions.",
+            )
+          : c(
+              "No se pudo abrir la cámara. Se abrirá el selector del dispositivo como alternativa.",
+              "Could not open the camera. The device selector will open as an alternative.",
+            );
 
       setCameraError(browserMessage);
-      setMessage({ type: 'error', text: browserMessage });
+      setMessage({ type: "error", text: browserMessage });
       cameraInputRef.current?.click();
     } finally {
       setCameraLoading(false);
@@ -188,32 +219,47 @@ export default function ProfileImage({
     const canvas = canvasRef.current;
 
     if (!video || !canvas || !video.videoWidth || !video.videoHeight) {
-      setCameraError('La cámara todavía no está lista para capturar.');
+      setCameraError(
+        c(
+          "La cámara todavía no está lista para capturar.",
+          "The camera is not ready to capture yet.",
+        ),
+      );
       return;
     }
 
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
 
-    const context = canvas.getContext('2d');
+    const context = canvas.getContext("2d");
     if (!context) {
-      setCameraError('No se pudo preparar la captura de imagen.');
+      setCameraError(
+        c(
+          "No se pudo preparar la captura de imagen.",
+          "Could not prepare the image capture.",
+        ),
+      );
       return;
     }
 
     context.drawImage(video, 0, 0, canvas.width, canvas.height);
 
     const blob = await new Promise<Blob | null>((resolve) =>
-      canvas.toBlob(resolve, 'image/jpeg', 0.92)
+      canvas.toBlob(resolve, "image/jpeg", 0.92),
     );
 
     if (!blob) {
-      setCameraError('No se pudo generar la foto capturada.');
+      setCameraError(
+        c(
+          "No se pudo generar la foto capturada.",
+          "Could not generate the captured photo.",
+        ),
+      );
       return;
     }
 
     const file = new File([blob], `perfil-camara-${Date.now()}.jpg`, {
-      type: 'image/jpeg',
+      type: "image/jpeg",
     });
 
     stopCamera();
@@ -225,22 +271,25 @@ export default function ProfileImage({
 
     if (!selectedFile) {
       setMessage({
-        type: 'error',
-        text: 'Seleccioná o sacá una foto antes de guardar.',
+        type: "error",
+        text: c(
+          "Seleccioná o sacá una foto antes de guardar.",
+          "Select or take a photo before saving.",
+        ),
       });
       return;
     }
 
     const validationError = validateFile(selectedFile);
     if (validationError) {
-      setMessage({ type: 'error', text: validationError });
+      setMessage({ type: "error", text: validationError });
       return;
     }
 
     setLoading(true);
 
     try {
-      const res = await uploadFile(selectedFile, 'file', '/api/file-upload');
+      const res = await uploadFile(selectedFile, "file", "/api/file-upload");
 
       if (res.ok) {
         const url = res.data?.url || res.data?.foto || res.data?.path || null;
@@ -250,18 +299,26 @@ export default function ProfileImage({
         }
 
         clearPreview();
-        setMessage({ type: 'success', text: 'Foto de perfil actualizada.' });
+        setMessage({
+          type: "success",
+          text: c("Foto de perfil actualizada.", "Profile photo updated."),
+        });
         onUpload?.(res.data);
       } else {
         setMessage({
-          type: 'error',
-          text: res.data?.message || res.data?.error || 'Error al subir la foto.',
+          type: "error",
+          text:
+            res.data?.message ||
+            res.data?.error ||
+            c("Error al subir la foto.", "Error uploading the photo."),
         });
       }
     } catch (error: unknown) {
       const text =
-        error instanceof Error ? error.message : 'Error al subir la foto.';
-      setMessage({ type: 'error', text });
+        error instanceof Error
+          ? error.message
+          : c("Error al subir la foto.", "Error uploading the photo.");
+      setMessage({ type: "error", text });
     } finally {
       setLoading(false);
       resetInputs();
@@ -273,119 +330,131 @@ export default function ProfileImage({
     : previewSrc || currentSrc || DEFAULT_PROFILE_IMAGE;
 
   const helperTextClass =
-    tone === 'onDark' ? 'text-slate-200/85' : 'text-muted-foreground';
+    tone === "onDark" ? "text-slate-200/85" : "text-muted-foreground";
 
   const successTextClass =
-    tone === 'onDark' ? 'text-emerald-300' : 'text-green-600';
+    tone === "onDark" ? "text-emerald-300" : "text-green-600";
 
-  const errorTextClass = tone === 'onDark' ? 'text-rose-300' : 'text-red-500';
+  const errorTextClass = tone === "onDark" ? "text-rose-300" : "text-red-500";
 
   return (
-    <div className='flex flex-col items-center gap-3' onClick={onClick}>
+    <div className="flex flex-col items-center gap-3" onClick={onClick}>
       <div
-        className='relative flex items-center justify-center flex-shrink-0 overflow-hidden rounded-full ring-1 ring-border/60 dark:ring-border/40 bg-muted'
+        className="relative flex items-center justify-center flex-shrink-0 overflow-hidden rounded-full ring-1 ring-border/60 dark:ring-border/40 bg-muted"
         style={{ width: size, height: size }}
       >
         {/* Se usa img para soportar previews locales tipo blob: en móviles. */}
         <img
           src={imageSrc}
-          alt={alt ?? 'Avatar'}
+          alt={alt ?? c("Avatar", "Avatar")}
           width={size}
           height={size}
-          className='object-cover w-full h-full rounded-full bg-white p-1 dark:bg-white'
+          className="object-cover w-full h-full rounded-full bg-white p-1 dark:bg-white"
           onError={() => setImageLoadError(true)}
         />
 
         {previewSrc && (
-          <div className='absolute inset-x-0 bottom-0 px-2 py-1 text-[10px] font-semibold text-center text-white bg-black/65'>
-            Vista previa
+          <div className="absolute inset-x-0 bottom-0 px-2 py-1 text-[10px] font-semibold text-center text-white bg-black/65">
+            {c("Vista previa", "Preview")}
           </div>
         )}
       </div>
 
       <input
         ref={galleryInputRef}
-        type='file'
-        accept='image/png,image/jpeg,image/webp,image/gif,image/svg+xml,image/heic,image/heif'
-        className='hidden'
+        type="file"
+        accept="image/png,image/jpeg,image/webp,image/gif,image/svg+xml,image/heic,image/heif"
+        className="hidden"
         onChange={(e) => handleSelectedFile(e.target.files?.[0] ?? null)}
       />
 
       <input
         ref={cameraInputRef}
-        type='file'
-        accept='image/*'
-        capture='user'
-        className='hidden'
+        type="file"
+        accept="image/*"
+        capture="user"
+        className="hidden"
         onChange={(e) => handleSelectedFile(e.target.files?.[0] ?? null)}
       />
 
       {showButton && (
-        <div className='flex flex-col items-center w-full gap-2'>
+        <div className="flex flex-col items-center w-full gap-2">
           {!selectedFile ? (
-            <div className='flex flex-wrap items-center justify-center gap-2'>
+            <div className="flex flex-wrap items-center justify-center gap-2">
               <button
-                type='button'
+                type="button"
                 onClick={() => galleryInputRef.current?.click()}
-                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60'
-                aria-label='Subir foto desde el dispositivo'
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60"
+                aria-label={c(
+                  "Subir foto desde el dispositivo",
+                  "Upload photo from device",
+                )}
                 disabled={loading || cameraLoading}
               >
-                <ImagePlus className='w-4 h-4' />
-                Subir foto
+                <ImagePlus className="w-4 h-4" />
+                {c("Subir foto", "Upload photo")}
               </button>
 
               <button
-                type='button'
+                type="button"
                 onClick={startCamera}
-                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-sky-600 rounded-md hover:bg-sky-700 disabled:opacity-60'
-                aria-label='Sacar foto con la cámara'
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-sky-600 rounded-md hover:bg-sky-700 disabled:opacity-60"
+                aria-label={c(
+                  "Sacar foto con la cámara",
+                  "Take photo with camera",
+                )}
                 disabled={loading || cameraLoading}
               >
-                <Camera className='w-4 h-4' />
-                {cameraLoading ? 'Abriendo cámara...' : 'Sacar foto'}
+                <Camera className="w-4 h-4" />
+                {cameraLoading
+                  ? c("Abriendo cámara...", "Opening camera...")
+                  : c("Sacar foto", "Take photo")}
               </button>
             </div>
           ) : (
-            <div className='flex flex-wrap items-center justify-center gap-2'>
+            <div className="flex flex-wrap items-center justify-center gap-2">
               <button
-                type='button'
+                type="button"
                 onClick={uploadSelectedFile}
-                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold text-white bg-emerald-600 rounded-md hover:bg-emerald-700 disabled:opacity-60'
-                aria-label='Guardar foto de perfil'
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-semibold text-white bg-emerald-600 rounded-md hover:bg-emerald-700 disabled:opacity-60"
+                aria-label={c("Guardar foto de perfil", "Save profile photo")}
                 disabled={loading}
               >
-                <Save className='w-4 h-4' />
-                {loading ? 'Guardando...' : 'Guardar foto'}
+                <Save className="w-4 h-4" />
+                {loading
+                  ? c("Guardando...", "Saving...")
+                  : c("Guardar foto", "Save photo")}
               </button>
 
               <button
-                type='button'
+                type="button"
                 onClick={() => galleryInputRef.current?.click()}
-                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60'
-                aria-label='Elegir otra foto'
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium border rounded-md border-border bg-background/80 hover:bg-background/90 disabled:opacity-60"
+                aria-label={c("Elegir otra foto", "Choose another photo")}
                 disabled={loading}
               >
-                <RotateCcw className='w-4 h-4' />
-                Cambiar
+                <RotateCcw className="w-4 h-4" />
+                {c("Cambiar", "Change")}
               </button>
 
               <button
-                type='button'
+                type="button"
                 onClick={clearPreview}
-                className='inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-700 border border-red-200 rounded-md bg-red-50 hover:bg-red-100 disabled:opacity-60 dark:text-red-200 dark:border-red-800 dark:bg-red-950/40'
-                aria-label='Cancelar cambio de foto'
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-red-700 border border-red-200 rounded-md bg-red-50 hover:bg-red-100 disabled:opacity-60 dark:text-red-200 dark:border-red-800 dark:bg-red-950/40"
+                aria-label={c("Cancelar cambio de foto", "Cancel photo change")}
                 disabled={loading}
               >
-                <X className='w-4 h-4' />
-                Cancelar
+                <X className="w-4 h-4" />
+                {c("Cancelar", "Cancel")}
               </button>
             </div>
           )}
 
           <p className={`max-w-xs text-center text-xs ${helperTextClass}`}>
-            Desde el celular podés subir una imagen desde la galería o abrir la cámara para sacar una foto nueva.
-            Revisá la vista previa antes de guardar.
+            {c(
+              "Desde el celular podés subir una imagen desde la galería o abrir la cámara para sacar una foto nueva. Revisá la vista previa antes de guardar.",
+              "From your phone, you can upload an image from the gallery or open the camera to take a new photo. Review the preview before saving.",
+            )}
           </p>
         </div>
       )}
@@ -393,7 +462,7 @@ export default function ProfileImage({
       {message && (
         <div
           className={`max-w-xs text-center text-xs ${
-            message.type === 'error' ? errorTextClass : successTextClass
+            message.type === "error" ? errorTextClass : successTextClass
           }`}
         >
           {message.text}
@@ -401,55 +470,62 @@ export default function ProfileImage({
       )}
 
       {cameraOpen && (
-        <div className='fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 py-6'>
-          <div className='w-full max-w-md overflow-hidden rounded-2xl border border-border bg-background shadow-2xl'>
-            <div className='flex items-center justify-between border-b border-border px-4 py-3'>
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-black/70 px-4 py-6">
+          <div className="w-full max-w-md overflow-hidden rounded-2xl border border-border bg-background shadow-2xl">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
               <div>
-                <h3 className='text-base font-semibold'>Sacar foto de perfil</h3>
-                <p className='text-xs text-muted-foreground'>
-                  Ubicá tu rostro dentro del recuadro y capturá la imagen.
+                <h3 className="text-base font-semibold">
+                  {c("Sacar foto de perfil", "Take profile photo")}
+                </h3>
+                <p className="text-xs text-muted-foreground">
+                  {c(
+                    "Ubicá tu rostro dentro del recuadro y capturá la imagen.",
+                    "Place your face inside the frame and capture the image.",
+                  )}
                 </p>
               </div>
               <button
-                type='button'
+                type="button"
                 onClick={stopCamera}
-                className='rounded-full p-2 text-muted-foreground hover:bg-muted hover:text-foreground'
-                aria-label='Cerrar cámara'
+                className="rounded-full p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label={c("Cerrar cámara", "Close camera")}
               >
-                <X className='h-5 w-5' />
+                <X className="h-5 w-5" />
               </button>
             </div>
 
-            <div className='bg-black'>
+            <div className="bg-black">
               <video
                 ref={videoRef}
-                className='aspect-square w-full object-cover'
+                className="aspect-square w-full object-cover"
                 playsInline
                 muted
                 autoPlay
               />
-              <canvas ref={canvasRef} className='hidden' />
+              <canvas ref={canvasRef} className="hidden" />
             </div>
 
             {cameraError && (
-              <div className='px-4 pt-3 text-sm text-red-500'>{cameraError}</div>
+              <div className="px-4 pt-3 text-sm text-red-500">
+                {cameraError}
+              </div>
             )}
 
-            <div className='flex flex-wrap items-center justify-end gap-2 px-4 py-4'>
+            <div className="flex flex-wrap items-center justify-end gap-2 px-4 py-4">
               <button
-                type='button'
+                type="button"
                 onClick={stopCamera}
-                className='rounded-md border border-border px-4 py-2 text-sm font-medium hover:bg-muted'
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium hover:bg-muted"
               >
-                Cancelar
+                {c("Cancelar", "Cancel")}
               </button>
               <button
-                type='button'
+                type="button"
                 onClick={capturePhoto}
-                className='inline-flex items-center gap-2 rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700'
+                className="inline-flex items-center gap-2 rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
               >
-                <Camera className='h-4 w-4' />
-                Capturar foto
+                <Camera className="h-4 w-4" />
+                {c("Capturar foto", "Capture photo")}
               </button>
             </div>
           </div>

--- a/src/components/tables/AvisosTable.tsx
+++ b/src/components/tables/AvisosTable.tsx
@@ -14,6 +14,37 @@ import {
   TableCaption,
 } from "@/components/ui/table";
 import { Aviso } from "@/interfaces/aviso.interface";
+import { useI18n } from "@/i18n/I18nProvider";
+
+function translateNoticeType(locale: string, value?: string | null) {
+  if (!value) return "-";
+
+  if (locale !== "en") {
+    const esTypes: Record<string, string> = {
+      general: "General",
+      evento: "Evento",
+      sistema: "Sistema",
+      recordatorio: "Recordatorio",
+      promocion: "Promoción",
+      promotion: "Promoción",
+    };
+    return esTypes[value.toLowerCase()] ?? value;
+  }
+
+  const enTypes: Record<string, string> = {
+    general: "General",
+    evento: "Event",
+    event: "Event",
+    sistema: "System",
+    system: "System",
+    recordatorio: "Reminder",
+    reminder: "Reminder",
+    promocion: "Promotion",
+    promotion: "Promotion",
+  };
+
+  return enTypes[value.toLowerCase()] ?? value;
+}
 
 export default function AvisosTable({
   avisos,
@@ -28,6 +59,9 @@ export default function AvisosTable({
   onView?: (aviso: Aviso) => void;
   onDelete?: (aviso: Aviso) => void;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => (locale === "en" ? en : es);
+
   if (loading) {
     return (
       <div className="space-y-2">
@@ -41,20 +75,20 @@ export default function AvisosTable({
   if (avisos.length === 0 && !loading) {
     return (
       <div className="py-10 text-center text-muted-foreground">
-        No hay avisos registrados aún.
+        {c("No hay avisos registrados aún.", "No notices have been registered yet.")}
       </div>
     );
   }
 
   return (
-    <Table className="w-full overflow-hidden text-sm border rounded-md border-border">
+    <Table className="w-full overflow-hidden text-sm border rounded-md border-slate-200 dark:border-slate-800">
       <TableHeader>
-        <TableRow className="bg-muted/50 text-muted-foreground">
-          <TableHead>Título</TableHead>
-          <TableHead>Mensaje</TableHead>
-          <TableHead>Tipo</TableHead>
-          <TableHead>Fecha de envío</TableHead>
-          <TableHead>Acciones</TableHead>
+        <TableRow className="bg-slate-100 text-slate-700 dark:bg-slate-800/80 dark:text-slate-200">
+          <TableHead>{c("Título", "Title")}</TableHead>
+          <TableHead>{c("Mensaje", "Message")}</TableHead>
+          <TableHead>{c("Tipo", "Type")}</TableHead>
+          <TableHead>{c("Fecha de envío", "Send date")}</TableHead>
+          <TableHead>{c("Acciones", "Actions")}</TableHead>
         </TableRow>
       </TableHeader>
 
@@ -62,13 +96,13 @@ export default function AvisosTable({
         {avisos.map((a) => (
           <TableRow
             key={a.id}
-            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors"
+            className="odd:bg-slate-50 transition-colors hover:bg-sky-100 dark:odd:bg-slate-900/60 dark:hover:bg-sky-950/40"
           >
-            <TableCell className="font-medium">{a.titulo}</TableCell>
-            <TableCell className="max-w-[220px] truncate whitespace-nowrap overflow-hidden">
+            <TableCell className="font-medium text-slate-950 dark:text-slate-50">{a.titulo}</TableCell>
+            <TableCell className="max-w-[220px] truncate whitespace-nowrap overflow-hidden text-slate-700 dark:text-slate-300">
               {a.mensaje}
             </TableCell>
-            <TableCell>{a.tipo}</TableCell>
+            <TableCell>{translateNoticeType(locale, a.tipo)}</TableCell>
             <TableCell>{a.fecha_envio}</TableCell>
             <TableCell className="flex gap-2">
               <Button
@@ -76,13 +110,13 @@ export default function AvisosTable({
                 variant="outline"
                 onClick={() => onView && onView(a)}
               >
-                Ver
+                {c("Ver", "View")}
               </Button>
               <Button
                 size="sm"
                 variant="outline"
                 onClick={() => onEdit(a)}
-                title="Editar"
+                title={c("Editar", "Edit")}
               >
                 <Pencil className="w-4 h-4" />
               </Button>
@@ -91,7 +125,7 @@ export default function AvisosTable({
                 className="bg-red-500 hover:bg-red-600 text-white w-[100px]"
                 onClick={() => onDelete && onDelete(a)}
               >
-                Eliminar
+                {c("Eliminar", "Delete")}
               </Button>
             </TableCell>
           </TableRow>
@@ -99,13 +133,13 @@ export default function AvisosTable({
       </TableBody>
 
       <TableFooter>
-        <TableRow>
-          <TableCell colSpan={4}>Total de avisos</TableCell>
+        <TableRow className="bg-slate-50 dark:bg-slate-900">
+          <TableCell colSpan={4}>{c("Total de avisos", "Total notices")}</TableCell>
           <TableCell className="text-right">{avisos.length}</TableCell>
         </TableRow>
       </TableFooter>
 
-      <TableCaption>Listado de avisos enviados.</TableCaption>
+      <TableCaption>{c("Listado de avisos enviados.", "List of sent notices.")}</TableCaption>
     </Table>
   );
 }

--- a/src/components/tables/UserTable.tsx
+++ b/src/components/tables/UserTable.tsx
@@ -14,6 +14,22 @@ import {
   TableCaption,
 } from "@/components/ui/table";
 import { Usuario } from "@/interfaces/usuario.interface";
+import { useI18n } from "@/i18n/I18nProvider";
+import type { GymMasterLocale } from "@/i18n/config";
+
+
+function usersTableTx(locale: GymMasterLocale, es: string, en: string) {
+  return locale === "en" ? en : es;
+}
+
+function translateUserRole(locale: GymMasterLocale, role?: string | null) {
+  if (locale !== "en") return role || "-";
+  const normalized = String(role || "").toLowerCase();
+  if (normalized === "socio") return "Member";
+  if (normalized === "usuario") return "Internal user";
+  if (normalized === "admin") return "Admin";
+  return role || "-";
+}
 
 export default function UsersTable({
   usuarios,
@@ -28,6 +44,9 @@ export default function UsersTable({
   onView?: (usuario: Usuario) => void;
   onDelete?: (usuario: Usuario) => void | Promise<void>;
 }) {
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => usersTableTx(locale, es, en);
+
   if (loading) {
     return (
       <div className="space-y-2">
@@ -41,39 +60,39 @@ export default function UsersTable({
   if (usuarios.length === 0 && !loading) {
     return (
       <div className="py-10 text-center text-muted-foreground">
-        No hay usuarios registrados aún.
+        {c("No hay usuarios registrados aún.", "There are no registered users yet.")}
       </div>
     );
   }
 
   return (
-    <Table className="overflow-hidden w-full text-sm rounded-md border border-border">
+    <Table className="overflow-hidden w-full text-sm rounded-md border border-border dark:border-slate-800">
       <TableHeader>
-        <TableRow className="bg-muted/50 text-muted-foreground">
-          <TableHead>Nombre</TableHead>
+        <TableRow className="bg-muted/50 text-muted-foreground dark:bg-slate-900/70">
+          <TableHead>{c("Nombre", "Name")}</TableHead>
           <TableHead>Email</TableHead>
-          <TableHead>Rol</TableHead>
-          <TableHead>Activo</TableHead>
-          <TableHead>Permisos</TableHead>
-          <TableHead>Acciones</TableHead>
+          <TableHead>{c("Rol", "Role")}</TableHead>
+          <TableHead>{c("Activo", "Active")}</TableHead>
+          <TableHead>{c("Permisos", "Permissions")}</TableHead>
+          <TableHead>{c("Acciones", "Actions")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {usuarios.map((u, i) => (
           <TableRow
             key={i}
-            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors"
+            className="odd:bg-muted/40 hover:bg-[#a8d9f9] transition-colors dark:odd:bg-slate-900/40 dark:hover:bg-slate-800"
           >
             <TableCell className="font-medium">{u.nombre}</TableCell>
             <TableCell>{u.email}</TableCell>
-            <TableCell>{u.rol}</TableCell>
+            <TableCell>{translateUserRole(locale, u.rol)}</TableCell>
             <TableCell>{u.activo ? "✅" : "❌"}</TableCell>
             <TableCell>
               {u.rol === 'admin'
-                ? 'Total'
+                ? c('Total', 'Full')
                 : Array.isArray(u.permisos_menu)
-                ? `${u.permisos_menu.length} módulos`
-                : 'Por defecto'}
+                ? `${u.permisos_menu.length} ${c('módulos', 'modules')}`
+                : c('Por defecto', 'Default')}
             </TableCell>
             <TableCell className="flex gap-2">
               <Button
@@ -81,13 +100,13 @@ export default function UsersTable({
                 variant="outline"
                 onClick={() => onView && onView(u)}
               >
-                Ver
+                {c("Ver", "View")}
               </Button>
               <Button
                 size="sm"
                 variant="outline"
                 onClick={() => onEdit(u)}
-                title="Editar"
+                title={c("Editar", "Edit")}
               >
                 <Pencil className="w-4 h-4" />
               </Button>
@@ -101,7 +120,7 @@ export default function UsersTable({
                 }
                 onClick={() => onDelete && onDelete(u)}
               >
-                {u.activo ? "Desactivar" : "Activar"}
+                {u.activo ? c("Desactivar", "Deactivate") : c("Activar", "Activate")}
               </Button>
             </TableCell>
           </TableRow>
@@ -109,11 +128,11 @@ export default function UsersTable({
       </TableBody>
       <TableFooter>
         <TableRow>
-          <TableCell colSpan={5}>Total de usuarios</TableCell>
+          <TableCell colSpan={5}>{c("Total de usuarios", "Total users")}</TableCell>
           <TableCell className="text-right">{usuarios.length}</TableCell>
         </TableRow>
       </TableFooter>
-      <TableCaption>Listado de usuarios registrados.</TableCaption>
+      <TableCaption>{c("Listado de usuarios registrados.", "List of registered users.")}</TableCaption>
     </Table>
   );
 }

--- a/src/components/ui/TextEditor.tsx
+++ b/src/components/ui/TextEditor.tsx
@@ -14,6 +14,7 @@ import {
   Heading2,
   Heading3,
 } from "lucide-react";
+import { useI18n } from "@/i18n/I18nProvider";
 
 interface TextEditorProps {
   value: string;
@@ -25,6 +26,8 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (props, ref) => {
     const { value, onChange } = props;
+    const { locale } = useI18n();
+    const tx = (es: string, en: string) => (locale === "en" ? en : es);
     const [activeTab, setActiveTab] = useState("write");
 
     const insertText = useCallback(
@@ -100,7 +103,10 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
 
     const getPreviewHTML = () => {
       if (!value.trim())
-        return '<p class="text-gray-500 dark:text-gray-400 italic">Vista previa del contenido...</p>';
+        return `<p class="text-gray-500 dark:text-gray-400 italic">${tx(
+          "Vista previa del contenido...",
+          "Content preview..."
+        )}</p>`;
 
       let html = formatMarkdown(value);
 
@@ -120,63 +126,63 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
     const toolbarButtons = [
       {
         icon: Bold,
-        action: () => insertText("**", "**", "texto en negrita"),
-        title: "Negrita",
+        action: () => insertText("**", "**", tx("texto en negrita", "bold text")),
+        title: tx("Negrita", "Bold"),
       },
       {
         icon: Italic,
-        action: () => insertText("*", "*", "texto en cursiva"),
-        title: "Cursiva",
+        action: () => insertText("*", "*", tx("texto en cursiva", "italic text")),
+        title: tx("Cursiva", "Italic"),
       },
       {
         icon: Heading1,
-        action: () => insertText("# ", "", "Título principal"),
-        title: "Título H1",
+        action: () => insertText("# ", "", tx("Título principal", "Main title")),
+        title: tx("Título H1", "H1 title"),
       },
       {
         icon: Heading2,
-        action: () => insertText("## ", "", "Subtítulo"),
-        title: "Título H2",
+        action: () => insertText("## ", "", tx("Subtítulo", "Subtitle")),
+        title: tx("Título H2", "H2 title"),
       },
       {
         icon: Heading3,
-        action: () => insertText("### ", "", "Título pequeño"),
-        title: "Título H3",
+        action: () => insertText("### ", "", tx("Título pequeño", "Small title")),
+        title: tx("Título H3", "H3 title"),
       },
       {
         icon: Link,
-        action: () => insertText("[", "](url)", "texto del enlace"),
-        title: "Enlace",
+        action: () => insertText("[", "](url)", tx("texto del enlace", "link text")),
+        title: tx("Enlace", "Link"),
       },
       {
         icon: Image,
-        action: () => insertText("![", "](url)", "descripción imagen"),
-        title: "Imagen",
+        action: () => insertText("![", "](url)", tx("descripción imagen", "image description")),
+        title: tx("Imagen", "Image"),
       },
       {
         icon: List,
-        action: () => insertText("* ", "", "elemento lista"),
-        title: "Lista",
+        action: () => insertText("* ", "", tx("elemento lista", "list item")),
+        title: tx("Lista", "List"),
       },
       {
         icon: ListOrdered,
-        action: () => insertText("1. ", "", "elemento numerado"),
-        title: "Lista numerada",
+        action: () => insertText("1. ", "", tx("elemento numerado", "numbered item")),
+        title: tx("Lista numerada", "Numbered list"),
       },
       {
         icon: Quote,
-        action: () => insertText("> ", "", "cita"),
-        title: "Cita",
+        action: () => insertText("> ", "", tx("cita", "quote")),
+        title: tx("Cita", "Quote"),
       },
       {
         icon: Code,
-        action: () => insertText("`", "`", "código"),
-        title: "Código",
+        action: () => insertText("`", "`", tx("código", "code")),
+        title: tx("Código", "Code"),
       },
     ];
 
     return (
-      <div className="w-full max-w-4xl mx-auto overflow-hidden bg-white rounded-lg shadow-lg dark:bg-background">
+      <div className="w-full max-w-4xl mx-auto overflow-hidden bg-white rounded-lg shadow-lg dark:border dark:border-slate-800 dark:bg-slate-900">
         <div className="border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center justify-between px-4 py-2">
             <div className="flex space-x-1">
@@ -189,7 +195,7 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
                 }`}
                 type="button"
               >
-                Escribir
+                {tx("Escribir", "Write")}
               </button>
               <button
                 onClick={() => setActiveTab("preview")}
@@ -200,15 +206,15 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
                 }`}
                 type="button"
               >
-                Vista previa
+                {tx("Vista previa", "Preview")}
               </button>
             </div>
             <div className="text-xs text-gray-500 dark:text-gray-400">
-              {value.length} caracteres
+              {value.length} {tx("caracteres", "characters")}
             </div>
           </div>
           {activeTab === "write" && (
-            <div className="flex flex-wrap gap-1 px-4 py-2 border-t bg-gray-50 dark:bg-muted">
+            <div className="flex flex-wrap gap-1 px-4 py-2 border-t bg-gray-50 dark:bg-slate-950 dark:border-slate-800">
               {toolbarButtons.map((button, index) => (
                 <button
                   key={index}
@@ -229,15 +235,18 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
               id="markdown-textarea"
               value={value}
               onChange={(e) => onChange(e.target.value)}
-              placeholder="Escribe tu mensaje usando Markdown...\n\nEjemplos:\n**texto en negrita**\n*texto en cursiva*\n# Título principal\n## Subtítulo\n[enlace](https://ejemplo.com)\n![imagen](https://ejemplo.com/imagen.jpg)\n* Lista con viñetas\n1. Lista numerada\n> Cita\n`código`"
-              className="w-full p-4 font-mono text-sm text-gray-900 bg-white border-0 resize-none h-96 focus:outline-none focus:ring-0 dark:bg-background dark:text-gray-100"
+              placeholder={tx(
+                "Escribe tu mensaje usando Markdown...\n\nEjemplos:\n**texto en negrita**\n*texto en cursiva*\n# Título principal\n## Subtítulo\n[enlace](https://ejemplo.com)\n![imagen](https://ejemplo.com/imagen.jpg)\n* Lista con viñetas\n1. Lista numerada\n> Cita\n`código`",
+                "Write your message using Markdown...\n\nExamples:\n**bold text**\n*italic text*\n# Main title\n## Subtitle\n[link](https://example.com)\n![image](https://example.com/image.jpg)\n* Bulleted list\n1. Numbered list\n> Quote\n`code`"
+              )}
+              className="w-full p-4 font-mono text-sm text-gray-900 bg-white border-0 resize-none h-96 focus:outline-none focus:ring-0 dark:bg-slate-950 dark:text-gray-100"
               style={{
                 fontFamily:
                   'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
               }}
             />
           ) : (
-            <div className="p-4 overflow-y-auto text-gray-900 h-96 bg-gray-50 dark:bg-muted dark:text-gray-100">
+            <div className="p-4 overflow-y-auto text-gray-900 h-96 bg-gray-50 dark:bg-slate-950 dark:text-gray-100">
               <div
                 className="prose-sm prose max-w-none"
                 dangerouslySetInnerHTML={{ __html: getPreviewHTML() }}
@@ -245,11 +254,13 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
             </div>
           )}
         </div>
-        <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-muted">
+        <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-950">
           <div className="flex items-center justify-between">
             <div className="text-xs text-gray-500 dark:text-gray-400">
-              Soporta Markdown: **negrita**, *cursiva*, [enlaces](url),
-              ![imágenes](url), listas, citas y más
+              {tx(
+                "Soporta Markdown: **negrita**, *cursiva*, [enlaces](url), ![imágenes](url), listas, citas y más",
+                "Supports Markdown: **bold**, *italic*, [links](url), ![images](url), lists, quotes, and more"
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
# feat(i18n): admin dashboard final sweep v3

## Resumen

Este PR cierra la tercera continuación del recorrido final de i18n ES/EN del menú administrador de Gym Master. El foco fue eliminar textos residuales mezclados en inglés/español, traducir contenido visible de combos y catálogos, mejorar consistencia de labels dinámicos y reforzar dark mode local en pantallas administrativas que todavía quedaban pendientes.

## Alcance funcional

Pantallas recorridas y corregidas:

- `/dashboard/mensajes-admin`
  - Bandeja de mensajes de socios.
  - Filtros, estados, panel de detalle y respuesta administrativa.
  - Dark mode local en cards, inputs, listado y panel derecho.

- `/dashboard/avisos`
  - Listado de avisos, acciones, buscador, modal de alta/edición y modal de detalle.
  - Editor Markdown: tabs, toolbar, placeholders, textos de ayuda y botones.
  - Dark mode local en tabla, modales y editor.

- `/dashboard/soporte-dragon-pyramid`
  - Mesa de ayuda interna Dragon Pyramid.
  - KPIs, lectura ejecutiva, formulario de ticket, listado, badges y panel de historial.
  - Traducción de combos de categoría, prioridad y estado/filtro.

- `/dashboard/respaldo-negocio`
  - Backup/export operativo.
  - Módulos exportables, historial reciente, badges y textos dinámicos de módulos.
  - Nota: la traducción interna de archivos Excel/JSON queda para el sweep específico de exportables.

- `/dashboard/usuarios`
  - Listado de usuarios, acciones, PDF/export, modal nuevo/editar y modal detalle.
  - Datos operativos de socio, datos laborales de empleado y permisos de menú.
  - Traducción de combos: rol, sexo, puestos, áreas, contratación, turnos y horarios.

- `/dashboard/gimnasio-parametrizacion`
  - Branding, datos legales, vista previa, Cloudinary, Stripe y textos legales.
  - Traducción de labels, placeholders, ayudas, estados y combos visibles.

- `/dashboard/parametrizacion`
  - Catálogos administrativos, descuento por pago adelantado y módulos relacionados.
  - Traducción de títulos, descripciones, chips, badges, registros y valores visibles.
  - Traducción de datos de presentación sin modificar valores persistidos ni lógica.

- `/dashboard/perfil`
  - Perfil personal, datos de cuenta, foto/cámara, accesos rápidos y recomendación de seguridad.
  - Traducción de roles, estados y textos auxiliares.

## Cambios técnicos

- Se aplicaron helpers de traducción local por pantalla cuando los textos venían de datos o catálogos ya persistidos.
- Se mantuvo el enfoque quirúrgico: cambios de presentación, labels, placeholders, botones, badges, tablas, modales y cards.
- Se reforzó dark mode únicamente en componentes/pantallas intervenidas.
- No se modificaron contratos de API, endpoints, DB, Swagger/OpenAPI, autenticación, RBAC, lógica de negocio ni cálculos.

## Fuera de alcance

- Traducción interna de PDFs, Excel, tickets, JSON exportados y otros artefactos generados.
- Traducción estructural de datos persistidos en base de datos mediante campos `*_en` o tablas de traducción.
- Cambios de endpoints, migraciones, seeds o Swagger/OpenAPI.
- Recorrido de pantallas exclusivas del socio.

## Validación sugerida

```bash
cd /e/gym-master-2026/sistema/gym-master

git status --short
rm -rf .next
npm run build

git checkout -- public/sw.js
rm -f public/fallback-*.js

git status --short
```

QA manual recomendado:

- Cambiar idioma ES/EN desde el selector global.
- Revisar light/dark mode en cada pantalla intervenida.
- Abrir modales de alta, edición y detalle donde corresponda.
- Verificar combos traducidos sin alterar el valor funcional enviado al backend.
- Revisar tablas, cards, badges, filtros, placeholders y textos vacíos.

## Próximo paso

Luego de mergear este PR, abrir una nueva rama desde `main` actualizado para comenzar el recorrido final del menú de socio:

```bash
git checkout main
git pull origin main
git checkout -b feature/i18n-es-en-socio-dashboard-final-sweep-v1
git push -u origin feature/i18n-es-en-socio-dashboard-final-sweep-v1
```
