### PR TITLE
feat: complete PWA install and update QA

### DIFF
--- a/docs/pwa/pwa-install-update-final-qa-v1-baseline.md
+++ b/docs/pwa/pwa-install-update-final-qa-v1-baseline.md
@@ -1,0 +1,122 @@
+# PWA Install & Update Final QA v1 — Baseline
+
+## Rama
+
+`feature/pwa-install-update-final-qa-v1`
+
+## Objetivo
+
+Cerrar la instalación y actualización de Gym Master como PWA en Chrome, Edge,
+Android y modo standalone sin debilitar la política de caché segura ya aprobada.
+
+## Cambios de este lote
+
+- El service worker deja de activarse automáticamente mediante `skipWaiting`.
+- Una versión nueva queda en espera hasta que el usuario elige actualizar.
+- La recarga ocurre después de `controllerchange`, con un timeout de recuperación.
+- Se comprueban actualizaciones al abrir, volver a primer plano, recuperar conexión
+  y de forma periódica.
+- Los avisos PWA también alcanzan a administradores y usuarios internos cuando
+  Gym Master se ejecuta como aplicación instalada.
+- Prompt de instalación, avisos de conexión y pulido standalone se montan desde
+  `SessionWrapper`, por lo que están disponibles desde el login y no dependen de
+  que `AppHeader` ya se haya renderizado.
+- El manifest permite cualquier orientación para no bloquear escritorio, tablets,
+  POS ni pantallas apaisadas.
+- Se agrega `npm run test:pwa-install-update`.
+- Los artefactos generados `sw.js`, `workbox-*` y `fallback-*` deben quedar fuera
+  del índice de Git.
+
+## Política conservada
+
+- `/api/*`: `NetworkOnly`.
+- Navegaciones: `NetworkOnly`.
+- `/_next/static/*`: caché versionada.
+- Imágenes públicas locales: caché controlada.
+- Fallback documental: `/offline`.
+
+## Decisión sobre actualizaciones
+
+Gym Master usa chunks con hashes y carga diferida. Workbox recomienda evitar la
+activación inmediata en este escenario. La nueva versión permanece esperando y
+el usuario confirma el cambio. El cliente envía `SKIP_WAITING`, espera
+`controllerchange` y recién entonces recarga.
+
+Esto reduce el riesgo de:
+
+- `ChunkLoadError`.
+- mezcla de bundles anteriores y nuevos;
+- recarga inesperada durante una venta, pago, ficha médica o formulario;
+- activación silenciosa en una sesión operativa.
+
+## Manifest e iconos
+
+El manifest conserva su identidad y `start_url` existentes para no crear una
+segunda instalación. Los iconos fueron comprobados en dimensiones reales:
+
+- 192 × 192.
+- 512 × 512.
+- maskable 192 × 192.
+- maskable 512 × 512.
+- Apple Touch Icon 180 × 180.
+
+`orientation` cambia de `portrait` a `any`, permitiendo vertical, horizontal,
+tablet, escritorio y ventanas PWA redimensionables.
+
+## Validación automática
+
+```bash
+npm run build
+npm run test:pwa-cache
+npm run test:pwa-install-update
+```
+
+El último comando valida:
+
+- manifest y campos críticos;
+- dimensiones reales de iconos PNG;
+- registro explícito del service worker;
+- actualización controlada;
+- montaje global de experiencia PWA;
+- ausencia de montajes duplicados;
+- service worker generado;
+- artefactos PWA no versionados.
+
+## Acción Git requerida
+
+Como los archivos generados estaban versionados previamente, deben retirarse una
+sola vez del índice:
+
+```bash
+git rm --cached --ignore-unmatch public/sw.js
+
+git ls-files   'public/workbox-*.js'   'public/fallback-*.js'   | xargs -r git rm --cached --
+```
+
+El build continuará generándolos localmente y `.gitignore` impedirá que vuelvan
+al repositorio.
+
+## QA manual previsto
+
+1. Manifest en Chrome DevTools sin errores.
+2. Instalación en Chrome y Edge.
+3. Apertura standalone sin barra de direcciones.
+4. Persistencia de idioma y tema.
+5. Versión A instalada.
+6. Build de versión B con cambio visual controlado.
+7. Aviso de nueva versión.
+8. Opción “Más tarde” sin recarga.
+9. Opción “Actualizar” y recarga tras `controllerchange`.
+10. Formulario abierto sin pérdida antes de aceptar.
+11. Login, logout y rutas por rol después de actualizar.
+12. Desinstalación y reinstalación sin sesiones privadas heredadas.
+
+## Sin cambios
+
+- Base de datos.
+- Migraciones.
+- RLS.
+- RPC.
+- Seeds.
+- Contratos API.
+- Reglas comerciales.

