### PR TITLE
Fix/rag coach admin socio selector v1

### DIFF
--- a/README_FIX_RAG_COACH_ADMIN_SOCIO_SELECTOR_I18N_V2.md
+++ b/README_FIX_RAG_COACH_ADMIN_SOCIO_SELECTOR_I18N_V2.md
@@ -1,0 +1,26 @@
+# Fix RAG Coach admin socio selector i18n v2
+
+## Objetivo
+Corregir textos residuales en español/mix ES-EN dentro del selector de socio del Coach IA cuando la interfaz está en inglés.
+
+## Archivo modificado
+- `src/app/dashboard/coach/page.tsx`
+
+## Cambios
+- Agrega lectura de `locale` mediante `useI18n` en la pantalla del Coach IA.
+- Traduce ES/EN el bloque administrativo de selección de socio:
+  - Socio operativo del Coach IA / Operational member for AI Coach
+  - Como administrador... / As an administrator...
+  - Buscar socio... / Search member...
+  - Seleccionar socio... / Select a member...
+  - Sin socio seleccionado / No member selected
+  - Sin selección... / Without a selected member...
+  - Limpiar selección / Clear selection
+- Traduce también textos del hero y contadores superiores para evitar mezclas visibles.
+
+## Alcance
+- No toca DB.
+- No agrega endpoints.
+- No modifica Swagger/OpenAPI.
+- No cambia la lógica de selección de socio ni la generación de dietas/rutinas/evolución.
+- Mantiene el comportamiento seguro: admin sin socio seleccionado no ejecuta acciones automáticas.

--- a/README_FIX_RAG_COACH_ADMIN_SOCIO_SELECTOR_V1.md
+++ b/README_FIX_RAG_COACH_ADMIN_SOCIO_SELECTOR_V1.md
@@ -1,0 +1,42 @@
+# Fix RAG Coach admin socio selector v1
+
+## Objetivo
+
+Corregir el uso del Coach IA desde una sesión de administrador cuando se intenta generar dieta, rutina o análisis físico sin un `id_socio` real.
+
+## Problema detectado
+
+El Coach IA necesita un UUID real de socio para guardar dietas, rutinas o análisis en los módulos del socio. Cuando el administrador usa `/dashboard/coach` sin contexto de socio, el backend bloquea correctamente las acciones automáticas para evitar usar identificadores inválidos como `me`.
+
+## Cambios incluidos
+
+- Agrega selector/buscador de socio en `/dashboard/coach` solo para sesiones admin.
+- Carga socios desde `/api/socios` usando el cliente browser existente `fetchSociosApi`.
+- Permite buscar por nombre, DNI, email o teléfono.
+- Envía `socio_id` real al endpoint `/api/rag/coach/chat` cuando el admin selecciona un socio.
+- Mantiene el comportamiento de socio logueado: usa `user.id_socio` como antes.
+- Si admin no selecciona socio, conserva el bloqueo seguro y orientación general.
+- Ajusta el mensaje del backend para indicar que el admin debe seleccionar un socio en el Coach IA.
+
+## Archivos modificados
+
+- `src/app/dashboard/coach/page.tsx`
+- `src/services/server/ragCoachUnifiedChatService.ts`
+
+## Fuera de alcance
+
+- No cambia DB.
+- No agrega endpoints.
+- No modifica Swagger/OpenAPI.
+- No cambia la lógica de generación cuando hay `id_socio` válido.
+- No toca RLS/RBAC.
+
+## Validación sugerida
+
+1. Login admin.
+2. Abrir `/dashboard/coach`.
+3. Seleccionar un socio real desde el panel "Socio operativo del Coach IA".
+4. Pedir: `Quiero una dieta para bajar grasa sin perder músculo`.
+5. Confirmar que no aparece `invalid input syntax for type uuid: "me"`.
+6. Confirmar que el backend recibe un `socio_id` UUID real.
+7. Login socio directo y confirmar que `/dashboard/coach` sigue funcionando sin selector admin.

