### PR TITLE
feat(i18n): add core seeds governance v1

### DIFF
--- a/docs/i18n/i18n-core-seeds-governance-v1.md
+++ b/docs/i18n/i18n-core-seeds-governance-v1.md
@@ -1,0 +1,57 @@
+# I18N core seeds governance v1
+
+## Objetivo
+
+Centralizar la gobernanza de traducciones ES/EN para datos core precargados por Gym Master sin traducir datos propios cargados por cada gimnasio.
+
+## Auditoría realizada con repo ZIP y dump local 2026-07-21
+
+Tablas core globales detectadas:
+
+- `objetivo`: 10 registros, sin columnas `nombre_en`/`descripcion_en`.
+- `nivel`: 3 registros, sin columnas `nombre_en`/`descripcion_en`.
+- `dia`: 6 registros, sin columnas `nombre_en`/`descripcion_en`.
+- `grupo_muscular`: 15 registros, sin columnas `nombre_en`/`descripcion_en`.
+- `comida_base`: 28 registros, sin columnas EN.
+- `rutina_generacion_regla`: 30 registros, sin columnas EN.
+- `ejercicio`: 979 registros, ya contiene `nombre_en` completo; `descripcion_en` y media EN tienen cobertura parcial.
+
+Catálogos parametrizables detectados con `codigo`, `nombre`, `descripcion` pero sin columnas EN:
+
+- `medio_pago`, `tipo_gasto`, `tipo_ingreso`, `categoria_producto`.
+- `tipo_equipamiento`, `ubicacion_equipamiento`, `ubicacion_gimnasio`, `tipo_mantenimiento`.
+- `tipo_empleado`, `empleado_tipo_contratacion`, `empleado_puesto_responsabilidad`, `empleado_area`, `empleado_turno`, `empleado_horario_disponibilidad`.
+- `comercial_canal_venta`, `comercial_grupo_cliente`, `comercial_ubicacion_stock`.
+- `infraestructura_categoria_activo`, `infraestructura_sector`, `infraestructura_checklist_template`, `infraestructura_checklist_item`.
+
+## Decisión técnica de esta etapa
+
+Esta primera etapa implementa una capa de presentación centralizada en `src/utils/coreSeedI18n.ts`.
+
+Reglas:
+
+1. Datos core conocidos por Gym Master pueden mostrarse en ES/EN.
+2. Datos propios del gimnasio no se traducen automáticamente.
+3. Para catálogos editables, la traducción por ahora solo aplica si el `codigo` coincide con un seed conocido.
+4. Si el código o texto no está reconocido, se devuelve el valor original.
+5. No se agregan migraciones ni columnas nuevas en esta etapa.
+
+## Archivos modificados
+
+- `src/utils/coreSeedI18n.ts`: helper central ES/EN para core seeds.
+- `src/utils/dietaI18nPresentation.ts`: pasa a delegar en el helper central.
+- `src/components/forms/RutinasForm.tsx`: elimina mapas locales duplicados de objetivos/niveles.
+- `src/app/dashboard/rutinas/page.tsx`: elimina mapa local duplicado de filtros.
+- `src/utils/rutinaPdf.ts`: usa helper central para días, grupos musculares y nombres de rutina.
+
+## Fuera de alcance
+
+- No modifica DB.
+- No modifica endpoints.
+- No modifica Swagger/OpenAPI.
+- No traduce productos, servicios ni textos propios creados por el gimnasio.
+- No cambia generación IA/RAG; eso queda para `feature/i18n-ai-generated-content-language-governance-v1`.
+
+## Próxima etapa recomendada
+
+Implementar `feature/i18n-ai-generated-content-language-governance-v1` o una segunda pasada de esta feature para mapear catálogos parametrizables en pantallas específicas usando `translateCoreCatalogName` y `translateCoreCatalogDescription` donde corresponda.

--- a/src/app/dashboard/rutinas/page.tsx
+++ b/src/app/dashboard/rutinas/page.tsx
@@ -14,6 +14,7 @@ import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { toast } from "sonner";
 import { useI18n } from "@/i18n/I18nProvider";