--- a/docs/pwa/pwa-install-update-final-qa-v1-exercise-media-level-i18n-hotfix-v1a.md
+++ b/docs/pwa/pwa-install-update-final-qa-v1-exercise-media-level-i18n-hotfix-v1a.md
@@ -1,0 +1,30 @@
+# Gym Master — PWA Install/Update Final QA v1
+
+## Hotfix v1a: niveles ES/EN en Exercise Media
+
+### Hallazgo de QA
+Durante la validación de la PWA instalada en Microsoft Edge, la pantalla `/dashboard/rutinas/media` mostraba los niveles core en español aunque el locale activo fuera inglés.
+
+### Corrección
+Se reutiliza `translateCoreLevel` para localizar los niveles controlados por Gym Master en:
+
+- filtro de niveles;
+- tabla del catálogo multimedia;
+- panel de detalle;
+- equivalencias automáticas de nivel origen/destino.
+
+### Gobernanza de datos
+La corrección solo traduce niveles core conocidos, por ejemplo:
+
+- Inicial → Beginner
+- Intermedio → Intermediate
+- Avanzado → Advanced
+- Experto → Expert
+
+Los valores no reconocidos o personalizados se conservan sin modificación. No se alteran IDs ni datos persistidos.
+
+### Impacto
+- Sin cambios de base de datos.
+- Sin migraciones.
+- Sin cambios de API, RLS, RPC o permisos.
+- Sin cambios en instalación, manifest, service worker o política de caché.