--- a/README_FIX_RAG_COACH_SOCIO_ID_RESOLUTION_V1.md
+++ b/README_FIX_RAG_COACH_SOCIO_ID_RESOLUTION_V1.md
@@ -1,0 +1,57 @@
+# FIX_RAG_COACH_SOCIO_ID_RESOLUTION_V1
+
+## Objetivo
+
+Corregir el error del Coach IA unificado cuando intenta generar dieta/rutina/evolución con `socio_id: "me"` o sin un `id_socio` real.
+
+## Problema detectado
+
+El frontend enviaba `socio_id: user?.id_socio || 'me'`.
+
+Cuando el usuario no tenía `id_socio` en sesión o estaba operando como administrador sin socio seleccionado, el backend terminaba usando `"me"` como identificador real y fallaba al guardar dieta:
+
+```text
+Error al generar la dieta: invalid input syntax for type uuid: "me"
+```
+
+También aparecía:
+
+```text
+Debe indicar un socio real para construir contexto.
+```
+
+## Cambios incluidos
+
+- El frontend deja de enviar `"me"` como fallback.
+- El backend valida UUID antes de aceptar un `socio_id`.
+- Si el JWT de socio no trae `id_socio`, el backend intenta resolverlo por `usuario_id` en tabla `socio`.
+- Si no hay socio real y el usuario es admin, bloquea la automatización y devuelve orientación segura en vez de intentar insertar con un UUID inválido.
+- Se mantiene la respuesta HTTP 200 del Coach IA, pero la acción vuelve como `guidance_only` y explica qué falta.
+
+## Archivos modificados
+
+- `src/app/dashboard/coach/page.tsx`
+- `src/services/server/ragCoachUnifiedChatService.ts`
+
+## No cambia
+
+- DB
+- migraciones
+- endpoints nuevos
+- Swagger/OpenAPI
+- generación real de dietas cuando hay `id_socio` válido
+- generación real de rutinas cuando hay `id_socio` válido
+- análisis RAG cuando hay `id_socio` válido
+
+## Validación sugerida
+
+```bash
+rm -rf .next
+npm run build
+```
+
+Luego probar:
+
+1. Socio logueado con `id_socio` válido: generar dieta debe funcionar.
+2. Socio con token viejo/incompleto: debe resolver por `usuario_id` si existe vínculo.
+3. Admin sin socio seleccionado: no debe aparecer `invalid input syntax for type uuid: "me"`; debe devolver mensaje seguro indicando que falta socio real.

--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -24,6 +24,7 @@ import {
   ShieldCheck,
   Sparkles,
   UserRound,
+  Users,
 } from 'lucide-react';
 
 import { AppFooter } from '@/components/footer/AppFooter';
@@ -39,8 +40,11 @@ import type {
   RagCoachContextSnapshot,
   RagCoachConversationMemory,
 } from '@/interfaces/ragCoachChat.interface';
+import type { Socio } from '@/interfaces/socio.interface';
 import { enviarMensajeCoachIa } from '@/services/ragCoachChatClient';
+import { fetchSociosApi } from '@/services/browser/socioApiClient';
 import { useAuthStore } from '@/stores/authStore';