+import { translateCoreLevel, translateCoreObjective } from "@/utils/coreSeedI18n";
 import RutinaModal from "@/components/modal/RutinaModal";
 import {
   Popover,
@@ -37,29 +38,14 @@ interface RutinaDisplayData {
   creado_en: string;
 }
 
-const ROUTINE_FILTER_LABEL_EN: Record<string, string> = {
-  inicial: "Beginner",
-  intermedio: "Intermediate",
-  avanzado: "Advanced",
-  definicion: "Definition",
-  volumen: "Volume",
-  fuerza: "Strength",
-  resistencia: "Endurance",
-  bajar_de_peso: "Lose weight",
-  perder_peso: "Lose weight",
-};
-
-const normalizeRoutineFilterLabel = (value: string): string =>
-  value
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
-
 const translateRoutineFilterLabel = (value: string, isEnglish: boolean): string => {
-  if (!isEnglish) return value;
-  return ROUTINE_FILTER_LABEL_EN[normalizeRoutineFilterLabel(value)] ?? value;
+  const translatedLevel = translateCoreLevel(value, isEnglish);
+  if (translatedLevel !== value) return translatedLevel;
+
+  const translatedObjective = translateCoreObjective(value, isEnglish);
+  if (translatedObjective !== value) return translatedObjective;
+
+  return value;
 };
 
 export default function RutinasPage() {

--- a/src/components/forms/RutinasForm.tsx
+++ b/src/components/forms/RutinasForm.tsx
@@ -16,6 +16,7 @@ import { Nivel } from "@/interfaces/niveles.interface";
 import { toast } from "sonner";
 import { generarNuevaRutina } from "@/services/apiClient";
 import { useI18n } from "@/i18n/I18nProvider";
+import { translateCoreLevel, translateCoreObjective } from "@/utils/coreSeedI18n";
 
 export interface RutinaFormValues {
   objetivo: string;
@@ -44,48 +45,9 @@ export default function RutinasForm({
   const isEnglish = locale === "en";
   const tx = (es: string, en: string) => (isEnglish ? en : es);
 
-  const translateObjective = (value?: string | null) => {
-    const label = String(value ?? "").trim();
-    const normalized = label.toLowerCase();
-    const map: Record<string, string> = {
-      fuerza: "Strength",
-      hipertrofia: "Hypertrophy",
-      resistencia: "Endurance",
-      tonificacion: "Toning",
-      tonificación: "Toning",
-      adelgazar: "Weight loss",
-      "perder peso": "Weight loss",
-      "ganar masa muscular": "Muscle gain",
-      mantenimiento: "Maintenance",
-      rehabilitacion: "Rehabilitation",
-      rehabilitación: "Rehabilitation",
-      "rehabilitación física": "Physical rehabilitation",
-      "rehabilitacion fisica": "Physical rehabilitation",
-      "salud general": "General health",
-      "preparación para competencia": "Competition preparation",
-      "preparacion para competencia": "Competition preparation",
-      "condición física postparto": "Postpartum physical conditioning",
-      "condicion fisica postparto": "Postpartum physical conditioning",
-      "condición physical postpartum": "Postpartum physical conditioning",
-      "condicion physical postpartum": "Postpartum physical conditioning",
-      "control del estrés": "Stress management",
-      "control del estres": "Stress management",
-    };
-    return isEnglish ? map[normalized] ?? label : label;
-  };
+  const translateObjective = (value?: string | null) => translateCoreObjective(value, isEnglish);
 
-  const translateLevel = (value?: string | null) => {
-    const label = String(value ?? "").trim();
-    const normalized = label.toLowerCase();
-    const map: Record<string, string> = {
-      principiante: "Beginner",
-      inicial: "Beginner",
-      intermedio: "Intermediate",
-      avanzado: "Advanced",
-      experto: "Expert",
-    };
-    return isEnglish ? map[normalized] ?? label : label;
-  };
+  const translateLevel = (value?: string | null) => translateCoreLevel(value, isEnglish);
 
   const [values, setValues] = useState<RutinaFormValues>(
     initialValues || {

--- a/src/utils/coreSeedI18n.ts
+++ b/src/utils/coreSeedI18n.ts
@@ -1,0 +1,368 @@
+import type { GymMasterLocale } from "@/i18n/config";
+
+export type CoreSeedLocale = GymMasterLocale | "es" | "en" | string | boolean | null | undefined;
+
+export type LocalizedCoreSeedItem = {
+  codigo?: string | null;
+  nombre?: string | null;
+  descripcion?: string | null;
+};
+
+export function isCoreSeedEnglish(localeOrFlag: CoreSeedLocale): boolean {
+  return localeOrFlag === true || localeOrFlag === "en";
+}
+
+export function normalizeCoreSeedKey(value: unknown): string {
+  return String(value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[_-]+/g, " ")
+    .replace(/[^a-zA-Z0-9/ ]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function coreSeedTx(localeOrFlag: CoreSeedLocale, es: string, en: string): string {
+  return isCoreSeedEnglish(localeOrFlag) ? en : es;
+}
+
+const CORE_OBJECTIVE_LABELS_EN: Record<string, string> = {
+  volumen: "Volume",
+  volume: "Volume",
+  definicion: "Definition",
+  definition: "Definition",
+  "bajar de peso": "Lose weight",
+  adelgazar: "Lose weight",
+  "perder peso": "Lose weight",
+  "perdida de peso": "Weight loss",
+  fuerza: "Strength",
+  "aumentar fuerza": "Increase strength",
+  resistencia: "Endurance",
+  "mejorar resistencia": "Improve endurance",
+  rehabilitacion: "Rehabilitation",
+  "rehabilitacion fisica": "Physical rehabilitation",
+  salud: "Health",
+  "salud general": "General health",
+  "preparacion para competencia": "Competition preparation",
+  "condicion fisica postparto": "Postpartum physical conditioning",
+  "control del estres": "Stress management",
+  hipertrofia: "Hypertrophy",
+  "ganancia muscular": "Muscle gain",
+  "ganar masa muscular": "Muscle gain",
+  mantenimiento: "Maintenance",
+  tonificacion: "Toning",
+};
+
+const CORE_LEVEL_LABELS_EN: Record<string, string> = {
+  inicial: "Beginner",
+  principiante: "Beginner",
+  beginner: "Beginner",
+  intermedio: "Intermediate",
+  intermediate: "Intermediate",
+  avanzado: "Advanced",
+  advanced: "Advanced",
+  experto: "Expert",
+};
+
+const CORE_DAY_LABELS_EN: Record<string, string> = {
+  lunes: "Monday",
+  martes: "Tuesday",
+  miercoles: "Wednesday",
+  jueves: "Thursday",
+  viernes: "Friday",
+  sabado: "Saturday",
+  domingo: "Sunday",
+};
+
+const CORE_MUSCLE_GROUP_LABELS_EN: Record<string, string> = {
+  pecho: "Chest",
+  espalda: "Back",
+  piernas: "Legs",
+  pierna: "Legs",
+  biceps: "Biceps",
+  triceps: "Triceps",
+  hombros: "Shoulders",
+  hombro: "Shoulders",
+  abdomen: "Core",
+  abdominales: "Core",
+  core: "Core",
+  gluteos: "Glutes",
+  gemelos: "Calves",
+  pantorrillas: "Calves",
+  cardio: "Cardio",
+  "pecho y toque de hombros": "Chest and shoulder taps",
+  "espalda y toque de hombros": "Back and shoulder taps",
+  "biceps y triceps": "Biceps and triceps",
+  "piernas y abdominales": "Legs and abs",
+  "pecho y triceps": "Chest and triceps",
+  "espalda y biceps": "Back and biceps",
+  "hombros y abdominales": "Shoulders and abs",
+};
+
+const CORE_MEAL_TITLE_LABELS_EN: Record<string, string> = {
+  desayuno: "Breakfast",
+  "colacion media manana": "Mid-morning snack",
+  almuerzo: "Lunch",
+  "colacion siesta": "Afternoon snack",
+  merienda: "Snack",
+  "colacion tarde": "Late-afternoon snack",
+  cena: "Dinner",
+};
+
+const CORE_MEAL_HINTS_EN: Record<string, string> = {
+  desayuno: "First fuel of the day",
+  "colacion media manana": "Keeps energy steady between meals",
+  almuerzo: "Main meal of the day",
+  "colacion siesta": "Light support for the afternoon",
+  merienda: "Energy before or after training",
+  "colacion tarde": "Helps control hunger and cravings",
+  cena: "End the day without excess",
+};
+
+const CORE_DIET_PLAN_LABELS_EN: Record<string, string> = {
+  "sin dieta asignada": "No diet assigned",
+  "dieta sin nombre": "Untitled diet",
+  "plan alimentario": "Meal plan",
+  "plan automatico": "Automatic plan",
+};
+
+const CORE_FOOD_ITEM_LABELS_EN: Record<string, string> = {
+  "tortilla de avena con banana 200gr avena 8 claras 2 yemas 1 banana edulcorante vainilla":
+    "Oat and banana pancake: 200 g oats, 8 egg whites, 2 yolks, 1 banana, sweetener, vanilla",
+  "1 scoop de proteina con 200ml de leche": "1 scoop of protein with 200 ml milk",
+  "200gr carne magra arroz integral 30gr queso": "200 g lean meat, brown rice, 30 g cheese",
+  "media porcion de tortilla de avena con banana": "Half portion of oat and banana pancake",
+  "fruta banana punado de nueces": "Fruit (banana) + handful of nuts",
+  "200gr carne magra arroz integral": "200 g lean meat, brown rice",
+  "pan integral con mantequilla de mani 2 rebanadas 2 huevos revueltos": "Whole-wheat bread with peanut butter (2 slices) + 2 scrambled eggs",
+  "batido con banana leche avena y proteina": "Shake with banana, milk, oats, and protein",
+  "carne roja 200gr arroz integral ensalada verde": "Red meat (200 g) + brown rice + green salad",
+  "1 sandwich integral de atun con verduras": "1 whole-wheat tuna sandwich with vegetables",
+  "tostadas con queso port salut y jamon cocido": "Toast with Port Salut cheese and cooked ham",
+  "1 scoop proteina nueces": "1 scoop of protein + walnuts",
+  "pollo al horno 200gr pure de papas ensalada cruda": "Baked chicken (200 g) + mashed potatoes + raw salad",
+  "claras revueltas 6 con espinaca 1 rodaja pan integral 1 kiwi": "Scrambled egg whites (6) with spinach + 1 slice whole-wheat bread + 1 kiwi",
+  "1 yogurt descremado 10 almendras": "1 low-fat yogurt + 10 almonds",
+  "150gr pechuga de pollo ensalada verde 1 batata 200gr": "150 g chicken breast + green salad + 1 sweet potato (200 g)",
+  "1 manzana 1 huevo duro": "1 apple + 1 hard-boiled egg",
+  "infusion 2 tostadas integrales con queso untable light": "Infusion + 2 whole-wheat toasts with light spreadable cheese",
+  "proteina en agua 1 scoop": "Protein in water (1 scoop)",
+  "pescado al horno 150gr ensalada cruda 1/2 taza arroz integral": "Baked fish (150 g) + raw salad + 1/2 cup brown rice",
+  "infusion 1 tostada integral con palta 1 huevo duro": "Infusion + 1 whole-wheat toast with avocado + 1 hard-boiled egg",
+  "1 manzana o fruta fresca 1 punado de semillas": "1 apple or fresh fruit + 1 handful of seeds",
+  "ensalada mixta 120gr pechuga de pollo 1 huevo": "Mixed salad + 120 g chicken breast + 1 egg",
+  "gelatina sin azucar 1 yogurt descremado": "Sugar-free gelatin + 1 low-fat yogurt",
+  "te verde 1 tostada con queso untable light": "Green tea + 1 toast with light spreadable cheese",
+  "1 scoop de proteina en agua": "1 scoop of protein in water",
+  "pescado 150gr a la plancha ensalada cocida medio palta": "Grilled fish (150 g) + cooked salad + half an avocado",
+};
+
+const CORE_CATALOG_LABELS_EN: Record<string, { name: string; description?: string }> = {
+  "medio_pago:efectivo": { name: "Cash" },
+  "medio_pago:transferencia": { name: "Bank transfer" },
+  "medio_pago:tarjeta_credito": { name: "Credit card" },
+  "medio_pago:tarjeta_debito": { name: "Debit card" },
+  "medio_pago:mercado_pago": { name: "Mercado Pago" },
+  "medio_pago:stripe": { name: "Stripe" },
+
+  "tipo_gasto:sueldos": { name: "Salaries" },
+  "tipo_gasto:mantenimiento": { name: "Maintenance" },
+  "tipo_gasto:servicios": { name: "Utilities" },
+  "tipo_gasto:insumos": { name: "Supplies" },
+  "tipo_gasto:alquiler": { name: "Rent" },
+  "tipo_gasto:impuestos": { name: "Taxes" },
+  "tipo_gasto:marketing": { name: "Marketing" },
+  "tipo_gasto:equipamiento": { name: "Equipment" },
+  "tipo_gasto:otros": { name: "Other" },
+
+  "tipo_ingreso:cuotas": { name: "Membership fees" },
+  "tipo_ingreso:ventas": { name: "Sales" },
+  "tipo_ingreso:servicios": { name: "Services" },
+  "tipo_ingreso:clases_especiales": { name: "Special classes" },
+  "tipo_ingreso:promociones": { name: "Promotions" },
+  "tipo_ingreso:otros": { name: "Other" },
+
+  "categoria_producto:bebidas": { name: "Beverages" },
+  "categoria_producto:suplementos": { name: "Supplements" },
+  "categoria_producto:indumentaria": { name: "Apparel" },
+  "categoria_producto:accesorios": { name: "Accessories" },
+  "categoria_producto:snacks": { name: "Snacks" },
+  "categoria_producto:higiene": { name: "Hygiene" },
+  "categoria_producto:otros": { name: "Other" },
+
+  "tipo_equipamiento:cardio": { name: "Cardio" },
+  "tipo_equipamiento:fuerza": { name: "Strength" },
+  "tipo_equipamiento:peso_libre": { name: "Free weights" },
+  "tipo_equipamiento:accesorios": { name: "Accessories" },
+  "tipo_equipamiento:funcional": { name: "Functional" },
+  "tipo_equipamiento:otros": { name: "Other" },
+
+  "tipo_mantenimiento:preventivo": { name: "Preventive" },
+  "tipo_mantenimiento:correctivo": { name: "Corrective" },
+  "tipo_mantenimiento:limpieza_profunda": { name: "Deep cleaning" },
+  "tipo_mantenimiento:lubricacion": { name: "Lubrication" },
+  "tipo_mantenimiento:calibracion": { name: "Calibration" },
+  "tipo_mantenimiento:seguridad": { name: "Safety" },
+  "tipo_mantenimiento:inspeccion_visual": { name: "Visual inspection" },
+  "tipo_mantenimiento:otros": { name: "Other" },
+
+  "empleado_area:recepcion": { name: "Front desk" },
+  "empleado_area:administracion": { name: "Administration" },
+  "empleado_area:entrenamiento": { name: "Training" },
+  "empleado_area:mantenimiento": { name: "Maintenance" },
+  "empleado_area:limpieza": { name: "Cleaning" },
+  "empleado_area:bar_snack": { name: "Bar / snack" },
+  "empleado_area:ventas": { name: "Sales" },
+
+  "empleado_tipo_contratacion:mensual": { name: "Monthly" },
+  "empleado_tipo_contratacion:por_hora": { name: "Hourly" },
+  "empleado_tipo_contratacion:jornal": { name: "Daily wage" },
+  "empleado_tipo_contratacion:eventual": { name: "Temporary" },
+  "empleado_tipo_contratacion:pasantia": { name: "Internship" },
+  "empleado_tipo_contratacion:monotributo_servicio": { name: "Contractor / external service" },
+  "empleado_tipo_contratacion:otro": { name: "Other" },
+
+  "empleado_puesto_responsabilidad:recepcion_caja": { name: "Front desk and cash register" },
+  "empleado_puesto_responsabilidad:administracion": { name: "Administration" },
+  "empleado_puesto_responsabilidad:entrenador_sala": { name: "Floor trainer" },
+  "empleado_puesto_responsabilidad:personal_trainer": { name: "Personal trainer" },
+  "empleado_puesto_responsabilidad:instructor_clases": { name: "Class instructor" },
+  "empleado_puesto_responsabilidad:mantenimiento_preventivo": { name: "Preventive maintenance" },
+  "empleado_puesto_responsabilidad:mantenimiento_correctivo": { name: "Corrective maintenance" },
+  "empleado_puesto_responsabilidad:limpieza_general": { name: "General cleaning" },
+  "empleado_puesto_responsabilidad:bar_snack": { name: "Bar / snack" },
+  "empleado_puesto_responsabilidad:seguridad": { name: "Security / access control" },
+
+  "empleado_turno:manana": { name: "Morning" },
+  "empleado_turno:tarde": { name: "Afternoon" },
+  "empleado_turno:noche": { name: "Night" },
+  "empleado_turno:rotativo": { name: "Rotating" },
+  "empleado_turno:fin_de_semana": { name: "Weekend" },
+  "empleado_turno:a_convenir": { name: "To be agreed" },
+
+  "comercial_canal_venta:admin": { name: "Administration" },
+  "comercial_canal_venta:kiosco": { name: "POS / Kiosk" },
+  "comercial_canal_venta:socio_web": { name: "Member web" },
+  "comercial_canal_venta:app_mobile": { name: "Mobile app" },
+
+  "comercial_grupo_cliente:general": { name: "General" },
+  "comercial_grupo_cliente:socio_activo": { name: "Active member" },
+  "comercial_grupo_cliente:socio_premium": { name: "Premium member" },
+  "comercial_grupo_cliente:no_socio": { name: "Non-member / visitor" },
+  "comercial_grupo_cliente:empleado": { name: "Employee / internal" },
+
+  "comercial_ubicacion_stock:deposito": { name: "Storage" },
+  "comercial_ubicacion_stock:kiosco": { name: "Kiosk" },
+  "comercial_ubicacion_stock:recepcion": { name: "Front desk" },
+  "comercial_ubicacion_stock:heladera": { name: "Fridge" },
+  "comercial_ubicacion_stock:vitrina": { name: "Display case" },
+  "comercial_ubicacion_stock:sala_profesores": { name: "Teachers' room" },
+
+  "gimnasio_condicion_fiscal:responsable_inscripto": { name: "VAT registered" },
+  "gimnasio_condicion_fiscal:monotributo": { name: "Monotributo" },
+  "gimnasio_condicion_fiscal:consumidor_final": { name: "Final consumer" },
+  "gimnasio_condicion_fiscal:exento": { name: "Tax exempt" },
+  "gimnasio_condicion_fiscal:no_informado": { name: "Not informed" },
+};
+
+function translateFromMap(
+  value: string | null | undefined,
+  localeOrFlag: CoreSeedLocale,
+  map: Record<string, string>,
+  fallbackEs: string,
+  fallbackEn = fallbackEs,
+) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return isCoreSeedEnglish(localeOrFlag) ? fallbackEn : fallbackEs;
+  if (!isCoreSeedEnglish(localeOrFlag)) return raw;
+  return map[normalizeCoreSeedKey(raw)] ?? raw;
+}
+
+export function translateCoreObjective(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  return translateFromMap(value, localeOrFlag, CORE_OBJECTIVE_LABELS_EN, "No definido", "Not defined");
+}
+
+export function translateCoreLevel(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  return translateFromMap(value, localeOrFlag, CORE_LEVEL_LABELS_EN, "No definido", "Not defined");
+}
+
+export function translateCoreDayLabel(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  return translateFromMap(value, localeOrFlag, CORE_DAY_LABELS_EN, "Día", "Day");
+}
+
+export function translateCoreMuscleGroup(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  return translateFromMap(value, localeOrFlag, CORE_MUSCLE_GROUP_LABELS_EN, "-");
+}
+
+export function translateCoreMealTitle(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  return translateFromMap(value, localeOrFlag, CORE_MEAL_TITLE_LABELS_EN, "Comida", "Meal");
+}
+
+export function translateCoreMealHint(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  const raw = String(value ?? "").trim();
+  if (!raw || !isCoreSeedEnglish(localeOrFlag)) return "";
+  return CORE_MEAL_HINTS_EN[normalizeCoreSeedKey(raw)] ?? "";
+}
+
+export function translateCoreDietPlanName(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return isCoreSeedEnglish(localeOrFlag) ? "Untitled diet" : "Dieta sin nombre";
+  if (!isCoreSeedEnglish(localeOrFlag)) return raw;
+
+  const key = normalizeCoreSeedKey(raw);
+  if (CORE_DIET_PLAN_LABELS_EN[key]) return CORE_DIET_PLAN_LABELS_EN[key];
+
+  if (key.startsWith("plan automatico")) {
+    const suffix = raw.replace(/^Plan autom[aá]tico\s*-?\s*/i, "").trim();
+    return suffix ? "Automatic plan - " + translateCoreObjective(suffix, true) : "Automatic plan";
+  }
+
+  return raw;
+}
+
+export function translateCoreWorkoutPlanName(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return isCoreSeedEnglish(localeOrFlag) ? "Untitled routine" : "Rutina sin nombre";
+  if (!isCoreSeedEnglish(localeOrFlag)) return raw;
+
+  if (/^Rutina auto\s+/i.test(raw)) return raw.replace(/^Rutina auto\s+/i, "Auto routine ");
+  if (/^Rutina semana\s+/i.test(raw)) return raw.replace(/^Rutina semana\s+/i, "Routine week ");
+  if (/^Rutina #/i.test(raw)) return raw.replace(/^Rutina #/i, "Routine #");
+
+  return raw;
+}
+
+export function translateCoreFoodItem(value: string | null | undefined, localeOrFlag: CoreSeedLocale) {
+  const raw = String(value ?? "").trim();
+  if (!raw || !isCoreSeedEnglish(localeOrFlag)) return raw;
+  return CORE_FOOD_ITEM_LABELS_EN[normalizeCoreSeedKey(raw)] ?? raw;
+}
+
+export function getCoreCatalogTranslation(catalogKey: string, itemOrCode: LocalizedCoreSeedItem | string | null | undefined) {
+  const code = typeof itemOrCode === "string" ? itemOrCode : itemOrCode?.codigo;
+  if (!code) return null;
+  return CORE_CATALOG_LABELS_EN[`${catalogKey}:${normalizeCoreSeedKey(code).replace(/\s+/g, "_")}`] ?? null;
+}
+
+export function translateCoreCatalogName(
+  catalogKey: string,
+  itemOrCode: LocalizedCoreSeedItem | string | null | undefined,
+  fallbackName: string | null | undefined,
+  localeOrFlag: CoreSeedLocale,
+) {
+  const raw = String(fallbackName ?? "").trim();
+  if (!isCoreSeedEnglish(localeOrFlag)) return raw;
+  return getCoreCatalogTranslation(catalogKey, itemOrCode)?.name ?? raw;
+}
+
+export function translateCoreCatalogDescription(
+  catalogKey: string,
+  itemOrCode: LocalizedCoreSeedItem | string | null | undefined,
+  fallbackDescription: string | null | undefined,
+  localeOrFlag: CoreSeedLocale,
+) {
+  const raw = String(fallbackDescription ?? "").trim();
+  if (!isCoreSeedEnglish(localeOrFlag)) return raw;
+  return getCoreCatalogTranslation(catalogKey, itemOrCode)?.description ?? raw;
+}

--- a/src/utils/dietaI18nPresentation.ts
+++ b/src/utils/dietaI18nPresentation.ts
@@ -1,125 +1,44 @@
+import {
+  normalizeCoreSeedKey,
+  translateCoreDietPlanName,
+  translateCoreFoodItem,
+  translateCoreMealHint,
+  translateCoreMealTitle,
+  translateCoreObjective,
+} from "@/utils/coreSeedI18n";
+
 export function normalizeDietI18nKey(value: string) {
-  return value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[_-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .toLowerCase();
+  return normalizeCoreSeedKey(value);
 }
 
-const GOAL_TRANSLATIONS: Record<string, string> = {
-  volumen: "Volume",
-  volume: "Volume",
-  definicion: "Definition",
-  definition: "Definition",
-  "bajar de peso": "Lose weight",
-  "perdida de peso": "Weight loss",
-  "pérdida de peso": "Weight loss",
-  mantenimiento: "Maintenance",
-  "ganancia muscular": "Muscle gain",
-  hipertrofia: "Hypertrophy",
-  salud: "Health",
-  "salud general": "General health",
-};
-
-const DIET_PLAN_NAME_TRANSLATIONS: Record<string, string> = {
-  "sin dieta asignada": "No diet assigned",
-  "dieta sin nombre": "Untitled diet",
-  "plan alimentario": "Meal plan",
-  "plan automatico": "Automatic plan",
-  "plan automático": "Automatic plan",
-};
-
-const MEAL_TITLE_TRANSLATIONS: Record<string, string> = {
-  desayuno: "Breakfast",
-  "colacion media manana": "Mid-morning snack",
-  "colación media mañana": "Mid-morning snack",
-  almuerzo: "Lunch",
-  "colacion siesta": "Afternoon snack",
-  "colación siesta": "Afternoon snack",
-  merienda: "Snack",
-  "colacion tarde": "Late-afternoon snack",
-  "colación tarde": "Late-afternoon snack",
-  cena: "Dinner",
-};
-
-const MEAL_HINT_TRANSLATIONS: Record<string, string> = {
-  desayuno: "First fuel of the day",
-  "colacion media manana": "Keeps energy steady between meals",
-  almuerzo: "Main meal of the day",
-  "colacion siesta": "Light support for the afternoon",
-  merienda: "Energy before or after training",
-  "colacion tarde": "Helps control hunger and cravings",
-  cena: "End the day without excess",
-};
-
-const FOOD_TRANSLATIONS: Record<string, string> = {
-  "tortilla de avena con banana, 200gr avena, 8 claras, 2 yemas, 1 banana, edulcorante, vainilla":
-    "Oat and banana pancake: 200 g oats, 8 egg whites, 2 yolks, 1 banana, sweetener, vanilla",
-  "1 scoop de proteina con 200ml de leche": "1 scoop of protein with 200 ml milk",
-  "1 scoop de proteína con 200ml de leche": "1 scoop of protein with 200 ml milk",
-  "200gr carne magra, arroz integral, 30gr queso": "200 g lean meat, brown rice, 30 g cheese",
-  "media porcion de tortilla de avena con banana": "Half portion of oat and banana pancake",
-  "media porción de tortilla de avena con banana": "Half portion of oat and banana pancake",
-  "fruta (banana) + punado de nueces": "Fruit (banana) + handful of nuts",
-  "fruta (banana) + puñado de nueces": "Fruit (banana) + handful of nuts",
-  "200gr carne magra, arroz integral": "200 g lean meat, brown rice",
-};
-
 export function translateDietGoal(value: string | null | undefined, isEnglish: boolean) {
-  const raw = String(value ?? "").trim();
-  if (!raw) return isEnglish ? "Not defined" : "No definido";
-  if (!isEnglish) return raw;
-  return GOAL_TRANSLATIONS[normalizeDietI18nKey(raw)] ?? raw;
+  return translateCoreObjective(value, isEnglish);
 }
 
 export function translateDietPlanName(value: string | null | undefined, isEnglish: boolean) {
-  const raw = String(value ?? "").trim();
-  if (!raw) return isEnglish ? "Untitled diet" : "Dieta sin nombre";
-  if (!isEnglish) return raw;
-
-  const key = normalizeDietI18nKey(raw);
-  if (DIET_PLAN_NAME_TRANSLATIONS[key]) return DIET_PLAN_NAME_TRANSLATIONS[key];
-
-  if (key.startsWith("plan automatico") || key.startsWith("plan automático")) {
-    const suffix = raw.replace(/^Plan autom[aá]tico\s*-?\s*/i, "").trim();
-    return suffix ? `Automatic plan - ${translateDietGoal(suffix, true)}` : "Automatic plan";
-  }
-
-  return raw;
+  return translateCoreDietPlanName(value, isEnglish);
 }
 
 export function translateMealTitle(value: string | null | undefined, isEnglish: boolean) {
-  const raw = String(value ?? "").trim();
-  if (!raw) return isEnglish ? "Meal" : "Comida";
-  if (!isEnglish) return raw;
-  return MEAL_TITLE_TRANSLATIONS[normalizeDietI18nKey(raw)] ?? raw;
+  return translateCoreMealTitle(value, isEnglish);
 }
 
 export function translateMealHint(key: string | null | undefined, isEnglish: boolean) {
-  const raw = String(key ?? "").trim();
-  if (!raw) return "";
-  if (!isEnglish) return "";
-  return MEAL_HINT_TRANSLATIONS[normalizeDietI18nKey(raw)] ?? "";
+  return translateCoreMealHint(key, isEnglish);
 }
 
 export function translateFoodItem(value: string | null | undefined, isEnglish: boolean) {
-  const raw = String(value ?? "").trim();
-  if (!raw || !isEnglish) return raw;
-  const key = normalizeDietI18nKey(raw);
-  return FOOD_TRANSLATIONS[key] ?? raw;
+  return translateCoreFoodItem(value, isEnglish);
 }
 
 export function translateDietProgressLabel(value: string | null | undefined, isEnglish: boolean) {
   const raw = String(value ?? "").trim();
   if (!isEnglish) return raw;
+
   switch (normalizeDietI18nKey(raw)) {
     case "seguimiento manual":
       return "Manual tracking";
     case "plan proximo":
-      return "Upcoming plan";
-    case "plan próximo":
       return "Upcoming plan";
     case "plan finalizado":
       return "Finished plan";
@@ -133,11 +52,18 @@ export function translateDietProgressLabel(value: string | null | undefined, isE
 export function translateDietText(value: string | null | undefined, isEnglish: boolean) {
   const raw = String(value ?? "").trim();
   if (!raw || !isEnglish) return raw;
-  return (
-    translateDietPlanName(raw, true) ||
-    translateDietGoal(raw, true) ||
-    translateMealTitle(raw, true) ||
-    translateFoodItem(raw, true) ||
-    raw
-  );
+
+  const translatedPlan = translateDietPlanName(raw, true);
+  if (translatedPlan !== raw) return translatedPlan;
+
+  const translatedGoal = translateDietGoal(raw, true);
+  if (translatedGoal !== raw) return translatedGoal;
+
+  const translatedMeal = translateMealTitle(raw, true);
+  if (translatedMeal !== raw) return translatedMeal;
+
+  const translatedFood = translateFoodItem(raw, true);
+  if (translatedFood !== raw) return translatedFood;
+
+  return raw;
 }

--- a/src/utils/rutinaPdf.ts
+++ b/src/utils/rutinaPdf.ts
@@ -1,6 +1,7 @@
 import jsPDF from "jspdf";
 import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
 import { formatFrontendDate } from '@/utils/dateFormat';
+import { translateCoreDayLabel, translateCoreMuscleGroup, translateCoreWorkoutPlanName } from "@/utils/coreSeedI18n";
 import { Rutina } from "@/interfaces/rutina.interface";
 
 type EjerciciosPorDia = Record<string, any[]>;
@@ -35,65 +36,16 @@ const capitalizar = (value: string): string => {
 const rutinaPdfTx = (locale: RutinaPdfLocale = "es", es: string, en: string): string =>
   locale === "en" ? en : es;
 
-const RUTINA_PDF_DAY_EN: Record<string, string> = {
-  lunes: "Monday",
-  martes: "Tuesday",
-  miercoles: "Wednesday",
-  miércoles: "Wednesday",
-  jueves: "Thursday",
-  viernes: "Friday",
-  sabado: "Saturday",
-  sábado: "Saturday",
-  domingo: "Sunday",
-};
-
-const RUTINA_PDF_MUSCLE_GROUP_EN: Record<string, string> = {
-  pecho: "Chest",
-  espalda: "Back",
-  piernas: "Legs",
-  pierna: "Legs",
-  biceps: "Biceps",
-  bíceps: "Biceps",
-  triceps: "Triceps",
-  tríceps: "Triceps",
-  hombros: "Shoulders",
-  hombro: "Shoulders",
-  abdomen: "Core",
-  abdominales: "Core",
-  core: "Core",
-  gluteos: "Glutes",
-  glúteos: "Glutes",
-  gemelos: "Calves",
-  pantorrillas: "Calves",
-  cardio: "Cardio",
-};
-
-const normalizeRutinaPdfKey = (value: string): string =>
-  String(value || "")
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .trim();
-
 const traducirDiaRutinaPdf = (dia: string, locale: RutinaPdfLocale = "es"): string => {
-  if (locale !== "en") return capitalizar(dia);
-  const normalized = normalizeRutinaPdfKey(dia);
-  return RUTINA_PDF_DAY_EN[normalized] || RUTINA_PDF_DAY_EN[String(dia || "").toLowerCase()] || capitalizar(dia);
+  const translated = translateCoreDayLabel(dia, locale);
+  return locale === "en" ? translated : capitalizar(translated);
 };
 
-const traducirGrupoRutinaPdf = (grupo: string, locale: RutinaPdfLocale = "es"): string => {
-  if (locale !== "en") return grupo;
-  const normalized = normalizeRutinaPdfKey(grupo);
-  return RUTINA_PDF_MUSCLE_GROUP_EN[normalized] || RUTINA_PDF_MUSCLE_GROUP_EN[String(grupo || "").toLowerCase()] || grupo;
-};
+const traducirGrupoRutinaPdf = (grupo: string, locale: RutinaPdfLocale = "es"): string =>
+  translateCoreMuscleGroup(grupo, locale);
 
-const traducirTituloRutinaPdf = (titulo: string, locale: RutinaPdfLocale = "es"): string => {
-  if (locale !== "en") return titulo;
-  if (titulo.startsWith("Rutina auto ")) return titulo.replace("Rutina auto ", "Auto routine ");
-  if (titulo.startsWith("Rutina semana ")) return titulo.replace("Rutina semana ", "Routine week ");
-  if (titulo.startsWith("Rutina #")) return titulo.replace("Rutina #", "Routine #");
-  return titulo;
-};
+const traducirTituloRutinaPdf = (titulo: string, locale: RutinaPdfLocale = "es"): string =>
+  translateCoreWorkoutPlanName(titulo, locale);
 
 const buildRutinaPdfFileTitle = (titulo: string, socioNombre: string, locale: RutinaPdfLocale = "es"): string => {
   const translatedTitle = traducirTituloRutinaPdf(titulo, locale);


### PR DESCRIPTION
# feat(i18n): add core seeds governance v1

## Resumen

Se incorpora una primera capa de gobernanza ES/EN para datos core precargados por Gym Master, centralizando traducciones de presentación sin modificar base de datos, endpoints ni Swagger/OpenAPI.

La feature diferencia explícitamente entre:

- **Datos core/seed de Gym Master:** pueden mostrarse en español o inglés mediante helpers centralizados.
- **Datos propios cargados por cada gimnasio:** se preservan tal como fueron ingresados y no se traducen automáticamente.

## Contexto

Después del cierre de i18n de paneles admin/socio y exportables PDF/Excel, quedaba pendiente resolver la coherencia bilingüe de datos base reutilizados por varios módulos, especialmente rutinas, dietas, objetivos, niveles, días, grupos musculares y catálogos seed.

A partir de la revisión del repo y del dump local actualizado se identificó que varias tablas core/parametrizables aún no cuentan con columnas equivalentes en inglés. Para evitar migraciones prematuras, esta etapa implementa una capa de presentación segura y centralizada.

## Cambios incluidos

### Nuevo helper central

- Se agrega `src/utils/coreSeedI18n.ts`.
- Centraliza normalización y traducciones ES/EN para datos core conocidos.
- Expone helpers reutilizables para objetivos, niveles, días, grupos musculares, comidas, nombres de dietas/rutinas automáticas y catálogos core conocidos.

### Refactor de dieta

- `src/utils/dietaI18nPresentation.ts` delega en `coreSeedI18n`.
- Se reducen mapas locales duplicados.
- Se conserva el comportamiento de fallback: si el dato no está reconocido, se devuelve el valor original.

### Refactor de rutinas

- `src/components/forms/RutinasForm.tsx` deja de depender de mapas locales duplicados para objetivos/niveles.
- `src/app/dashboard/rutinas/page.tsx` reutiliza la gobernanza central para filtros y presentación.
- `src/utils/rutinaPdf.ts` reutiliza traducciones centralizadas para días, grupos musculares y nombres de rutina.

### Documentación técnica

- Se agrega `docs/i18n/i18n-core-seeds-governance-v1.md`.
- Documenta alcance, auditoría, decisión técnica, reglas de traducción y próximos pasos recomendados.

## Archivos modificados

- `docs/i18n/i18n-core-seeds-governance-v1.md`
- `src/app/dashboard/rutinas/page.tsx`
- `src/components/forms/RutinasForm.tsx`
- `src/utils/coreSeedI18n.ts`
- `src/utils/dietaI18nPresentation.ts`
- `src/utils/rutinaPdf.ts`

## Fuera de alcance

- No se modifica la base de datos.
- No se agregan migraciones.
- No se modifican endpoints.
- No se modifica Swagger/OpenAPI.
- No se traducen productos, servicios ni textos propios creados por cada gimnasio.
- No se cambia la generación IA/RAG; queda para una feature posterior.

## Criterios de validación

- `npm run build` debe compilar correctamente.
- La rama no debe incluir artefactos PWA generados por build, como `public/sw.js` o `public/fallback-*.js`.
- La rama no debe incluir scripts temporales de patch ni carpetas `.bak*`.
- Los helpers deben mantener fallback seguro al valor original cuando el dato no pertenece al core seed conocido.
- La UI y los PDF existentes deben seguir respetando el locale actual sin alterar datos propios del gimnasio.

## Riesgo técnico

Bajo. La implementación es principalmente de presentación y centralización de helpers. No modifica persistencia, contratos API, pagos, asistencia, RAG, ni reglas de negocio críticas.

## Próximos pasos sugeridos

1. `feature/i18n-ai-generated-content-language-governance-v1`: aplicar gobernanza de idioma a contenido generado por IA, RAG, rutinas automáticas, dietas automáticas y disclaimers.
2. `fix/rag-corpus-status-fetch-resilience-v1`: resolver resiliencia del endpoint de estado del corpus RAG.
3. Segunda pasada opcional sobre catálogos parametrizables en pantallas específicas usando `translateCoreCatalogName` y `translateCoreCatalogDescription` donde corresponda.