--- a/next.config.js
+++ b/next.config.js
@@ -74,7 +74,9 @@ const runtimeCaching = [
 const withPWA = require('next-pwa')({
   dest: 'public',
   register: false,
-  skipWaiting: true,
+  // Keep updates waiting until the user explicitly accepts the new version.
+  // This avoids mixing an old page with a newly activated worker and hashed chunks.
+  skipWaiting: false,
   clientsClaim: true,
   cleanupOutdatedCaches: true,
   cacheStartUrl: false,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:install": "playwright install chromium",
-    "test:pwa-cache": "node scripts/verify-pwa-cache-policy.mjs"
+    "test:pwa-cache": "node scripts/verify-pwa-cache-policy.mjs",
+    "test:pwa-install-update": "node scripts/verify-pwa-install-update.mjs"
   },
   "dependencies": {
     "@getbrevo/brevo": "^2.5.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,7 +10,7 @@
     "standalone",
     "minimal-ui"
   ],
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#000000",
   "theme_color": "#000000",
   "categories": [

--- a/scripts/verify-pwa-install-update.mjs
+++ b/scripts/verify-pwa-install-update.mjs
@@ -1,0 +1,282 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+const manifestPath = resolve(root, 'public', 'manifest.json');
+const configPath = resolve(root, 'next.config.js');
+const serviceWorkerPath = resolve(root, 'public', 'sw.js');
+const sessionWrapperPath = resolve(root, 'src', 'components', 'SessionWrapper.tsx');
+const appHeaderPath = resolve(root, 'src', 'components', 'header', 'AppHeader.tsx');
+const updateBannerPath = resolve(
+  root,
+  'src',
+  'components',
+  'pwa',
+  'PwaConnectionUpdateBanner.tsx',
+);
+const installPromptPath = resolve(
+  root,
+  'src',
+  'components',
+  'pwa',
+  'SocioPwaInstallPrompt.tsx',
+);
+const registrarPath = resolve(
+  root,
+  'src',
+  'components',
+  'pwa',
+  'PwaServiceWorkerRegistrar.tsx',
+);
+
+function fail(message) {
+  console.error(`PWA install/update verification failed: ${message}`);
+  process.exit(1);
+}
+
+function readRequired(path, label) {
+  if (!existsSync(path)) {
+    fail(`${label} was not found.`);
+  }
+
+  return readFileSync(path, 'utf8');
+}
+
+function readPngDimensions(path) {
+  if (!existsSync(path)) {
+    fail(`required icon was not found: ${path}`);
+  }
+
+  const buffer = readFileSync(path);
+  const pngSignature = '89504e470d0a1a0a';
+
+  if (buffer.length < 24 || buffer.subarray(0, 8).toString('hex') !== pngSignature) {
+    fail(`icon is not a valid PNG: ${path}`);
+  }
+
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+function requireSourceTokens(source, tokens, label) {
+  const missing = tokens.filter((token) => !source.includes(token));
+
+  if (missing.length > 0) {
+    fail(`${label} tokens missing: ${missing.join(', ')}`);
+  }
+}
+
+const manifestSource = readRequired(manifestPath, 'public/manifest.json');
+let manifest;
+
+try {
+  manifest = JSON.parse(manifestSource);
+} catch {
+  fail('public/manifest.json is not valid JSON.');
+}
+
+const requiredManifestValues = {
+  name: 'Gym Master - Dragon Pyramid',
+  short_name: 'Gym Master',
+  id: '/dashboard',
+  start_url: '/dashboard?source=pwa',
+  scope: '/',
+  display: 'standalone',
+  orientation: 'any',
+  background_color: '#000000',
+  theme_color: '#000000',
+};
+
+for (const [key, expected] of Object.entries(requiredManifestValues)) {
+  if (manifest[key] !== expected) {
+    fail(`manifest.${key} must be ${JSON.stringify(expected)}.`);
+  }
+}
+
+if (!Array.isArray(manifest.icons)) {
+  fail('manifest.icons must be an array.');
+}
+
+const requiredIcons = [
+  { src: '/icon-192x192.png', size: 192, purpose: 'any' },
+  { src: '/icon-512x512.png', size: 512, purpose: 'any' },
+  { src: '/maskable-icon-192x192.png', size: 192, purpose: 'maskable' },
+  { src: '/maskable-icon-512x512.png', size: 512, purpose: 'maskable' },
+  { src: '/apple-touch-icon.png', size: 180, purpose: 'any' },
+];
+
+for (const requiredIcon of requiredIcons) {
+  const icon = manifest.icons.find((candidate) => candidate.src === requiredIcon.src);
+
+  if (!icon) {
+    fail(`manifest icon missing: ${requiredIcon.src}`);
+  }
+
+  if (icon.sizes !== `${requiredIcon.size}x${requiredIcon.size}`) {
+    fail(`manifest icon has an invalid sizes value: ${requiredIcon.src}`);
+  }
+
+  if (!String(icon.purpose ?? '').split(/\s+/).includes(requiredIcon.purpose)) {
+    fail(`manifest icon has an invalid purpose: ${requiredIcon.src}`);
+  }
+
+  const iconPath = resolve(root, 'public', requiredIcon.src.replace(/^\//, ''));
+  const dimensions = readPngDimensions(iconPath);
+
+  if (
+    dimensions.width !== requiredIcon.size ||
+    dimensions.height !== requiredIcon.size
+  ) {
+    fail(
+      `icon dimensions do not match the manifest: ${requiredIcon.src} is ${dimensions.width}x${dimensions.height}`,
+    );
+  }
+}
+
+const configSource = readRequired(configPath, 'next.config.js');
+requireSourceTokens(
+  configSource,
+  [
+    'register: false',
+    'skipWaiting: false',
+    'clientsClaim: true',
+    'cleanupOutdatedCaches: true',
+    'cacheStartUrl: false',
+    'dynamicStartUrl: false',
+    "document: '/offline'",
+  ],
+  'next.config.js',
+);
+
+const registrarSource = readRequired(
+  registrarPath,
+  'PwaServiceWorkerRegistrar.tsx',
+);
+requireSourceTokens(
+  registrarSource,
+  [
+    "SERVICE_WORKER_URL = '/sw.js'",
+    "SERVICE_WORKER_SCOPE = '/'",
+    "updateViaCache: 'none'",
+  ],
+  'service worker registrar',
+);
+
+if (
+  !/navigator\.serviceWorker\s*\.register\s*\(\s*SERVICE_WORKER_URL\s*,/s.test(
+    registrarSource,
+  )
+) {
+  fail('the App Router service worker registrar does not register /sw.js.');
+}
+
+const sessionWrapperSource = readRequired(
+  sessionWrapperPath,
+  'SessionWrapper.tsx',
+);
+requireSourceTokens(
+  sessionWrapperSource,
+  [
+    '<PwaServiceWorkerRegistrar />',
+    '<SocioPwaInstallPrompt />',
+    '<PwaConnectionUpdateBanner />',
+    '<PwaAndroidInstalledAppPolish />',
+  ],
+  'global PWA mount',
+);
+
+const appHeaderSource = readRequired(appHeaderPath, 'AppHeader.tsx');
+const duplicateHeaderMounts = [
+  '<SocioPwaInstallPrompt />',
+  '<PwaConnectionUpdateBanner />',
+  '<PwaAndroidInstalledAppPolish />',
+].filter((token) => appHeaderSource.includes(token));
+
+if (duplicateHeaderMounts.length > 0) {
+  fail(
+    `PWA components are mounted twice in AppHeader: ${duplicateHeaderMounts.join(', ')}`,
+  );
+}
+
+const updateBannerSource = readRequired(
+  updateBannerPath,
+  'PwaConnectionUpdateBanner.tsx',
+);
+requireSourceTokens(
+  updateBannerSource,
+  [
+    'registration.waiting',
+    "newWorker.state === 'installed'",
+    "waitingWorker.postMessage({ type: 'SKIP_WAITING' })",
+    "'controllerchange'",
+    "'updatefound'",
+    "'visibilitychange'",
+    'window.location.reload()',
+    'UPDATE_ACTIVATION_TIMEOUT_MS',
+  ],
+  'controlled update flow',
+);
+
+const installPromptSource = readRequired(
+  installPromptPath,
+  'SocioPwaInstallPrompt.tsx',
+);
+requireSourceTokens(
+  installPromptSource,
+  [
+    "'beforeinstallprompt'",
+    "'appinstalled'",
+    "'(display-mode: standalone)'",
+    'event.preventDefault()',
+    'installEvent.prompt()',
+  ],
+  'install prompt flow',
+);
+
+if (!existsSync(serviceWorkerPath)) {
+  fail('public/sw.js was not generated. Run npm run build first.');
+}
+
+const serviceWorkerSource = readFileSync(serviceWorkerPath, 'utf8');
+requireSourceTokens(
+  serviceWorkerSource,
+  ['SKIP_WAITING', '/offline'],
+  'generated service worker',
+);
+
+let trackedGeneratedFiles = '';
+
+try {
+  trackedGeneratedFiles = execFileSync(
+    'git',
+    [
+      'ls-files',
+      'public/sw.js',
+      'public/workbox-*.js',
+      'public/fallback-*.js',
+    ],
+    {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  ).trim();
+} catch {
+  fail('git could not verify generated PWA artifacts.');
+}
+
+if (trackedGeneratedFiles) {
+  fail(
+    `generated PWA artifacts are still tracked by Git: ${trackedGeneratedFiles
+      .split(/\r?\n/)
+      .join(', ')}`,
+  );
+}
+
+console.log('PWA manifest OK: install identity, standalone display, orientation and icons are valid.');
+console.log('PWA install OK: the install prompt is mounted globally and detects installed mode.');
+console.log('PWA update OK: updates wait for user confirmation and reload after controllerchange.');
+console.log('PWA repository OK: generated service worker and Workbox assets are not versioned.');

--- a/src/app/dashboard/rutinas/media/page.tsx
+++ b/src/app/dashboard/rutinas/media/page.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/services/apiClient";
 import { useAuthStore } from "@/stores/authStore";
 import { useI18n } from "@/i18n/I18nProvider";
+import { translateCoreLevel } from "@/utils/coreSeedI18n";
 
 type CatalogSummary = {
   total: number;
@@ -219,6 +220,10 @@ export default function RutinasExerciseMediaCatalogPage() {
   const { locale } = useI18n();
   const isEnglish = locale === "en";
   const tx = useCallback((es: string, en: string) => (isEnglish ? en : es), [isEnglish]);
+  const translateLevel = useCallback(
+    (value?: string | null) => translateCoreLevel(value, isEnglish),
+    [isEnglish],
+  );
 
   const [items, setItems] = useState<EjercicioMediaCatalogItem[]>([]);
   const [objetivos, setObjetivos] = useState<Objetivo[]>([]);
@@ -1497,7 +1502,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                                   </p>
                                   <p className="text-slate-500">
                                     {candidate.source_objetivo} ·{" "}
-                                    {candidate.source_nivel}
+                                    {translateLevel(candidate.source_nivel)}
                                   </p>
                                 </td>
                                 <td className="px-3 py-2">
@@ -1506,7 +1511,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                                   </p>
                                   <p className="text-slate-500">
                                     {candidate.target_objetivo} ·{" "}
-                                    {candidate.target_nivel}
+                                    {translateLevel(candidate.target_nivel)}
                                   </p>
                                 </td>
                                 <td className="px-3 py-2 text-slate-600">
@@ -1570,7 +1575,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                       <option value="todos">{tx("Todos los niveles", "All levels")}</option>
                       {niveles.map((nivel) => (
                         <option key={nivel.id_nivel} value={nivel.id_nivel}>
-                          {nivel.nombre_nivel}
+                          {translateLevel(nivel.nombre_nivel)}
                         </option>
                       ))}
                     </select>
@@ -1732,8 +1737,9 @@ export default function RutinasExerciseMediaCatalogPage() {
                                     `${tx("Objetivo", "Goal")} ${item.id_objetivo}`}
                                 </p>
                                 <p className="text-xs">
-                                  {item.nivel_nombre ??
-                                    `${tx("Nivel", "Level")} ${item.id_nivel}`}
+                                  {item.nivel_nombre
+                                    ? translateLevel(item.nivel_nombre)
+                                    : `${tx("Nivel", "Level")} ${item.id_nivel}`}
                                 </p>
                               </td>
                               <td className="px-4 py-3">
@@ -1863,7 +1869,7 @@ export default function RutinasExerciseMediaCatalogPage() {
                         </p>
                         <p className="text-sm text-slate-500 dark:text-neutral-400">
                           {selectedExercise.objetivo_nombre} ·{" "}
-                          {selectedExercise.nivel_nombre} ·{" "}
+                          {translateLevel(selectedExercise.nivel_nombre)} ·{" "}
                           {selectedExercise.grupo_muscular_nombre}
                         </p>
                       </div>

--- a/src/components/SessionWrapper.tsx
+++ b/src/components/SessionWrapper.tsx
@@ -9,6 +9,9 @@ import { I18nProvider } from '@/i18n/I18nProvider';
 import type { GymMasterLocale } from '@/i18n/config';
 import { clearSensitivePwaCaches } from '@/utils/pwaCacheSecurity';
 import { PwaServiceWorkerRegistrar } from '@/components/pwa/PwaServiceWorkerRegistrar';
+import { PwaAndroidInstalledAppPolish } from '@/components/pwa/PwaAndroidInstalledAppPolish';
+import { PwaConnectionUpdateBanner } from '@/components/pwa/PwaConnectionUpdateBanner';
+import { SocioPwaInstallPrompt } from '@/components/pwa/SocioPwaInstallPrompt';
 
 export function SessionWrapper({
   children,
@@ -32,7 +35,12 @@ export function SessionWrapper({
             enableSystem
             disableTransitionOnChange
           >
-            <I18nProvider initialLocale={initialLocale}>{children}</I18nProvider>
+            <I18nProvider initialLocale={initialLocale}>
+              {children}
+              <SocioPwaInstallPrompt />
+              <PwaConnectionUpdateBanner />
+              <PwaAndroidInstalledAppPolish />
+            </I18nProvider>
           </ThemeProvider>
         </SessionContextProvider>
       </SessionProvider>

--- a/src/components/header/AppHeader.tsx
+++ b/src/components/header/AppHeader.tsx
@@ -6,9 +6,6 @@ import { CircleHelp, Lock, Menu, Moon, Search, Settings, SlidersHorizontal, Sun,
 import ProfileImage from '@/components/perfil/ProfileImage';
 import { HeaderNotificationsBell } from '@/components/header/HeaderNotificationsBell';
 import { SocioMobileBottomNavigation } from '@/components/navigation/SocioMobileBottomNavigation';
-import { SocioPwaInstallPrompt } from '@/components/pwa/SocioPwaInstallPrompt';
-import { PwaConnectionUpdateBanner } from '@/components/pwa/PwaConnectionUpdateBanner';
-import { PwaAndroidInstalledAppPolish } from '@/components/pwa/PwaAndroidInstalledAppPolish';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -243,9 +240,6 @@ export const AppHeader = ({ title }: AppHeaderProps) => {
       </header>
 
       <SocioMobileBottomNavigation />
-      <SocioPwaInstallPrompt />
-      <PwaConnectionUpdateBanner />
-      <PwaAndroidInstalledAppPolish />
     </>
   );
 };

--- a/src/components/pwa/PwaConnectionUpdateBanner.tsx
+++ b/src/components/pwa/PwaConnectionUpdateBanner.tsx
@@ -10,6 +10,7 @@ import { useI18n } from '@/i18n/I18nProvider';
 
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 const ONLINE_RESTORED_VISIBLE_MS = 4500;
+const UPDATE_ACTIVATION_TIMEOUT_MS = 10_000;
 
 function isStandaloneMode() {
   if (typeof window === 'undefined') return false;
@@ -22,6 +23,15 @@ function isStandaloneMode() {
     window.matchMedia('(display-mode: standalone)').matches ||
     navigatorWithStandalone.standalone === true
   );
+}
+
+function requestRegistrationUpdate(registration: ServiceWorkerRegistration) {
+  if (!window.navigator.onLine) return;
+
+  void registration.update().catch(() => {
+    // An update check is opportunistic. Network or browser failures must not
+    // interrupt the active Gym Master session.
+  });
 }
 
 export function PwaConnectionUpdateBanner() {
@@ -39,7 +49,13 @@ export function PwaConnectionUpdateBanner() {
   const wasOfflineRef = useRef(false);
 
   const isSocio = user?.rol?.trim().toLowerCase() === 'socio';
-  const shouldTargetSocioPwa = isAuthenticated && isSocio && (isMobile || isStandalone);
+  const isSocioMobile = isSocio && isMobile;
+
+  // Mobile users keep the original compact experience. Any authenticated role
+  // also receives update/offline notices when Gym Master runs as an installed
+  // standalone app on desktop, tablet or mobile.
+  const shouldShowPwaStatus =
+    isAuthenticated && (isMobile || isStandalone);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -98,15 +114,16 @@ export function PwaConnectionUpdateBanner() {
     if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
 
     let intervalId: number | null = null;
-    const hadControllerAtMount = Boolean(navigator.serviceWorker.controller);
+    let cleanupRegistrationWatch: (() => void) | undefined;
+    let activeRegistration: ServiceWorkerRegistration | null = null;
 
     const markUpdateReady = () => {
-      if (!isRefreshing) {
-        setUpdateReady(true);
-      }
+      setUpdateReady(true);
     };
 
     const watchRegistration = (registration: ServiceWorkerRegistration) => {
+      activeRegistration = registration;
+
       if (registration.waiting && navigator.serviceWorker.controller) {
         markUpdateReady();
       }
@@ -115,11 +132,16 @@ export function PwaConnectionUpdateBanner() {
         const newWorker = registration.installing;
         if (!newWorker) return;
 
-        newWorker.addEventListener('statechange', () => {
-          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+        const handleStateChange = () => {
+          if (
+            newWorker.state === 'installed' &&
+            navigator.serviceWorker.controller
+          ) {
             markUpdateReady();
           }
-        });
+        };
+
+        newWorker.addEventListener('statechange', handleStateChange);
       };
 
       registration.addEventListener('updatefound', handleUpdateFound);
@@ -129,48 +151,99 @@ export function PwaConnectionUpdateBanner() {
       };
     };
 
-    let cleanupRegistrationWatch: (() => void) | undefined;
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && activeRegistration) {
+        requestRegistrationUpdate(activeRegistration);
+      }
+    };
+
+    const handleOnlineUpdateCheck = () => {
+      if (activeRegistration) {
+        requestRegistrationUpdate(activeRegistration);
+      }
+    };
 
     navigator.serviceWorker.ready
       .then((registration) => {
         cleanupRegistrationWatch = watchRegistration(registration);
+        requestRegistrationUpdate(registration);
 
         intervalId = window.setInterval(() => {
-          registration.update().catch(() => {
-            // La actualización del SW no debe romper la UI si el navegador falla o está offline.
-          });
+          requestRegistrationUpdate(registration);
         }, UPDATE_CHECK_INTERVAL_MS);
       })
       .catch(() => {
-        // Si no hay SW disponible, la experiencia online/offline sigue funcionando.
+        // Online/offline feedback remains available even when registration
+        // cannot be resolved in the current browser.
       });
 
-    const handleControllerChange = () => {
-      if (hadControllerAtMount) {
-        markUpdateReady();
-      }
-    };
-
-    navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('online', handleOnlineUpdateCheck);
 
     return () => {
       cleanupRegistrationWatch?.();
-      navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('online', handleOnlineUpdateCheck);
 
       if (intervalId) {
         window.clearInterval(intervalId);
       }
     };
-  }, [isRefreshing]);
+  }, []);
 
   const handleUpdateNow = useCallback(async () => {
+    if (!('serviceWorker' in navigator)) return;
+
     setIsRefreshing(true);
 
     try {
       const registration = await navigator.serviceWorker.getRegistration();
-      registration?.waiting?.postMessage({ type: 'SKIP_WAITING' });
+      const waitingWorker = registration?.waiting;
+
+      if (!waitingWorker) {
+        setUpdateReady(false);
+        setIsRefreshing(false);
+
+        if (registration) {
+          requestRegistrationUpdate(registration);
+        }
+
+        return;
+      }
+
+      await new Promise<void>((resolve) => {
+        let completed = false;
+
+        const finish = () => {
+          if (completed) return;
+          completed = true;
+          window.clearTimeout(timeoutId);
+          navigator.serviceWorker.removeEventListener(
+            'controllerchange',
+            handleControllerChange,
+          );
+          resolve();
+        };
+
+        const handleControllerChange = () => {
+          finish();
+        };
+
+        const timeoutId = window.setTimeout(
+          finish,
+          UPDATE_ACTIVATION_TIMEOUT_MS,
+        );
+
+        navigator.serviceWorker.addEventListener(
+          'controllerchange',
+          handleControllerChange,
+        );
+
+        waitingWorker.postMessage({ type: 'SKIP_WAITING' });
+      });
     } catch {
-      // Si el SW no responde, forzamos la recarga igualmente para tomar los assets nuevos.
+      // A controlled reload is still the safest recovery if the waiting worker
+      // disappeared between detection and user confirmation.
     }
 
     window.location.reload();
@@ -211,13 +284,16 @@ export function PwaConnectionUpdateBanner() {
     return null;
   }, [isOnline, showOnlineRestored, t, updateReady]);
 
-  if (!shouldTargetSocioPwa || !banner) return null;
+  if (!shouldShowPwaStatus || !banner) return null;
 
   const Icon = banner.icon;
+  const positionClassName = isSocioMobile
+    ? 'inset-x-3 bottom-[calc(10.2rem+env(safe-area-inset-bottom))] mx-auto max-w-md'
+    : 'inset-x-3 bottom-[calc(1rem+env(safe-area-inset-bottom))] mx-auto max-w-md md:left-auto md:right-4 md:mx-0 md:w-full';
 
   return (
     <aside
-      className='fixed inset-x-3 bottom-[calc(10.2rem+env(safe-area-inset-bottom))] z-[76] mx-auto max-w-md rounded-3xl border border-slate-200 bg-white p-3 shadow-lg md:hidden dark:border-slate-800 dark:bg-slate-950 gm-pwa-floating-card'
+      className={`fixed z-[76] rounded-3xl border border-slate-200 bg-white p-3 shadow-lg dark:border-slate-800 dark:bg-slate-950 gm-pwa-floating-card ${positionClassName}`}
       role='status'
       aria-live='polite'
     >
@@ -235,7 +311,9 @@ export function PwaConnectionUpdateBanner() {
         </div>
 
         <div className='min-w-0 flex-1'>
-          <p className='text-sm font-bold text-slate-950 dark:text-slate-50'>{banner.title}</p>
+          <p className='text-sm font-bold text-slate-950 dark:text-slate-50'>
+            {banner.title}
+          </p>
           <p className='mt-0.5 text-xs leading-5 text-slate-600 dark:text-slate-300'>
             {banner.body}
           </p>
@@ -248,13 +326,16 @@ export function PwaConnectionUpdateBanner() {
                 onClick={handleUpdateNow}
                 disabled={isRefreshing}
               >
-                {isRefreshing ? t('socioDashboard.pwa.updating') : t('socioDashboard.pwa.update')}
+                {isRefreshing
+                  ? t('socioDashboard.pwa.updating')
+                  : t('socioDashboard.pwa.update')}
               </Button>
               <Button
                 size='sm'
                 variant='ghost'
                 className='h-8 rounded-full px-3 text-xs'
                 onClick={handleDismissUpdate}
+                disabled={isRefreshing}
               >
                 {t('socioDashboard.pwa.later')}
               </Button>
@@ -265,9 +346,10 @@ export function PwaConnectionUpdateBanner() {
         {banner.kind === 'update' ? (
           <button
             type='button'
-            className='rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-900 dark:hover:text-slate-200'
+            className='rounded-full p-1 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-slate-900 dark:hover:text-slate-200'
             onClick={handleDismissUpdate}
             aria-label={t('socioDashboard.pwa.hideUpdate')}
+            disabled={isRefreshing}
           >
             <X className='h-4 w-4' aria-hidden='true' />
           </button>


### PR DESCRIPTION
# feat: complete PWA install and update QA

## Resumen

Esta rama completa el QA final de instalación y actualización de la PWA de Gym Master.

El trabajo consolida una experiencia instalable y segura en Chrome y Microsoft Edge, compatible con Next.js App Router y `next-pwa`, con actualización controlada por el usuario y sin activación automática de una versión nueva mientras existe una operación o formulario en curso.

También incluye un ajuste puntual de internacionalización detectado durante el recorrido final de la PWA instalada en `/dashboard/rutinas/media`.

## Rama

```text
feature/pwa-install-update-final-qa-v1
```

## Contexto

La rama parte de la política de caché endurecida previamente:

- APIs autenticadas mediante `NetworkOnly`.
- Navegaciones dinámicas mediante `NetworkOnly`.
- Caché limitada a assets versionados e imágenes públicas.
- Fallback offline seguro.
- Registro explícito del service worker para App Router.
- Limpieza de cachés heredadas y aislamiento entre sesiones.

Sobre esa base, esta feature se concentra en instalabilidad, ejecución standalone y actualización segura entre versiones.

## Cambios principales

### 1. Manifest y experiencia instalable

- Se validó la identidad PWA de Gym Master.
- Se conserva `display: standalone`.
- Se ajustó `orientation` de `portrait` a `any` para soportar escritorio, tablet, móvil, POS y landscape.
- Se verificaron iconos `192x192`, `512x512`, variantes `maskable` y Apple Touch Icon.
- Se conservaron `start_url`, `scope`, shortcuts y `launch_handler`.

### 2. Actualización controlada

- Se deshabilitó la activación automática mediante `skipWaiting: false`.
- Se implementó detección de un service worker nuevo en estado `waiting`.
- Se muestra una acción explícita para actualizar.
- El flujo de actualización:
  1. envía `SKIP_WAITING` al worker en espera;
  2. espera `controllerchange`;
  3. recarga una sola vez después del cambio de controlador;
  4. dispone de un timeout defensivo para evitar estados bloqueados.

### 3. Comprobación periódica de nuevas versiones

Se verifica la disponibilidad de actualización:

- al iniciar la aplicación;
- al recuperar conexión;
- al volver la pestaña o PWA al primer plano;
- periódicamente durante sesiones prolongadas.

### 4. Montaje global de la experiencia PWA

Los componentes de instalación, conectividad y actualización se montan desde `SessionWrapper`, por lo que funcionan en:

- login;
- dashboard;
- todos los roles;
- Chrome y Edge;
- navegador y modo standalone.

### 5. Limpieza del header

Se retiró del `AppHeader` la responsabilidad de montar globalmente el banner PWA, evitando dependencias de rutas o roles que no utilizan ese header.

### 6. Verificación automática

Se agregó:

```bash
npm run test:pwa-install-update
```

El script valida:

- identidad y configuración del manifest;
- orientación e iconos requeridos;
- montaje global del flujo PWA;
- actualización controlada con `skipWaiting: false`;
- espera de `controllerchange` antes de recargar;
- ausencia de artefactos generados versionados.

### 7. Hotfix de Exercise Media

Durante el QA en Edge se detectó que los niveles del catálogo core seguían visibles en español con la interfaz en inglés.

Se corrigió la presentación en:

```text
/dashboard/rutinas/media
```

Mapeo visual:

| Español | Inglés |
|---|---|
| Inicial | Beginner |
| Intermedio | Intermediate |
| Avanzado | Advanced |
| Experto | Expert |

La corrección alcanza selector, tabla, detalle y equivalencias. No modifica IDs ni datos persistidos.

## Archivos principales

```text
next.config.js
package.json
public/manifest.json
scripts/verify-pwa-install-update.mjs
src/components/SessionWrapper.tsx
src/components/header/AppHeader.tsx
src/components/pwa/PwaConnectionUpdateBanner.tsx
src/app/dashboard/rutinas/media/page.tsx
docs/pwa/pwa-install-update-final-qa-v1-baseline.md
docs/pwa/pwa-install-update-final-qa-v1-exercise-media-level-i18n-hotfix-v1a.md
```

Además, los archivos generados `public/sw.js`, `public/workbox-*.js` y `public/fallback-*.js` permanecen fuera del versionado.

## Validación automática

Ejecutado:

```bash
rm -rf .next
npm run build
npm run test:pwa-cache
npm run test:pwa-install-update
```

Resultados esperados y obtenidos:

```text
PWA cache policy OK: authenticated APIs and navigations are network-only.
PWA cache policy OK: only versioned Next.js assets and public local images use runtime caches.
PWA registration OK: App Router registers /sw.js explicitly and excludes the unavailable app build manifest.
PWA manifest OK: install identity, standalone display, orientation and icons are valid.
PWA install OK: the install prompt is mounted globally and detects installed mode.
PWA update OK: updates wait for user confirmation and reload after controllerchange.
PWA repository OK: generated service worker and Workbox assets are not versioned.
```

## QA manual realizado

### Manifest

- `display: standalone`.
- `orientation: any`.
- `start_url: /dashboard?source=pwa`.
- `scope: /`.
- Iconos normales y maskable visibles.
- Sin errores que bloqueen la instalación.

### Chrome

- Opción de instalación disponible.
- Nombre e icono correctos.
- Apertura en ventana independiente.
- `display-mode: standalone` confirmado.
- Login, dashboard, navegación, idioma, dark mode y responsive validados.

### Microsoft Edge

- Instalación correcta.
- Apertura standalone confirmada.
- Navegación y módulos internos validados.
- Recorrido de Exercise Media utilizado para detectar y cerrar el hotfix de niveles.

### Actualización Versión A → Versión B

- Se generó un build nuevo con la PWA ya instalada.
- El nuevo worker fue detectado.
- La actualización quedó esperando confirmación.
- El usuario activó la actualización.
- Se esperó `controllerchange` antes de recargar.
- El cambio nuevo quedó visible después de la actualización.
- No hubo pantalla blanca, `ChunkLoadError` ni mezcla visible de versiones.

## Seguridad y privacidad

Esta rama conserva la política ya aprobada:

- no se cachean APIs autenticadas;
- no se cachean documentos privados del dashboard;
- no se habilita operación offline transaccional ficticia;
- no se modifican permisos, RBAC, sesión ni aislamiento de usuarios;
- una actualización no se activa automáticamente mientras el usuario trabaja.

## Base de datos e infraestructura

No incluye cambios en:

```text
Base de datos
Migraciones
RLS
RPC
Seeds
Storage
Contratos API
Reglas comerciales
```

No requiere backup de Supabase ni `db push`.

## Riesgo y rollback

Riesgo principal: comportamiento de actualización del service worker en navegadores Chromium.

Rollback:

1. revertir el commit de esta rama;
2. reconstruir el proyecto;
3. desplegar nuevamente;
4. el registrador existente detectará el worker restaurado;
5. no existe migración ni cambio persistente que revertir.

## Checklist

- [x] Manifest validado.
- [x] Iconos y variantes maskable validados.
- [x] Instalación en Chrome.
- [x] Instalación en Edge.
- [x] Modo standalone confirmado.
- [x] Actualización A → B aprobada.
- [x] Recarga después de `controllerchange`.
- [x] Sin pantalla blanca.
- [x] Sin `ChunkLoadError`.
- [x] Hotfix Exercise Media ES/EN validado.
- [x] Build correcto.
- [x] Verificadores PWA correctos.
- [x] Sin DB, migraciones ni archivos sensibles.

## Resultado

Gym Master queda instalable como PWA en Chrome y Microsoft Edge, con ejecución standalone y un flujo de actualización controlado, observable y seguro para operaciones reales.