+import { useI18n } from '@/i18n/I18nProvider';
 
 type ChatMessage = {
   id: string;
@@ -93,6 +97,42 @@ function createId() {
 
 function getDisplayName(user?: { nombre?: string | null; email?: string | null } | null) {
   return user?.nombre?.trim() || user?.email?.trim() || 'socio';
+}
+
+function normalizeRole(value?: string | null) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s-]+/g, '_');
+}
+
+function isAdminUserRole(value?: string | null) {
+  const normalized = normalizeRole(value);
+  return ['admin', 'administrador', 'administrator'].includes(normalized);
+}
+
+function coachTx(locale: string, es: string, en: string) {
+  return locale === 'en' ? en : es;
+}
+
+function normalizeSearchText(value?: string | null) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+function socioOptionLabel(socio: Socio) {
+  const name = socio.nombre_completo?.trim() || 'Socio sin nombre';
+  const dni = socio.dni?.trim();
+  const email = socio.email?.trim();
+  return [name, dni ? `DNI ${dni}` : null, email].filter(Boolean).join(' · ');
+}
+
+function shortSocioLabel(socio?: Socio | null) {
+  if (!socio) return '';
+  return socio.nombre_completo?.trim() || socio.email?.trim() || socio.id_socio;
 }
 
 function actionLinkLabel(action: RagCoachChatActionResult) {
@@ -306,16 +346,52 @@ function renderAction(action: RagCoachChatActionResult) {
 export default function CoachIaPage() {
   const router = useRouter();
   const { user, isAuthenticated, initializeAuth, isInitialized } = useAuthStore();
+  const { locale } = useI18n();
+  const c = (es: string, en: string) => coachTx(locale, es, en);
   const displayName = useMemo(() => getDisplayName(user), [user]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [socios, setSocios] = useState<Socio[]>([]);
+  const [sociosLoading, setSociosLoading] = useState(false);
+  const [sociosError, setSociosError] = useState<string | null>(null);
+  const [selectedSocioId, setSelectedSocioId] = useState('');
+  const [socioSearch, setSocioSearch] = useState('');
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const totalAssistantMessages = messages.filter((message) => message.role === 'assistant').length;
   const totalActionMessages = messages.reduce((total, message) => total + (message.actions?.filter((action) => action.ok).length ?? 0), 0);
   const hasRagSources = messages.some((message) => hasSources(message.actions));
   const latestContextMessage = useMemo(() => getLatestContextMessage(messages), [messages]);
   const latestContextSnapshot = latestContextMessage?.contextSnapshot;
+  const isAdminSession = useMemo(
+    () => isAdminUserRole((user as any)?.rol || (user as any)?.role),
+    [user],
+  );
+  const filteredSocios = useMemo(() => {
+    const search = normalizeSearchText(socioSearch);
+    const ordered = [...socios].sort((a, b) => {
+      if (a.activo !== b.activo) return a.activo ? -1 : 1;
+      return (a.nombre_completo ?? '').localeCompare(b.nombre_completo ?? '', 'es');
+    });
+
+    if (!search) return ordered.slice(0, 80);
+
+    return ordered
+      .filter((socio) => {
+        const haystack = normalizeSearchText([
+          socio.nombre_completo,
+          socio.dni,
+          socio.email,
+          socio.telefono,
+        ].filter(Boolean).join(' '));
+        return haystack.includes(search);
+      })
+      .slice(0, 80);
+  }, [socioSearch, socios]);
+  const selectedSocio = useMemo(
+    () => socios.find((socio) => socio.id_socio === selectedSocioId) ?? null,
+    [selectedSocioId, socios],
+  );
 
   useEffect(() => {
     initializeAuth();
@@ -328,13 +404,38 @@ export default function CoachIaPage() {
   }, [isAuthenticated, isInitialized, router]);
 
   useEffect(() => {
+    if (!isInitialized || !isAuthenticated || !isAdminSession) return;
+
+    let isMounted = true;
+    setSociosLoading(true);
+    setSociosError(null);
+
+    fetchSociosApi()
+      .then((rows) => {
+        if (!isMounted) return;
+        setSocios(rows ?? []);
+      })
+      .catch((error) => {
+        if (!isMounted) return;
+        setSociosError(error instanceof Error ? error.message : 'No se pudo cargar el listado de socios.');
+      })
+      .finally(() => {
+        if (isMounted) setSociosLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isAdminSession, isAuthenticated, isInitialized]);
+
+  useEffect(() => {
     if (!isInitialized || !isAuthenticated || messages.length > 0) return;
 
     setMessages([
       {
         id: createId(),
         role: 'assistant',
-        content: `Hola, ${displayName}. Soy tu Coach IA de Gym Master. Puedo ayudarte con rutinas, dietas y evolución física usando tu contexto del gimnasio cuando esté disponible.`,
+        content: `Hola, ${displayName}. Soy tu Coach IA de Gym Master. Puedo ayudarte con rutinas, dietas y evolución física usando el contexto del socio cuando esté disponible.`,
         suggestedReplies: quickPrompts,
         nextBestStep: 'Contame tu objetivo, disponibilidad semanal, nivel y restricciones.',
       },
@@ -374,9 +475,13 @@ export default function CoachIaPage() {
     setMessages((current) => [...current, userMessage]);
 
     try {
+      const effectiveSocioId = isAdminSession
+        ? selectedSocioId || undefined
+        : user?.id_socio || undefined;
+
       const res = await enviarMensajeCoachIa({
         message,
-        socio_id: user?.id_socio || 'me',
+        socio_id: effectiveSocioId,
         conversationContext: buildConversationMemory(messages, userMessage),
       });
 
@@ -433,7 +538,7 @@ export default function CoachIaPage() {
       {
         id: createId(),
         role: 'assistant',
-        content: `Conversación reiniciada, ${displayName}. Contame qué objetivo querés trabajar ahora.`,
+        content: `Conversación reiniciada, ${displayName}. Contame qué objetivo querés trabajar ahora${selectedSocio ? ` para ${shortSocioLabel(selectedSocio)}` : ''}.`,
         suggestedReplies: quickPrompts,
         nextBestStep: 'Elegí una sugerencia o escribí tu consulta completa.',
       },
@@ -445,7 +550,7 @@ export default function CoachIaPage() {
       <div className="flex h-[100dvh] w-full overflow-hidden bg-slate-50 dark:bg-slate-950">
         <AppSidebar />
         <SidebarInset className="h-[100dvh] overflow-hidden bg-slate-50 dark:bg-slate-950">
-          <AppHeader title="Coach IA" />
+          <AppHeader title={c("Coach IA", "AI Coach")} />
           <section className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-6">
             <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 pb-4">
               <div className="overflow-hidden rounded-3xl border border-cyan-100 bg-gradient-to-br from-slate-950 via-slate-900 to-cyan-950 p-5 text-white shadow-xl dark:border-cyan-500/20 sm:p-6">
@@ -453,32 +558,101 @@ export default function CoachIaPage() {
                   <div className="max-w-3xl">
                     <div className="inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold text-cyan-100">
                       <Brain className="h-3.5 w-3.5" />
-                      RAG Coach contextual memory
+                      {c("RAG Coach con memoria contextual", "RAG Coach contextual memory")}
                     </div>
                     <h1 className="mt-4 text-2xl font-black tracking-tight sm:text-4xl">
-                      Coach IA con memoria contextual del socio
+                      {c("Coach IA con memoria contextual del socio", "AI Coach with member contextual memory")}
                     </h1>
                     <p className="mt-3 max-w-2xl text-sm leading-relaxed text-slate-300 sm:text-base">
-                      Consultá rutinas, dietas y evolución física con continuidad conversacional, contexto operativo y recomendaciones más personalizadas.
+                      {c("Consultá rutinas, dietas y evolución física con continuidad conversacional, contexto operativo y recomendaciones más personalizadas.", "Consult routines, diets and physical evolution with conversational continuity, operational context and more personalized recommendations.")}
                     </p>
                   </div>
 
                   <div className="grid grid-cols-3 gap-2 sm:min-w-[360px]">
                     <div className="rounded-2xl border border-white/10 bg-white/10 p-3 text-center backdrop-blur">
                       <div className="text-2xl font-black">{totalAssistantMessages}</div>
-                      <div className="text-[11px] text-slate-300">respuestas</div>
+                      <div className="text-[11px] text-slate-300">{c("respuestas", "responses")}</div>
                     </div>
                     <div className="rounded-2xl border border-white/10 bg-white/10 p-3 text-center backdrop-blur">
                       <div className="text-2xl font-black">{totalActionMessages}</div>
-                      <div className="text-[11px] text-slate-300">acciones</div>
+                      <div className="text-[11px] text-slate-300">{c("acciones", "actions")}</div>
                     </div>
                     <div className="rounded-2xl border border-white/10 bg-white/10 p-3 text-center backdrop-blur">
-                      <div className="text-2xl font-black">{hasRagSources ? 'Sí' : '—'}</div>
-                      <div className="text-[11px] text-slate-300">fuentes</div>
+                      <div className="text-2xl font-black">{hasRagSources ? c('Sí', 'Yes') : '—'}</div>
+                      <div className="text-[11px] text-slate-300">{c("fuentes", "sources")}</div>
                     </div>
                   </div>
                 </div>
               </div>
+
+              {isAdminSession && (
+                <Card className="rounded-3xl border-cyan-100 bg-white shadow-sm dark:border-cyan-500/20 dark:bg-slate-900">
+                  <CardContent className="p-4 sm:p-5">
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-2 flex items-center gap-2 text-sm font-bold text-slate-950 dark:text-white">
+                          <Users className="h-4 w-4 text-[#02a8e1]" />
+                          {c("Socio operativo del Coach IA", "Operational member for AI Coach")}
+                        </div>
+                        <p className="mb-3 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                          {c("Como administrador, seleccioná un socio real antes de generar dietas, rutinas o análisis. El Coach enviará ese id_socio válido al backend.", "As an administrator, select a real member before generating diets, routines or analyses. The Coach will send that valid id_socio to the backend.")}
+                        </p>
+                        <div className="grid gap-2 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+                          <input
+                            value={socioSearch}
+                            onChange={(event) => setSocioSearch(event.target.value)}
+                            placeholder={c("Buscar socio por nombre, DNI o email...", "Search member by name, ID or email...")}
+                            className="h-11 rounded-2xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-[#02a8e1] focus:ring-2 focus:ring-cyan-100 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:focus:ring-cyan-500/20"
+                          />
+                          <select
+                            value={selectedSocioId}
+                            onChange={(event) => setSelectedSocioId(event.target.value)}
+                            disabled={sociosLoading || filteredSocios.length === 0}
+                            className="h-11 rounded-2xl border border-slate-200 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-[#02a8e1] focus:ring-2 focus:ring-cyan-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:focus:ring-cyan-500/20"
+                          >
+                            <option value="">
+                              {sociosLoading ? c('Cargando socios...', 'Loading members...') : c('Seleccionar socio para acciones automáticas', 'Select a member for automatic actions')}
+                            </option>
+                            {filteredSocios.map((socio) => (
+                              <option key={socio.id_socio} value={socio.id_socio}>
+                                {socioOptionLabel(socio)}{socio.activo ? '' : c(' · Inactivo', ' · Inactive')}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        {sociosError && (
+                          <p className="mt-2 text-xs font-medium text-rose-600 dark:text-rose-300">
+                            {sociosError}
+                          </p>
+                        )}
+                      </div>
+
+                      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-300 lg:min-w-[280px]">
+                        <div className="font-semibold text-slate-950 dark:text-white">
+                          {selectedSocio ? shortSocioLabel(selectedSocio) : c('Sin socio seleccionado', 'No member selected')}
+                        </div>
+                        <div className="mt-1 leading-relaxed">
+                          {selectedSocio
+                            ? c('Las próximas respuestas podrán generar y guardar datos en módulos del socio seleccionado.', 'The next responses can generate and save data in the selected member modules.')
+                            : c('Sin selección, el Coach solo dará orientación general segura y bloqueará acciones automáticas.', 'Without a selected member, the Coach will only provide safe general guidance and block automatic actions.')}
+                        </div>
+                        {selectedSocioId && (
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="mt-3 h-8 rounded-xl text-xs dark:border-slate-700 dark:bg-slate-900"
+                            onClick={() => setSelectedSocioId('')}
+                            disabled={loading}
+                          >
+                            {c("Limpiar selección", "Clear selection")}
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
 
               <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
                 <Card className="flex min-h-[70dvh] flex-col overflow-hidden rounded-3xl border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">

--- a/src/services/server/ragCoachUnifiedChatService.ts
+++ b/src/services/server/ragCoachUnifiedChatService.ts
@@ -15,6 +15,7 @@ import { findAllEvolucionesSocioByIdSocio } from '@/services/evolucionSocioServi
 import { buildRutinasRagContext } from './ragRutinasCoachService';
 import { buildDietasRagContext } from './ragDietasCoachService';
 import { analyzeEvolucionFisicaWithRag } from './ragEvolucionFisicaCoachService';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 import { buildRagCoachSocioContext, type RagCoachSocioContext } from './ragCoachSocioContextService';
 
 const MAX_MESSAGE_LENGTH = 1600;
@@ -43,10 +44,40 @@ function isAdminRole(role?: string | null) {
   return normalized === 'admin' || normalized === 'administrador';
 }
 
-function resolveSocioId(user: JwtUser, requested?: string | null) {
+function isValidUuid(value?: string | null): value is string {
+  if (typeof value !== 'string') return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+async function resolveSocioId(user: JwtUser, requested?: string | null) {
   const cleanRequested = cleanText(requested);
-  if (cleanRequested && cleanRequested !== 'me') return cleanRequested;
-  return user.id_socio || '';
+
+  if (isValidUuid(cleanRequested)) {
+    return cleanRequested.trim();
+  }
+
+  if (isValidUuid(user.id_socio)) {
+    return user.id_socio.trim();
+  }
+
+  if (!isAdminRole(user.rol) && isValidUuid(user.id)) {
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase
+      .from('socio')
+      .select('id_socio')
+      .eq('usuario_id', user.id)
+      .maybeSingle();
+
+    if (error) {
+      console.warn('No se pudo resolver id_socio para Coach IA:', error.message);
+    }
+
+    if (isValidUuid(data?.id_socio)) {
+      return data.id_socio.trim();
+    }
+  }
+
+  return '';
 }
 
 function getDisplayName(user: JwtUser) {
@@ -664,28 +695,28 @@ export async function handleUnifiedRagCoachChat(
 
   const name = getDisplayName(user);
   const greeting = `Hola, ${name}, ¿en qué te puedo ayudar?`;
-  const socioId = resolveSocioId(user, payload.socio_id);
+  const effectiveSocioId = await resolveSocioId(user, payload.socio_id);
+  const hasResolvedSocio = Boolean(effectiveSocioId);
 
-  if (!socioId && !isAdminRole(user.rol)) {
+  if (!hasResolvedSocio && !isAdminRole(user.rol)) {
     throw new Error('No se pudo identificar el socio autenticado.');
   }
 
-  const effectiveSocioId = socioId || cleanText(payload.socio_id);
-  if (!effectiveSocioId) {
-    throw new Error('Debe indicar un socio para usar el Coach IA.');
-  }
-
-  const socioContext = await buildRagCoachSocioContext(user, effectiveSocioId).catch((error) => {
-    console.warn('No se pudo construir contexto del socio para el Coach IA:', error);
-    return null;
-  });
+  const socioContext = hasResolvedSocio
+    ? await buildRagCoachSocioContext(user, effectiveSocioId).catch((error) => {
+        console.warn('No se pudo construir contexto del socio para el Coach IA:', error);
+        return null;
+      })
+    : null;
 
   const conversationMemory = sanitizeConversationMemory(payload.conversationContext);
   const detectedIntent = detectIntent(message);
   const intent = resolveIntentWithMemory(message, detectedIntent, conversationMemory);
   const memoryTrace = buildMemoryTrace(conversationMemory, intent, socioContext);
   const safetyNotes = buildSafetyNotes(message, intent, socioContext);
-  const evolutionSuggestion = await getEvolutionSuggestion(user, effectiveSocioId, socioContext);
+  const evolutionSuggestion = hasResolvedSocio
+    ? await getEvolutionSuggestion(user, effectiveSocioId, socioContext)
+    : 'Para generar dietas, rutinas o análisis automáticos necesito un socio real asociado a la sesión o seleccionado por administración.';
   const contextLine = getContextCoachLine(socioContext);
   const coachNotes: string[] = [];
   const suggestedReplies: string[] = [];
@@ -770,6 +801,53 @@ export async function handleUnifiedRagCoachChat(
       contextSummary: socioContext?.resumenHumano,
       contextHints: socioContext?.hints,
       nextBestStep: 'Derivar a orientación nutricional profesional antes de generar una dieta automática.',
+      safetySummary: safetyNotes.join(' '),
+      qaSummary: buildQaSummary([action]),
+      contextSnapshot: socioContext?.contextSnapshot,
+      memoryHighlights: socioContext?.memoryHighlights,
+      memoryTrace,
+      contextConfidence: buildContextConfidence(socioContext),
+    };
+  }
+
+  if (!hasResolvedSocio && (
+    intent === 'routine_request' ||
+    intent === 'diet_request' ||
+    intent === 'routine_and_diet_request' ||
+    intent === 'evolution_analysis_request'
+  )) {
+    const action: RagCoachChatActionResult = {
+      type: 'guidance_only',
+      ok: true,
+      title: 'Socio no identificado',
+      message: 'No ejecuté acciones automáticas porque no recibí un id_socio real. Así evitamos crear rutinas, dietas o consultas con un identificador inválido.',
+      safetyNotes,
+      qualityAudit: buildQualityAudit({
+        domain: 'orientacion',
+        message,
+        context: socioContext,
+        safetyNotes,
+        blocked: true,
+      }),
+    };
+
+    return {
+      greeting,
+      intent: 'general_guidance',
+      reply: [
+        `${name}, entendí tu pedido, pero no puedo generar una dieta, rutina o análisis automático sin identificar un socio real.`,
+        isAdminRole(user.rol)
+          ? 'Estás operando como administrador: seleccioná un socio real en el Coach IA o enviá la solicitud con un id_socio válido.'
+          : 'Tu sesión no trajo id_socio válido. Cerrá sesión y volvé a ingresar para refrescar el token; si persiste, revisá que tu usuario esté vinculado a un socio.',
+        'Puedo darte orientación general segura mientras tanto, pero no voy a guardar datos en módulos del socio sin ese vínculo.',
+      ].join('\n\n'),
+      actions: [action],
+      suggestedReplies: ['Quiero orientación general', 'Voy a seleccionar un socio'],
+      missingParams: ['id_socio'],
+      coachNotes: [...coachNotes, 'Se bloqueó automatización porque no hay id_socio real resuelto.'],
+      contextSummary: socioContext?.resumenHumano,
+      contextHints: socioContext?.hints,
+      nextBestStep: 'Seleccionar un socio real en el Coach IA o refrescar sesión de socio antes de generar dieta/rutina.',
       safetySummary: safetyNotes.join(' '),
       qaSummary: buildQaSummary([action]),
       contextSnapshot: socioContext?.contextSnapshot,


### PR DESCRIPTION
# fix(rag): add admin member selector for AI Coach context

## Branch

`fix/rag-coach-admin-socio-selector-v1`

## Context

The AI Coach was designed mainly for logged-in members, but it is also accessible from admin sessions. When an administrator used `/dashboard/coach` without a real member context, the flow could send `socio_id: "me"` or no valid member UUID to the backend. That produced failures when the backend attempted to generate and persist automatic member artifacts such as routines, diets or physical evolution analysis.

Observed error:

```text
invalid input syntax for type uuid: "me"
```

## Summary

This hotfix adds a safe admin flow for AI Coach operations:

- Adds an admin-only member selector/search block in `/dashboard/coach`.
- Sends a real member UUID (`socio_id`) to the backend when the admin selects a member.
- Keeps automatic generation blocked when an admin has not selected a member.
- Preserves safe general guidance when no member context exists.
- Localizes the new admin selector block in Spanish and English.
- Keeps the existing member flow unchanged when a real member is logged in.

## Main changes

### `/dashboard/coach`

- Added operational member context for admin sessions.
- Added member search/select UI for automatic Coach actions.
- Added localized labels, descriptions and empty-selection state.
- Prevents accidental automatic actions without a valid member context.

### Server-side Coach flow

- Hardened validation around `socio_id`.
- Avoids treating `"me"` as a PostgreSQL UUID.
- Keeps safe fallback behavior when no real member can be resolved.

## Expected behavior

### Admin without selected member

The Coach should not generate or persist diet/routine/evolution records. It should return safe guidance and explain that a real member must be selected.

### Admin with selected member

The Coach should use the selected member UUID and allow automatic actions such as routine, diet or evolution analysis generation.

### Logged-in member

The Coach should continue using the member's own context without requiring the admin selector.

## Files changed

```text
src/app/dashboard/coach/page.tsx
src/services/server/ragCoachUnifiedChatService.ts
README_FIX_RAG_COACH_SOCIO_ID_RESOLUTION_V1.md
README_FIX_RAG_COACH_ADMIN_SOCIO_SELECTOR_V1.md
README_FIX_RAG_COACH_ADMIN_SOCIO_SELECTOR_I18N_V2.md
```

## What was not changed

- No database schema changes.
- No new API routes.
- No Swagger/OpenAPI changes.
- No changes to Supabase RLS/RBAC policies.
- No changes to the generation logic when a valid member UUID is already available.

## Validation checklist

Run before merge:

```bash
cd /e/gym-master-2026/sistema/gym-master

git status --short
rm -rf .next
npm run build

git checkout -- public/sw.js
rm -f public/fallback-*.js

git status --short
```

Manual QA:

- [ ] Open `/dashboard/coach` as admin.
- [ ] Confirm the admin member selector appears.
- [ ] Ask for a diet/routine without selecting a member and confirm safe fallback.
- [ ] Select a real member and ask for a routine.
- [ ] Confirm no `invalid input syntax for type uuid: "me"` error appears.
- [ ] Confirm the generated routine/diet/evolution action uses the selected member context.
- [ ] Switch UI to Spanish and English and confirm the new selector texts do not mix languages.
- [ ] Open `/dashboard/coach` as a member and confirm the normal member flow still works.

## Rollback

If needed, revert the PR commit or restore the touched files from `main`.

## Follow-up work

After this hotfix is merged, continue with:

```text
feature/i18n-es-en-exportables-final-sweep-v1
```

Later planned feature:

```text
feature/i18n-ai-generated-content-language-governance-v1
```

That feature will govern the language of AI-generated routines, diets, evolution analysis, QA notes, contextual memory, safety messages and core preloaded catalogs.
