### PR TITLE
Feature/security auth rbac final audit v1

### DIFF
--- a/docs/respaldo-negocio/admin-respaldo-exportacion-excel-worksheet-name-hotfix-v1.md
+++ b/docs/respaldo-negocio/admin-respaldo-exportacion-excel-worksheet-name-hotfix-v1.md
@@ -1,0 +1,29 @@
+# Hotfix de nombres de hojas Excel en Respaldo del negocio
+
+## Rama
+
+`feature/security-auth-rbac-final-audit-v1`
+
+## Incidencia
+
+La exportación XLSX fallaba al crear hojas cuyos rótulos contenían caracteres prohibidos por Excel. El caso visible era `Gastos / egresos`, pero cualquier rótulo presente o futuro con `\`, `/`, `*`, `?`, `:`, `[` o `]` podía provocar el mismo error.
+
+La función de normalización existente tenía expresiones regulares mal escapadas, por lo que no eliminaba correctamente los caracteres inválidos ni normalizaba los espacios.
+
+## Corrección
+
+- Sanitización centralizada de caracteres prohibidos y de control.
+- Límite estricto de 31 caracteres por hoja.
+- Eliminación de apóstrofes al inicio o final.
+- Nombres alternativos para hojas vacías.
+- Resolución determinista de nombres duplicados mediante sufijos `(2)`, `(3)`, etc.
+- Aplicación de la misma regla a la hoja Resumen y a todos los módulos exportables.
+- Gate automático `npm run test:business-backup-export`.
+
+## Resultado esperado
+
+`Gastos / egresos` se exporta como `Gastos - egresos`. La exportación completa de todos los módulos puede generarse en XLSX sin fallar por nombres de hojas. La exportación JSON no cambia.
+
+## Alcance técnico
+
+No modifica base de datos, migraciones, RLS, RPC, contratos de API, contenido exportado ni permisos Auth/RBAC.

--- a/docs/security/security-auth-rbac-final-audit-v1-api-families.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-api-families.md
@@ -1,0 +1,121 @@
+# Security Auth & RBAC Final Audit v1 — API families hardening
+
+## Rama
+
+`feature/security-auth-rbac-final-audit-v1`
+
+## Bloque
+
+Bloque 2 — Protección server-side de APIs heredadas y permisos por familia funcional.
+
+## Objetivo
+
+Cerrar rutas privadas que todavía podían ejecutarse sin una validación uniforme de JWT, rol y permiso de módulo. El guard del dashboard continúa siendo una barrera de experiencia de usuario; la autorización definitiva ahora se aplica dentro de los handlers API alcanzados por este bloque.
+
+## Alcance protegido
+
+Se endurecieron 40 archivos de rutas distribuidos en estas familias:
+
+- Actividades y turnos/cupos.
+- BI de cuotas y pagos.
+- Avisos.
+- Equipamientos, alertas, mantenimiento BI y preventivos.
+- Infraestructura edilicia, órdenes, checklists y QR.
+- Mantenimientos de equipos.
+- Productos, historial y movimientos de stock.
+- Proveedores.
+- Servicios.
+
+## Política aplicada
+
+Cada handler protegido ejecuta, antes de consultar o modificar datos:
+
+1. Validación estricta de `Authorization: Bearer <token>`.
+2. Rechazo de tokens de Terminal fuera de los endpoints autorizados.
+3. Validación del rol permitido.
+4. Validación del permiso de menú asociado al módulo.
+5. Respuesta uniforme con `401` o `403` para fallas de autenticación/autorización.
+
+La infraestructura compartida incorpora:
+
+- `authorizeDashboardRequest(...)` para componer autenticación, rol y permiso.
+- `requireAnyDashboardPermission(...)` para APIs compartidas por más de un módulo.
+- `authorizationErrorResponse(...)` para no convertir rechazos de seguridad en errores `500`.
+
+## Reglas relevantes por dominio
+
+### Actividades
+
+- Admin, usuario interno y socio pueden consultar actividades y turnos si poseen el permiso `Actividades`.
+- Solo admin y usuario interno autorizado pueden crear, modificar o eliminar actividades y turnos.
+- El socio conserva la posibilidad de solicitar/cancelar su propia inscripción mediante las comprobaciones de propiedad existentes.
+
+### Comercial
+
+- Las lecturas de productos, proveedores y servicios conservan compatibilidad con los módulos que legítimamente las consumen, incluido POS/Kiosco.
+- Las mutaciones permanecen vinculadas al permiso específico de Productos, Proveedores o Servicios.
+- Los movimientos de stock requieren acceso a Stock Ledger o Productos.
+
+### Infraestructura
+
+- Mantenimiento edilicio, activos, sectores, órdenes y checklists requieren el permiso correspondiente.
+- Etiquetas QR y lector QR/barra comparten únicamente los endpoints QR necesarios.
+- El resto de los módulos no obtiene acceso por esa compatibilidad.
+
+### Cuotas y pagos
+
+El dashboard BI de cuotas requiere el permiso `Pagos`, asociado a `/dashboard/bi-cuotas-pagos`.
+
+## Clientes actualizados
+
+Los clientes browser que antes llamaban rutas ahora protegidas sin Bearer agregan `authHeader()`:
+
+- `infraestructuraMantenimientoClient.ts`
+- `equipamientoPreventivoClient.ts`
+- `equipamientoService.ts` para alertas y BI
+- `cuotasPagosBiApiClient.ts`
+
+## Verificación automática
+
+```bash
+npm run test:auth-rbac
+```
+
+El gate comprueba:
+
+- aislamiento del token de Terminal;
+- helpers de rol y permisos simples/múltiples;
+- protección de los 40 archivos de rutas;
+- preservación de respuestas 401/403;
+- ausencia de uso directo de `authMiddleware` sin permiso de módulo en estas familias;
+- encabezados Bearer en los clientes actualizados;
+- reglas críticas de Actividades, POS/Kiosco, Stock Ledger, Cuotas e Infraestructura QR.
+
+## QA manual sugerido
+
+### Usuario autorizado
+
+- Abrir cada módulo desde el menú.
+- Confirmar carga de listados, detalles y métricas.
+- Ejecutar una operación segura de creación/edición cuando exista un dato de prueba.
+- Confirmar respuestas `200/201` y ausencia de regresiones visuales.
+
+### Usuario sin permiso del módulo
+
+- Intentar la URL del dashboard manualmente.
+- Ejecutar la API correspondiente con su JWT normal.
+- Confirmar `403`, sin datos parciales ni respuesta `500`.
+
+### Socio
+
+- Confirmar lectura e inscripción propia en Actividades.
+- Confirmar bloqueo `403` en Avisos administrativos, Equipamientos, Infraestructura, Cuotas BI, Productos, Proveedores y Servicios.
+
+### Sin token y token de Terminal
+
+- Sin Bearer: `401`.
+- Token de Terminal contra cualquier ruta de este bloque: `403`.
+
+## Base de datos
+
+Este bloque no modifica tablas, migraciones, RLS, RPC ni datos persistidos. La seguridad de tenant y las políticas de acceso a nivel de Supabase se auditarán en `feature/database-rls-final-audit-v1`.

--- a/docs/security/security-auth-rbac-final-audit-v1-baseline.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-baseline.md
@@ -53,13 +53,21 @@ El endurecimiento de familias API quedó documentado en:
 
 Este bloque incorpora autenticación, rol, permiso de módulo y respuestas 401/403 uniformes en 40 archivos de rutas de Actividades, Cuotas, Avisos, Equipamientos, Infraestructura, Mantenimientos, Productos, Proveedores y Servicios.
 
-## Próximos bloques
+## Bloque 3 completado
 
-1. Auditar operaciones con `socioId`, `id_socio`, `usuarioId` o parámetros equivalentes.
-2. Validar Master Admin y sincronización de licencia.
-3. Revisar rutas protegidas restantes fuera de las familias cubiertas.
-4. Ejecutar la matriz manual por rol y por URL directa.
-5. Documentar hallazgos que deban resolverse específicamente con RLS.
+El endurecimiento de recursos sensibles quedó documentado en:
+
+`docs/security/security-auth-rbac-final-audit-v1-sensitive-resources.md`
+
+Este bloque incorpora autorización por módulo y propiedad del socio en Socios, Pagos, Ficha médica, Rutinas, Dietas, Evolución física, Mensajes, Notificaciones y analítica sensible. También aísla la gestión de licencia al rol Master Admin y reduce la exposición del verificador público de recibos.
+
+## Próximos pasos de la rama
+
+1. Ejecutar build y matriz manual completa del Bloque 3.
+2. Corregir únicamente regresiones detectadas durante QA.
+3. Realizar el gate consolidado de los tres bloques.
+4. Preparar PR e informe técnico de cierre.
+5. Registrar para la auditoría RLS cualquier riesgo que dependa de Supabase y no de la API.
 
 ## Base de datos
 

--- a/docs/security/security-auth-rbac-final-audit-v1-baseline.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-baseline.md
@@ -61,11 +61,19 @@ El endurecimiento de recursos sensibles quedó documentado en:
 
 Este bloque incorpora autorización por módulo y propiedad del socio en Socios, Pagos, Ficha médica, Rutinas, Dietas, Evolución física, Mensajes, Notificaciones y analítica sensible. También aísla la gestión de licencia al rol Master Admin y reduce la exposición del verificador público de recibos.
 
+## Bloque 4 completado
+
+El barrido final quedó documentado en:
+
+`docs/security/security-auth-rbac-final-audit-v1-final-sweep.md`
+
+Este bloque clasifica explícitamente los 175 archivos de API Routes, protege las familias operativas restantes, refuerza la confirmación Stripe y el perfil propio, registra las excepciones públicas/internas, endurece el proxy de imágenes y valida la firma real de archivos antes de cargarlos.
+
 ## Próximos pasos de la rama
 
-1. Ejecutar build y matriz manual completa del Bloque 3.
-2. Corregir únicamente regresiones detectadas durante QA.
-3. Realizar el gate consolidado de los tres bloques.
+1. Ejecutar build y gates automáticos consolidados.
+2. Ejecutar la matriz manual del Bloque 4.
+3. Corregir únicamente regresiones detectadas durante QA.
 4. Preparar PR e informe técnico de cierre.
 5. Registrar para la auditoría RLS cualquier riesgo que dependa de Supabase y no de la API.
 

--- a/docs/security/security-auth-rbac-final-audit-v1-baseline.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-baseline.md
@@ -45,14 +45,21 @@ Se detectaron rutas heredadas de actividades, avisos, cuotas, equipamientos, inf
   - aislamiento del socio autenticado.
 - Verificador estático `npm run test:auth-rbac`.
 
+## Bloque 2 completado
+
+El endurecimiento de familias API quedó documentado en:
+
+`docs/security/security-auth-rbac-final-audit-v1-api-families.md`
+
+Este bloque incorpora autenticación, rol, permiso de módulo y respuestas 401/403 uniformes en 40 archivos de rutas de Actividades, Cuotas, Avisos, Equipamientos, Infraestructura, Mantenimientos, Productos, Proveedores y Servicios.
+
 ## Próximos bloques
 
-1. Proteger endpoints heredados sin autenticación explícita.
-2. Aplicar RBAC server-side por familia funcional.
-3. Auditar operaciones con `socioId`, `id_socio`, `usuarioId` o parámetros equivalentes.
-4. Normalizar respuestas 401/403 sin convertir fallas de autorización en 500.
-5. Validar Master Admin y sincronización de licencia.
-6. Ejecutar matriz manual por rol y por URL directa.
+1. Auditar operaciones con `socioId`, `id_socio`, `usuarioId` o parámetros equivalentes.
+2. Validar Master Admin y sincronización de licencia.
+3. Revisar rutas protegidas restantes fuera de las familias cubiertas.
+4. Ejecutar la matriz manual por rol y por URL directa.
+5. Documentar hallazgos que deban resolverse específicamente con RLS.
 
 ## Base de datos
 

--- a/docs/security/security-auth-rbac-final-audit-v1-baseline.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-baseline.md
@@ -1,0 +1,59 @@
+# Security Auth & RBAC Final Audit v1 — baseline
+
+## Rama
+
+`feature/security-auth-rbac-final-audit-v1`
+
+## Objetivo
+
+Realizar la auditoría final de autenticación, autorización y aislamiento por rol antes de la revisión específica de RLS y del cierre de producción.
+
+## Hallazgos iniciales
+
+### 1. Sesiones de Terminal reutilizables fuera de su alcance
+
+El JWT renovado para la Terminal incluye `terminal_session: true`, pero el middleware de autenticación aceptaba ese token en cualquier endpoint protegido que recibiera el encabezado `Authorization`.
+
+Esto permitía que una sesión operativa de larga duración intentara reutilizarse fuera de los endpoints estrictamente necesarios para la Terminal.
+
+### 2. Autenticación no equivale a autorización
+
+Una parte importante de los endpoints ya valida JWT, pero varios solo comprueban que exista un usuario autenticado. Todavía debe auditarse por familias si el rol, el permiso de menú y el alcance del socio solicitado son coherentes con la operación.
+
+### 3. Endpoints heredados sin autenticación explícita
+
+Se detectaron rutas heredadas de actividades, avisos, cuotas, equipamientos, infraestructura, mantenimientos, productos, proveedores y servicios que todavía no invocan `authMiddleware` directamente. Deben clasificarse entre públicas intencionales y privadas, y endurecerse en parches sucesivos.
+
+### 4. El guard del dashboard es una barrera de UX, no la frontera de seguridad
+
+`DashboardRouteGuard` impide la navegación normal por URL y mejora la experiencia, pero se ejecuta en cliente y usa estado persistido. La protección definitiva debe residir en cada API y, posteriormente, en las políticas RLS de Supabase.
+
+## Primer endurecimiento aplicado
+
+- Validación estricta del encabezado `Authorization: Bearer <token>`.
+- Validación mínima del payload JWT: identidad, correo y rol reconocido.
+- Errores tipados con código y estado HTTP.
+- Rechazo por defecto de tokens con `terminal_session: true`.
+- Opt-in explícito para los tres endpoints operativos de Terminal:
+  - `GET /api/asistencias/qr-dia`
+  - `GET /api/asistencias/recientes`
+  - `GET /api/notificaciones/terminal`
+- Validación server-side del permiso `/dashboard/asistencias/terminal` en esos endpoints.
+- Helpers reutilizables para:
+  - roles permitidos;
+  - permisos de módulo;
+  - aislamiento del socio autenticado.
+- Verificador estático `npm run test:auth-rbac`.
+
+## Próximos bloques
+
+1. Proteger endpoints heredados sin autenticación explícita.
+2. Aplicar RBAC server-side por familia funcional.
+3. Auditar operaciones con `socioId`, `id_socio`, `usuarioId` o parámetros equivalentes.
+4. Normalizar respuestas 401/403 sin convertir fallas de autorización en 500.
+5. Validar Master Admin y sincronización de licencia.
+6. Ejecutar matriz manual por rol y por URL directa.
+
+## Base de datos
+
+Este parche no modifica tablas, migraciones, RLS, RPC ni datos persistidos. La auditoría de políticas de Supabase se mantiene separada para `feature/database-rls-final-audit-v1`.

--- a/docs/security/security-auth-rbac-final-audit-v1-final-sweep.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-final-sweep.md
@@ -1,0 +1,231 @@
+# Security Auth & RBAC Final Audit v1 — final sweep
+
+## Rama
+
+`feature/security-auth-rbac-final-audit-v1`
+
+## Bloque
+
+Bloque 4 — Barrido final, clasificación explícita de API Routes y cierre de fronteras públicas/internas.
+
+## Objetivo
+
+Completar la auditoría de autenticación y autorización de la aplicación antes de la revisión específica de RLS. El objetivo de este bloque es que ninguna API Route quede pública por omisión y que cada operación privada aplique, según corresponda:
+
+1. JWT válido mediante `Authorization: Bearer <token>`.
+2. Rechazo de tokens de Terminal fuera de su alcance.
+3. Rol autorizado.
+4. Permiso real del módulo.
+5. Propiedad del socio o de la cuenta cuando el recurso sea personal.
+6. Respuestas `401` y `403` tipadas, sin convertir rechazos de seguridad en `500`.
+
+## Resultado consolidado
+
+El verificador `npm run test:auth-rbac` clasifica los **175 archivos `route.ts`** existentes debajo de `src/app/api`.
+
+La cobertura acumulativa queda compuesta por:
+
+- 3 endpoints operativos de Terminal con opt-in explícito.
+- 40 rutas heredadas protegidas en el Bloque 2.
+- 24 rutas sensibles de dashboard protegidas en el Bloque 3.
+- 20 rutas personales con alcance por socio protegidas en el Bloque 3.
+- 68 rutas operativas del barrido final con rol y permiso de módulo.
+- 3 rutas personales o de cuenta propia del barrido final.
+- 6 rutas autenticadas de alcance transversal.
+- 11 rutas públicas o internas con política explícita y control específico.
+
+No quedan API Routes implícitamente públicas.
+
+## Familias privadas cerradas en el barrido final
+
+### Operación, asistencia y analítica
+
+- Asistencias, egresos y aforo.
+- Ranking de asistencia.
+- Métricas de asistencia y retención.
+- Métricas de equipamiento.
+- Respaldo y exportación del negocio.
+
+### Comercial y finanzas
+
+- Caja.
+- POS/Kiosco y scanner móvil administrativo.
+- Compras y reposición.
+- Ventas y detalles de venta.
+- Códigos, QR y etiquetas.
+- Stock Ledger.
+- Packs, promociones y servicios.
+- Finanzas BI.
+- Cuotas, descuentos, pagos y confirmación Stripe.
+- Otros gastos y comprobantes.
+
+### Personal y administración
+
+- Empleados y sueldos.
+- Entrenadores y horarios.
+- Usuarios internos.
+- Perfil propio de usuario.
+- Datos y logo del gimnasio.
+- Parametrización, niveles y objetivos.
+
+La ruta heredada `/dashboard/entrenadores` reutiliza explícitamente el permiso `Empleados`, evitando que un usuario interno autorizado sea bloqueado antes de su redirección.
+
+### IA, RAG y media
+
+- Chat, búsqueda y estado del Coach.
+- Corpus, ingesta y vectorización, reservados al administrador.
+- Catálogo, importación, sincronización y carga de media de ejercicios.
+
+### Soporte
+
+- Tickets y detalle de tickets de Dragon Pyramid.
+- El endpoint heredado `/api/test-alertas`, que puede desactivar socios por deuda, queda limitado a administrador y responde `404` en producción.
+
+## Recursos personales reforzados
+
+### Asistencia QR
+
+`/api/asistencias/registro-qr` autoriza antes de leer o procesar el código. El socio puede registrar su propia asistencia y el personal autorizado puede operar desde Asistencias. El token de Terminal no obtiene acceso implícito a esta ruta.
+
+### Estado de cuota
+
+`/api/cuota-estado` ignora cualquier `socio_id` enviado por el navegador cuando el solicitante es socio y utiliza exclusivamente `user.id_socio`.
+
+### Perfil de usuario
+
+`/api/usuarios/[id]/perfil` permite la cuenta propia o un administrador con permiso `Usuarios`. Un usuario interno o socio no puede cambiar el ID para consultar otra cuenta.
+
+### Confirmación Stripe
+
+`/api/pagar-cuota/confirmar` queda limitada al rol `socio` con acceso a `Pagar cuota`. Antes de registrar el pago valida simultáneamente:
+
+- `metadata.usuario_id === user.id`;
+- `metadata.socio_id === user.id_socio`;
+- presencia de ambos metadatos.
+
+Una sesión Stripe ajena, incompleta o manipulada responde `403`.
+
+## Políticas públicas e internas explícitas
+
+Las excepciones que no usan un JWT normal declaran una política visible en el código:
+
+| Política | Endpoint o familia | Control principal |
+|---|---|---|
+| `PUBLIC_AUTH_PROVIDER` | NextAuth | Proveedor de autenticación |
+| `PUBLIC_LOGIN` | Login personalizado | Credenciales y rol solicitado |
+| `PUBLIC_RECOVERY` | Solicitud de recuperación | Flujo de reset controlado |
+| `PUBLIC_RECOVERY_TOKEN` | Validación/reset | Token de recuperación |
+| `TERMINAL_BEARER_REFRESH` | Renovación Terminal | JWT normal, permiso Asistencias y emisión acotada |
+| `PUBLIC_TOKEN` | Scanner móvil público | Token aleatorio con formato, expiración y estado de sesión |
+| `PUBLIC_VERIFICATION_CODE` | Verificación de recibo | ID + código de verificación, exposición reducida |
+| `PUBLIC_SIGNED_WEBHOOK` | Stripe webhook | Firma `stripe-signature` |
+| `PUBLIC_DOCUMENTATION` | Swagger JSON | Especificación pública intencional |
+| `PUBLIC_CONTROLLED` | Proxy de imágenes | Validación de URL, red, redirecciones, tipo y tamaño |
+| `INTERNAL_SHARED_SECRET` | Sincronización de licencia | Secreto dedicado y comparación en tiempo constante |
+
+## Endurecimiento del proxy de imágenes
+
+El proxy público requerido por los PDFs ahora:
+
+- acepta únicamente HTTP/HTTPS;
+- rechaza credenciales embebidas y puertos no permitidos;
+- bloquea localhost, dominios internos y rangos IP privados, loopback, link-local, reservados y multicast;
+- resuelve DNS antes de cada destino;
+- valida nuevamente cada redirección;
+- limita las redirecciones a tres;
+- exige `Content-Type: image/*`;
+- limita la respuesta a 10 MB;
+- agrega `X-Content-Type-Options: nosniff`.
+
+Este control reduce el riesgo SSRF en la capa de aplicación. La política de red y egress de la plataforma deberá revisarse también durante la preparación de producción.
+
+## Seguridad de cargas
+
+Se incorpora `src/lib/security/uploadValidation.ts` para verificar tipo MIME permitido y firma binaria real antes de enviar archivos a Cloudinary.
+
+La validación se aplica a:
+
+- fotografía de perfil;
+- logo del gimnasio;
+- media de ejercicios;
+- comprobantes de gastos.
+
+Formatos reconocidos:
+
+- PNG;
+- JPEG;
+- WEBP;
+- GIF;
+- HEIC/HEIF;
+- PDF únicamente en comprobantes.
+
+SVG queda excluido de cargas de usuario por su capacidad de contener contenido activo. Un archivo cuyo contenido no coincide con el MIME declarado responde `400`.
+
+## Clientes browser
+
+El gate verifica que los clientes de operación, comercial, finanzas, parametrización, soporte, RAG, usuarios y respaldo conserven encabezados Bearer al llamar las rutas ahora protegidas.
+
+## Verificación automática
+
+```bash
+npm run test:auth-rbac
+```
+
+El gate falla cuando:
+
+- aparece una API Route nueva sin clasificación;
+- una ruta protegida deja de invocar el helper esperado;
+- se pierde la respuesta tipada de autorización;
+- un cliente crítico deja de enviar Bearer;
+- se relaja el aislamiento de Terminal, socio, cuenta propia o Master Admin;
+- se elimina un control de los endpoints públicos;
+- una carga deja de validar la firma real del archivo.
+
+## QA manual mínimo
+
+### Administrador
+
+- Recorrer operación, comercial, usuarios, parametrización, soporte, RAG y respaldo.
+- Confirmar carga y mutaciones autorizadas sin `401/403` incorrectos.
+
+### Usuario interno
+
+- Probar un usuario con permiso y otro sin permiso.
+- Confirmar `200` para módulos autorizados y `403` para URL/API no autorizada.
+
+### Socio
+
+- Confirmar Coach, pagos propios, cuota, asistencia QR y perfil propio.
+- Probar IDs de otro socio, otra cuenta y otra sesión Stripe; deben responder `403`.
+
+### Master Admin
+
+- Confirmar acceso exclusivo a licencia.
+- Confirmar bloqueo de módulos operativos no asignados.
+
+### Público e interno
+
+- Scanner: token inválido/expirado no expone sesión.
+- Recibo: código inválido no expone datos.
+- Stripe webhook: firma inválida es rechazada.
+- Image proxy: localhost, IP privada, puerto no permitido y recurso no imagen son rechazados.
+- License sync: secreto ausente o incorrecto es rechazado.
+
+### Uploads
+
+- Imagen válida aceptada.
+- Archivo renombrado con MIME falso rechazado.
+- SVG rechazado.
+- Archivo sobre el límite rechazado.
+
+## Límites y trabajo posterior
+
+Esta rama protege la frontera Next.js y la navegación por rol. La garantía multi-tenant definitiva también depende de políticas RLS, RPC y consultas de Supabase, que se auditarán en:
+
+`feature/database-rls-final-audit-v1`
+
+Los endpoints públicos de login, recuperación, scanner e image proxy también deben recibir rate limiting en la capa de plataforma/edge para producción. No se implementa un contador en memoria dentro de Next.js porque no ofrece garantías consistentes en despliegues serverless distribuidos.
+
+## Base de datos
+
+Este bloque no modifica tablas, migraciones, RLS, RPC, seeds ni datos persistidos.

--- a/docs/security/security-auth-rbac-final-audit-v1-sensitive-resources.md
+++ b/docs/security/security-auth-rbac-final-audit-v1-sensitive-resources.md
@@ -1,0 +1,124 @@
+# Security Auth & RBAC Final Audit v1 — recursos sensibles y propiedad
+
+## Rama
+
+`feature/security-auth-rbac-final-audit-v1`
+
+## Bloque
+
+Bloque 3 — datos personales, propiedad del socio y aislamiento de Master Admin.
+
+## Objetivo
+
+Impedir que un JWT autenticado sea suficiente para consultar o modificar recursos sensibles. Cada operación debe validar, según corresponda:
+
+1. identidad autenticada;
+2. rol permitido;
+3. permiso del módulo;
+4. socio objetivo;
+5. propiedad del recurso;
+6. exposición mínima de datos.
+
+## Hallazgos corregidos
+
+### Socios y pagos
+
+- El detalle `/api/socios/[id]` podía consultar un socio por ID sin comprobar que un usuario con rol `socio` estuviera solicitando su propio registro.
+- `/api/pagos/[id]` no tenía una frontera Auth/RBAC equivalente a la colección de pagos.
+- Las colecciones de socios y pagos validaban autenticación, pero no aplicaban de manera uniforme el permiso del módulo.
+- El historial `/api/mi-cuenta/pagos` ahora queda reservado al rol `socio` y filtra por el socio resuelto desde el JWT o desde la relación `usuario_id`.
+- La verificación pública de recibos conserva su propósito, exige código válido y deja de exponer el correo electrónico del socio.
+
+### Rutinas
+
+- La generación aceptaba un `id_socio` enviado por el cliente antes de consolidar la identidad propia del socio autenticado.
+- El historial por socio no rechazaba de forma uniforme una consulta cruzada.
+- Los usuarios internos autorizados no eran tratados consistentemente como gestores en todas las operaciones.
+
+Ahora el socio siempre se resuelve desde su JWT o relación de usuario; un ID distinto produce `403`. Los roles `admin` y `usuario` requieren el permiso de Rutinas.
+
+### Dietas
+
+Las lecturas, generación y consulta por ID ahora validan el socio propietario. Un socio no puede usar un ID de dieta o de socio perteneciente a otra persona. La consulta global queda reservada a gestores autorizados.
+
+### Evolución física
+
+Las altas y consultas resuelven el socio propio incluso cuando el JWT no contiene `id_socio`. Un `socio_id` enviado por el cliente no puede reemplazar la identidad autenticada. Las consultas administrativas requieren el permiso del Gestor de evolución física.
+
+### Ficha médica
+
+Todas las rutas de ficha actual, historial, detalle y actualización aplican autorización personal o permiso administrativo. El servicio mantiene la validación de relación entre usuario y socio antes de devolver o modificar información clínica.
+
+### Mensajes y notificaciones
+
+- Mensajes administrativos: permiso `/dashboard/mensajes-admin`.
+- Mensajes personales: rol socio y permiso `/dashboard/mensajes`.
+- Centro, plantillas, detalle y envío de notificaciones: permiso `/dashboard/notificaciones`.
+- Notificaciones del header: sesión autenticada y respuesta 401 tipada.
+
+### Analítica sensible
+
+Se endurecieron los endpoints de:
+
+- BI demográfico y promociones;
+- ranking mensual y bonificaciones;
+- métricas de pagos/finanzas;
+- métricas y generación administrativa de rutinas.
+
+Cada familia exige el permiso exacto de su pantalla además del rol `admin` o `usuario`.
+
+### Master Admin y licencia Dragon Pyramid
+
+La consulta, edición y reactivación de licencia exigen explícitamente:
+
+- rol `masteradmin`;
+- acceso a `/dashboard/masteradmin/license`;
+- respuestas tipadas 401/403.
+
+El aviso de licencia continúa limitado a `admin` y `masteradmin`. El estado de suspensión conserva una respuesta reducida para socios, sin detalles internos ni nombre del cliente.
+
+### Archivos y fotografías
+
+La foto de perfil se carga en una carpeta derivada del rol autenticado y se asigna al mismo usuario del JWT. Los errores de autenticación se preservan como 401. Las cargas administrativas especializadas conservan sus controles de rol y tamaño/tipo de archivo.
+
+## Verificación automática
+
+```bash
+npm run test:auth-rbac
+```
+
+El gate comprueba:
+
+- middleware JWT y aislamiento de Terminal;
+- 40 rutas heredadas del Bloque 2;
+- 24 rutas sensibles con rol y permiso de dashboard;
+- 20 rutas personales con alcance de socio o gestión autorizada;
+- propiedad en rutinas, dietas, evolución, ficha médica, detalle de socio y pagos;
+- aislamiento de Master Admin;
+- redacción del recibo público;
+- actualización de foto del usuario autenticado.
+
+## QA manual requerido
+
+Probar la matriz con:
+
+- Master Admin;
+- administrador;
+- usuario interno con permiso;
+- usuario interno sin permiso;
+- socio propietario;
+- socio intentando usar el ID de otro socio;
+- ausencia de token;
+- token de Terminal fuera de su alcance.
+
+Validar especialmente respuestas `200`, `401` y `403`, ausencia de `500` por autorización y ausencia de datos parciales antes del rechazo.
+
+## Límites del bloque
+
+Este endurecimiento se ejecuta en API Routes y servicios del servidor. No reemplaza la protección de base de datos. El aislamiento multi-tenant, las políticas RLS y las operaciones directas contra Supabase se revisarán en:
+
+`feature/database-rls-final-audit-v1`
+
+## Base de datos
+
+No se agregan migraciones, tablas, políticas RLS, RPC ni cambios de datos persistidos.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:e2e:install": "playwright install chromium",
     "test:pwa-cache": "node scripts/verify-pwa-cache-policy.mjs",
     "test:pwa-install-update": "node scripts/verify-pwa-install-update.mjs",
-    "test:auth-rbac": "node scripts/verify-auth-rbac-security.mjs"
+    "test:auth-rbac": "node scripts/verify-auth-rbac-security.mjs",
+    "test:business-backup-export": "node scripts/verify-business-backup-export.mjs"
   },
   "dependencies": {
     "@getbrevo/brevo": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:install": "playwright install chromium",
     "test:pwa-cache": "node scripts/verify-pwa-cache-policy.mjs",
-    "test:pwa-install-update": "node scripts/verify-pwa-install-update.mjs"
+    "test:pwa-install-update": "node scripts/verify-pwa-install-update.mjs",
+    "test:auth-rbac": "node scripts/verify-auth-rbac-security.mjs"
   },
   "dependencies": {
     "@getbrevo/brevo": "^2.5.0",

--- a/scripts/verify-auth-rbac-security.mjs
+++ b/scripts/verify-auth-rbac-security.mjs
@@ -110,6 +110,155 @@ const protectedPersonalResourceRoutes = [
   'src/app/api/socios/[id]/route.ts',
 ];
 
+// Final Auth/RBAC sweep: every remaining operational API receives an explicit
+// dashboard, personal, self-account or controlled-public policy.
+const protectedFinalDashboardRoutes = [
+  'src/app/api/admin/metricas/asistencia/[tipo]/route.ts',
+  'src/app/api/admin/metricas/asistencia/prediccion-abandono/route.ts',
+  'src/app/api/admin/metricas/asistencia/top-inactivos/route.ts',
+  'src/app/api/admin/metricas/equipamiento/costo-beneficio/route.ts',
+  'src/app/api/admin/metricas/equipamiento/estado-actual/route.ts',
+  'src/app/api/admin/metricas/equipamiento/prediccion-fallo/route.ts',
+  'src/app/api/admin/metricas/equipamiento/top-fallos/route.ts',
+  'src/app/api/admin/metricas/retencion_por_combinacion/route.ts',
+  'src/app/api/admin/respaldo-negocio/exportar/route.ts',
+  'src/app/api/admin/respaldo-negocio/route.ts',
+  'src/app/api/asistencias/[id]/salida/route.ts',
+  'src/app/api/asistencias/aforo/route.ts',
+  'src/app/api/asistencias/ranking-mensual/route.ts',
+  'src/app/api/asistencias/route.ts',
+  'src/app/api/comercial/caja/route.ts',
+  'src/app/api/comercial/codigos/labels/route.ts',
+  'src/app/api/comercial/codigos/qr/route.ts',
+  'src/app/api/comercial/compras-reposicion/route.ts',
+  'src/app/api/comercial/kiosco-pos/route.ts',
+  'src/app/api/comercial/mobile-scanner/route.ts',
+  'src/app/api/comercial/pack-analytics/route.ts',
+  'src/app/api/comercial/servicios-promociones/route.ts',
+  'src/app/api/comercial/stock-ledger/route.ts',
+  'src/app/api/compras/[id]/route.ts',
+  'src/app/api/compras/route.ts',
+  'src/app/api/cuota/[id]/route.ts',
+  'src/app/api/cuota/route.ts',
+  'src/app/api/empleados-sueldos/[id]/route.ts',
+  'src/app/api/empleados-sueldos/route.ts',
+  'src/app/api/empleados/[id]/route.ts',
+  'src/app/api/empleados/route.ts',
+  'src/app/api/entrenadores/[id]/horarios/route.ts',
+  'src/app/api/entrenadores/[id]/route.ts',
+  'src/app/api/entrenadores/route.ts',
+  'src/app/api/finanzas/dashboard-bi/route.ts',
+  'src/app/api/gimnasio-parametrizacion/logo-upload/route.ts',
+  'src/app/api/gimnasio-parametrizacion/route.ts',
+  'src/app/api/gimnasio-parametrizacion/stripe-status/route.ts',
+  'src/app/api/niveles/route.ts',
+  'src/app/api/objetivos/route.ts',
+  'src/app/api/otros_gastos/comprobante-upload/route.ts',
+  'src/app/api/otros_gastos/route.ts',
+  'src/app/api/pagar-cuota/confirmar/route.ts',
+  'src/app/api/pagar-cuota/route.ts',
+  'src/app/api/parametrizacion/catalogos/route.ts',
+  'src/app/api/parametrizacion/cuotas-descuento/route.ts',
+  'src/app/api/rag/coach/chat/route.ts',
+  'src/app/api/rag/coach/corpus/run/route.ts',
+  'src/app/api/rag/coach/corpus/status/route.ts',
+  'src/app/api/rag/coach/ingest/dietas/route.ts',
+  'src/app/api/rag/coach/ingest/ejercicios/route.ts',
+  'src/app/api/rag/coach/search/route.ts',
+  'src/app/api/rag/coach/status/route.ts',
+  'src/app/api/rag/coach/vectorize/pending/route.ts',
+  'src/app/api/rutinas/ejercicios-media/equivalence-sync/route.ts',
+  'src/app/api/rutinas/ejercicios-media/import/route.ts',
+  'src/app/api/rutinas/ejercicios-media/route.ts',
+  'src/app/api/rutinas/ejercicios-media/upload/route.ts',
+  'src/app/api/rutinas/ejercicios-media/youtube-auto-discovery/route.ts',
+  'src/app/api/rutinas/ejercicios-media/youtube-import/route.ts',
+  'src/app/api/soporte/tickets/[id]/route.ts',
+  'src/app/api/soporte/tickets/route.ts',
+  'src/app/api/test-alertas/route.ts',
+  'src/app/api/usuarios/[id]/route.ts',
+  'src/app/api/usuarios/route.ts',
+  'src/app/api/ventas/[id]/route.ts',
+  'src/app/api/ventas/route.ts',
+  'src/app/api/ventas_detalles/route.ts',
+];
+
+const protectedFinalPersonalRoutes = [
+  'src/app/api/asistencias/registro-qr/route.ts',
+  'src/app/api/cuota-estado/route.ts',
+];
+
+const protectedOwnUserRoutes = [
+  'src/app/api/usuarios/[id]/perfil/route.ts',
+];
+
+const authenticatedOnlyRoutes = [
+  'src/app/api/auth/change-password/route.ts',
+  'src/app/api/dragon-pyramid/license/suspension-status/route.ts',
+  'src/app/api/dragon-pyramid/license/warning/route.ts',
+  'src/app/api/file-upload/route.ts',
+  'src/app/api/mi-cuenta/pagos/route.ts',
+  'src/app/api/notificaciones/header/route.ts',
+];
+
+const explicitNonJwtPolicies = [
+  {
+    path: 'src/app/api/auth/[...nextauth]/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_AUTH_PROVIDER',
+    snippets: ['NextAuth'],
+  },
+  {
+    path: 'src/app/api/auth/forgot-password/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_RECOVERY',
+    snippets: ['requestPasswordReset'],
+  },
+  {
+    path: 'src/app/api/auth/reset-password/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_RECOVERY_TOKEN',
+    snippets: ['validatePasswordResetToken', 'resetPasswordWithToken'],
+  },
+  {
+    path: 'src/app/api/auth/terminal-session/refresh/route.ts',
+    marker: 'AUTH POLICY: TERMINAL_BEARER_REFRESH',
+    snippets: ['terminal_session', 'jwt.verify'],
+  },
+  {
+    path: 'src/app/api/comercial/mobile-scanner/public/[token]/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_TOKEN',
+    snippets: ['PUBLIC_SCANNER_TOKEN_RE', 'Cache-Control'],
+  },
+  {
+    path: 'src/app/api/custom-login/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_LOGIN',
+    snippets: ['signIn', 'LOGIN_MISSING_FIELDS'],
+  },
+  {
+    path: 'src/app/api/image-proxy/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_CONTROLLED',
+    snippets: ['assertSafeImageUrl', "redirect: 'manual'", 'MAX_IMAGE_BYTES'],
+  },
+  {
+    path: 'src/app/api/internal/dragon-pyramid/license-sync/route.ts',
+    marker: 'AUTH POLICY: INTERNAL_SHARED_SECRET',
+    snippets: ['timingSafeEqual', 'x-dragon-pyramid-sync-key'],
+  },
+  {
+    path: 'src/app/api/pagos/[id]/verificar/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_VERIFICATION_CODE',
+    snippets: ['isPagoVerificationCodeValid'],
+  },
+  {
+    path: 'src/app/api/stripe-webhook/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_SIGNED_WEBHOOK',
+    snippets: ['constructEvent', 'stripe-signature'],
+  },
+  {
+    path: 'src/app/api/swagger-json/route.ts',
+    marker: 'AUTH POLICY: PUBLIC_DOCUMENTATION',
+    snippets: ['openApiSpec'],
+  },
+];
+
 const clientAuthChecks = [
   {
     path: 'src/services/infraestructuraMantenimientoClient.ts',
@@ -162,6 +311,85 @@ const sensitiveClientAuthChecks = [
   },
 ];
 
+const finalClientAuthChecks = [
+  {
+    path: 'src/services/browser/usuarioApiClient.ts',
+    requiredSnippets: ['/api/usuarios', 'authHeader()'],
+  },
+  {
+    path: 'src/services/browser/respaldoNegocioApiClient.ts',
+    requiredSnippets: ['/api/admin/respaldo-negocio', 'authHeader()'],
+  },
+  {
+    path: 'src/services/asistenciaAforoService.ts',
+    requiredSnippets: ['/api/asistencias/aforo', 'authHeader()'],
+  },
+  {
+    path: 'src/services/qrService.ts',
+    requiredSnippets: ['/api/asistencias/registro-qr', 'authHeader()'],
+  },
+  {
+    path: 'src/services/comercialCajaService.ts',
+    requiredSnippets: ['/api/comercial/caja', 'Authorization'],
+  },
+  {
+    path: 'src/services/comercialCodigosService.ts',
+    requiredSnippets: ['/api/comercial/codigos/labels', 'Authorization'],
+  },
+  {
+    path: 'src/services/comercialComprasReposicionService.ts',
+    requiredSnippets: ['/api/comercial/compras-reposicion', 'authHeader()'],
+  },
+  {
+    path: 'src/services/comercialKioscoService.ts',
+    requiredSnippets: ['/api/productos', 'Authorization'],
+  },
+  {
+    path: 'src/services/comercialPackAnalyticsService.ts',
+    requiredSnippets: ['/api/comercial/pack-analytics', 'Authorization'],
+  },
+  {
+    path: 'src/services/comercialServiciosPromocionesService.ts',
+    requiredSnippets: ['/api/comercial/servicios-promociones', 'authHeader()'],
+  },
+  {
+    path: 'src/services/comercialStockLedgerService.ts',
+    requiredSnippets: ['/api/comercial/stock-ledger', 'Authorization'],
+  },
+  {
+    path: 'src/services/compraService.ts',
+    requiredSnippets: ['/api/compras', 'authHeader()'],
+  },
+  {
+    path: 'src/services/ventaService.ts',
+    requiredSnippets: ['/api/ventas', 'Authorization'],
+  },
+  {
+    path: 'src/services/finanzasService.ts',
+    requiredSnippets: ['/api/finanzas/dashboard-bi', 'authHeader()'],
+  },
+  {
+    path: 'src/services/gimnasioParametrizacionService.ts',
+    requiredSnippets: ['/api/gimnasio-parametrizacion', 'authHeader()'],
+  },
+  {
+    path: 'src/services/otrosGastosService.ts',
+    requiredSnippets: ['/api/otros_gastos', 'authHeader()'],
+  },
+  {
+    path: 'src/services/parametrizacionService.ts',
+    requiredSnippets: ['/api/parametrizacion/catalogos', 'authHeader()'],
+  },
+  {
+    path: 'src/services/ragCoachChatClient.ts',
+    requiredSnippets: ['/api/rag/coach/chat', 'Authorization'],
+  },
+  {
+    path: 'src/services/ragCorpusAdminClient.ts',
+    requiredSnippets: ['/api/rag/coach/corpus/status', 'Authorization'],
+  },
+];
+
 const assertions = [
   {
     ok: authMiddleware.includes('allowTerminalSession?: boolean'),
@@ -198,6 +426,14 @@ const assertions = [
   {
     ok: authorization.includes('requireOwnSocioOrRoles'),
     message: 'Debe existir el helper de aislamiento por socio.',
+  },
+  {
+    ok: authorization.includes('authorizeOwnUserOrDashboardRequest'),
+    message: 'Debe existir el helper de perfil propio o administración autorizada.',
+  },
+  {
+    ok: authorization.includes('AUTH_USER_SCOPE_FORBIDDEN'),
+    message: 'El helper de cuentas debe rechazar acceso cruzado entre usuarios.',
   },
 ];
 
@@ -291,6 +527,93 @@ for (const route of protectedPersonalResourceRoutes) {
   );
 }
 
+for (const route of protectedFinalDashboardRoutes) {
+  const source = read(route);
+  const handlerCount = countOccurrences(source, 'export async function ');
+
+  assertions.push(
+    {
+      ok: handlerCount > 0,
+      message: `${route} debe declarar al menos un handler HTTP.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizeDashboardRequest(') >= 1,
+      message: `${route} debe exigir rol y permiso de dashboard.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizationErrorResponse(') >= handlerCount,
+      message: `${route} debe preservar 401/403 en todos sus handlers.`,
+    },
+    {
+      ok: !source.includes('authMiddleware('),
+      message: `${route} no debe limitarse a comprobar que exista un JWT.`,
+    },
+  );
+}
+
+for (const route of protectedFinalPersonalRoutes) {
+  const source = read(route);
+  const handlerCount = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].reduce(
+    (total, method) =>
+      total + countOccurrences(source, `export async function ${method}`),
+    0,
+  );
+
+  assertions.push(
+    {
+      ok: source.includes('authorizePersonalOrDashboardRequest('),
+      message: `${route} debe separar recursos personales de gestión autorizada.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizationErrorResponse(') >= handlerCount,
+      message: `${route} debe preservar respuestas 401/403 tipadas.`,
+    },
+  );
+}
+
+for (const route of protectedOwnUserRoutes) {
+  const source = read(route);
+  assertions.push(
+    {
+      ok: source.includes('authorizeOwnUserOrDashboardRequest('),
+      message: `${route} debe limitar el perfil a la cuenta propia o al administrador.`,
+    },
+    {
+      ok: source.includes('authorizationErrorResponse('),
+      message: `${route} debe preservar respuestas 401/403 tipadas.`,
+    },
+  );
+}
+
+for (const route of authenticatedOnlyRoutes) {
+  const source = read(route);
+  assertions.push(
+    {
+      ok: source.includes('authMiddleware('),
+      message: `${route} debe exigir una sesión autenticada.`,
+    },
+    {
+      ok: source.includes('authorizationErrorResponse('),
+      message: `${route} debe conservar el estado real de errores de sesión.`,
+    },
+  );
+}
+
+for (const policy of explicitNonJwtPolicies) {
+  const source = read(policy.path);
+  assertions.push({
+    ok: source.includes(policy.marker),
+    message: `${policy.path} debe declarar explícitamente ${policy.marker}.`,
+  });
+
+  for (const snippet of policy.snippets) {
+    assertions.push({
+      ok: source.includes(snippet),
+      message: `${policy.path} debe conservar el control público/interno ${snippet}.`,
+    });
+  }
+}
+
 for (const client of clientAuthChecks) {
   const source = read(client.path);
   assertions.push(
@@ -311,6 +634,16 @@ for (const client of sensitiveClientAuthChecks) {
     assertions.push({
       ok: source.includes(snippet),
       message: `${client.path} debe conservar autenticación para ${snippet}.`,
+    });
+  }
+}
+
+for (const client of finalClientAuthChecks) {
+  const source = read(client.path);
+  for (const snippet of client.requiredSnippets) {
+    assertions.push({
+      ok: source.includes(snippet),
+      message: `${client.path} debe conservar Bearer para ${snippet}.`,
     });
   }
 }
@@ -423,6 +756,128 @@ assertions.push(
   },
 );
 
+const dashboardRoutePermissions = read('src/lib/permissions/menuPermissions.ts');
+const stripeStatusRoute = read('src/app/api/gimnasio-parametrizacion/stripe-status/route.ts');
+const registroQrRoute = read('src/app/api/asistencias/registro-qr/route.ts');
+const ownProfileRoute = read('src/app/api/usuarios/[id]/perfil/route.ts');
+const imageProxyRoute = read('src/app/api/image-proxy/route.ts');
+const internalLicenseSyncRoute = read('src/app/api/internal/dragon-pyramid/license-sync/route.ts');
+const publicScannerRoute = read('src/app/api/comercial/mobile-scanner/public/[token]/route.ts');
+const paymentConfirmationRoute = read('src/app/api/pagar-cuota/confirmar/route.ts');
+const uploadValidation = read('src/lib/security/uploadValidation.ts');
+const profileUploadSecurityRoute = read('src/app/api/file-upload/route.ts');
+const logoUploadRoute = read('src/app/api/gimnasio-parametrizacion/logo-upload/route.ts');
+const exerciseMediaUploadRoute = read('src/app/api/rutinas/ejercicios-media/upload/route.ts');
+const expenseReceiptUploadRoute = read('src/app/api/otros_gastos/comprobante-upload/route.ts');
+const testAlertasRoute = read('src/app/api/test-alertas/route.ts');
+
+assertions.push(
+  {
+    ok:
+      dashboardRoutePermissions.includes('path: "/dashboard/entrenadores"') &&
+      dashboardRoutePermissions.includes('permissionKey: "Empleados"'),
+    message: 'La ruta heredada de entrenadores debe reutilizar el permiso Empleados.',
+  },
+  {
+    ok:
+      stripeStatusRoute.includes("'/dashboard/mi-cuenta/pagar-cuota'") &&
+      stripeStatusRoute.includes("['admin', 'socio']"),
+    message: 'El estado de Stripe debe funcionar para configuración admin y pago propio del socio.',
+  },
+  {
+    ok:
+      countOccurrences(registroQrRoute, 'authorizeRegistroQR(') === 3 &&
+      registroQrRoute.includes('authorizePersonalOrDashboardRequest('),
+    message: 'El registro QR debe autorizar GET y POST antes de procesar el código.',
+  },
+  {
+    ok:
+      ownProfileRoute.includes('authorizeOwnUserOrDashboardRequest(') &&
+      ownProfileRoute.includes("'/dashboard/usuarios'"),
+    message: 'El perfil de usuario debe permitir cuenta propia o administración de Usuarios.',
+  },
+  {
+    ok:
+      imageProxyRoute.includes("redirect: 'manual'") &&
+      imageProxyRoute.includes('isBlockedIp') &&
+      imageProxyRoute.includes('MAX_IMAGE_BYTES'),
+    message: 'El proxy público de imágenes debe bloquear SSRF, redirecciones inseguras y payloads grandes.',
+  },
+  {
+    ok:
+      internalLicenseSyncRoute.includes('timingSafeEqual') &&
+      internalLicenseSyncRoute.includes('DRAGON_PYRAMID_LICENSE_SYNC_SECRET'),
+    message: 'La sincronización interna de licencia debe comparar su secreto en tiempo constante.',
+  },
+  {
+    ok:
+      publicScannerRoute.includes('PUBLIC_SCANNER_TOKEN_RE') &&
+      publicScannerRoute.includes("'Cache-Control': 'no-store'"),
+    message: 'El scanner público debe validar tokens y evitar cachear sesiones.',
+  },
+  {
+    ok:
+      paymentConfirmationRoute.includes("'/dashboard/mi-cuenta/pagar-cuota'") &&
+      paymentConfirmationRoute.includes("['socio']") &&
+      paymentConfirmationRoute.includes('metadataUsuarioId !== user.id') &&
+      paymentConfirmationRoute.includes('metadataSocioId !== user.id_socio'),
+    message: 'La confirmación Stripe debe limitarse al socio dueño de la sesión y sus metadatos.',
+  },
+  {
+    ok:
+      uploadValidation.includes('hasSafeUploadSignature') &&
+      uploadValidation.includes("case 'application/pdf'") &&
+      uploadValidation.includes("case 'image/png'") &&
+      uploadValidation.includes("case 'image/jpeg'") &&
+      !uploadValidation.includes('svg'),
+    message: 'Las cargas deben validar firma real y excluir SVG activo.',
+  },
+  {
+    ok:
+      profileUploadSecurityRoute.includes('hasSafeUploadSignature') &&
+      logoUploadRoute.includes('hasSafeUploadSignature') &&
+      exerciseMediaUploadRoute.includes('hasSafeUploadSignature') &&
+      expenseReceiptUploadRoute.includes('hasSafeUploadSignature'),
+    message: 'Perfil, logo, media y comprobantes deben validar la firma del archivo antes de subirlo.',
+  },
+  {
+    ok:
+      testAlertasRoute.includes("process.env.NODE_ENV === 'production'") &&
+      testAlertasRoute.includes("['admin']"),
+    message: 'El endpoint de diagnóstico de alertas debe ser admin-only y permanecer deshabilitado en producción.',
+  },
+);
+
+function listApiRouteFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) return listApiRouteFiles(absolute);
+    if (entry.name !== 'route.ts') return [];
+    return [path.relative(root, absolute).replaceAll('\\', '/')];
+  });
+}
+
+const classifiedApiRoutes = new Set([
+  ...terminalRoutes,
+  ...protectedLegacyApiRoutes,
+  ...protectedSensitiveDashboardRoutes,
+  ...protectedPersonalResourceRoutes,
+  ...protectedFinalDashboardRoutes,
+  ...protectedFinalPersonalRoutes,
+  ...protectedOwnUserRoutes,
+  ...authenticatedOnlyRoutes,
+  ...explicitNonJwtPolicies.map((policy) => policy.path),
+]);
+const allApiRouteFiles = listApiRouteFiles(path.join(root, 'src/app/api'));
+const unclassifiedApiRoutes = allApiRouteFiles.filter(
+  (route) => !classifiedApiRoutes.has(route),
+);
+
+assertions.push({
+  ok: unclassifiedApiRoutes.length === 0,
+  message: `Todas las API Routes deben tener política Auth/RBAC explícita. Sin clasificar: ${unclassifiedApiRoutes.join(', ')}`,
+});
+
 const failures = assertions.filter((assertion) => !assertion.ok);
 
 if (failures.length > 0) {
@@ -462,4 +917,22 @@ console.log(
 );
 console.log(
   'Protected browser clients OK: infrastructure, preventive equipment, equipment BI and fees BI send Bearer headers.',
+);
+console.log(
+  'Final browser clients OK: operational, commercial, finance, support and RAG clients send Bearer headers.',
+);
+console.log(
+  'Upload security OK: profile, branding, exercise media and receipts validate MIME type and file signature.',
+);
+console.log(
+  `Final dashboard APIs OK: ${protectedFinalDashboardRoutes.length} routes enforce role and module permission.`,
+);
+console.log(
+  `Final personal/account APIs OK: ${protectedFinalPersonalRoutes.length + protectedOwnUserRoutes.length} routes enforce personal or self-account scope.`,
+);
+console.log(
+  `Explicit API policy registry OK: ${classifiedApiRoutes.size} route files are classified; no implicit public endpoints remain.`,
+);
+console.log(
+  'Controlled public endpoints OK: scanner tokens, Stripe signatures, verification codes, image proxy and internal license sync are constrained.',
 );

--- a/scripts/verify-auth-rbac-security.mjs
+++ b/scripts/verify-auth-rbac-security.mjs
@@ -5,6 +5,9 @@ const root = process.cwd();
 const read = (relativePath) =>
   fs.readFileSync(path.join(root, relativePath), 'utf8');
 
+const countOccurrences = (source, value) =>
+  source.split(value).length - 1;
+
 const authMiddleware = read('src/middlewares/auth.middleware.ts');
 const authorization = read('src/lib/auth/serverAuthorization.ts');
 
@@ -12,6 +15,68 @@ const terminalRoutes = [
   'src/app/api/asistencias/qr-dia/route.ts',
   'src/app/api/asistencias/recientes/route.ts',
   'src/app/api/notificaciones/terminal/route.ts',
+];
+
+const protectedLegacyApiRoutes = [
+  'src/app/api/actividades/[id]/route.ts',
+  'src/app/api/actividades/route.ts',
+  'src/app/api/actividades/turnos-cupos/inscripciones/[id]/route.ts',
+  'src/app/api/actividades/turnos-cupos/inscripciones/route.ts',
+  'src/app/api/actividades/turnos-cupos/route.ts',
+  'src/app/api/actividades/turnos-cupos/turnos/[id]/route.ts',
+  'src/app/api/actividades/turnos-cupos/turnos/route.ts',
+  'src/app/api/admin/cuotas/dashboard-bi/route.ts',
+  'src/app/api/admin/cuotas/estado-socios/route.ts',
+  'src/app/api/admin/cuotas/resumen/route.ts',
+  'src/app/api/avisos/[id]/route.ts',
+  'src/app/api/avisos/route.ts',
+  'src/app/api/equipamientos/[id]/route.ts',
+  'src/app/api/equipamientos/alertas-mantenimiento/route.ts',
+  'src/app/api/equipamientos/mantenimiento-bi/route.ts',
+  'src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts',
+  'src/app/api/equipamientos/preventivos/ordenes/route.ts',
+  'src/app/api/equipamientos/preventivos/planes/route.ts',
+  'src/app/api/equipamientos/preventivos/route.ts',
+  'src/app/api/equipamientos/route.ts',
+  'src/app/api/infraestructura/activos/route.ts',
+  'src/app/api/infraestructura/checklists/ejecuciones/route.ts',
+  'src/app/api/infraestructura/mantenimiento-edilicio/route.ts',
+  'src/app/api/infraestructura/ordenes/[id]/route.ts',
+  'src/app/api/infraestructura/ordenes/route.ts',
+  'src/app/api/infraestructura/qr/labels/route.ts',
+  'src/app/api/infraestructura/qr/resolve/route.ts',
+  'src/app/api/infraestructura/qr/route.ts',
+  'src/app/api/infraestructura/sectores/route.ts',
+  'src/app/api/mantenimientos/[id]/route.ts',
+  'src/app/api/mantenimientos/completado/[id]/route.ts',
+  'src/app/api/mantenimientos/route.ts',
+  'src/app/api/productos/[id]/route.ts',
+  'src/app/api/productos/historial-precios-costos/route.ts',
+  'src/app/api/productos/route.ts',
+  'src/app/api/productos/stock-movimientos/route.ts',
+  'src/app/api/proveedores/[id]/route.ts',
+  'src/app/api/proveedores/route.ts',
+  'src/app/api/servicios/[id]/route.ts',
+  'src/app/api/servicios/route.ts',
+];
+
+const clientAuthChecks = [
+  {
+    path: 'src/services/infraestructuraMantenimientoClient.ts',
+    minimumHeaders: 9,
+  },
+  {
+    path: 'src/services/equipamientoPreventivoClient.ts',
+    minimumHeaders: 4,
+  },
+  {
+    path: 'src/services/equipamientoService.ts',
+    minimumHeaders: 2,
+  },
+  {
+    path: 'src/services/browser/cuotasPagosBiApiClient.ts',
+    minimumHeaders: 1,
+  },
 ];
 
 const assertions = [
@@ -30,6 +95,18 @@ const assertions = [
   {
     ok: authorization.includes('requireDashboardPermission'),
     message: 'Debe existir el helper server-side de permisos por módulo.',
+  },
+  {
+    ok: authorization.includes('requireAnyDashboardPermission'),
+    message: 'Debe existir el helper para endpoints compartidos por varios módulos.',
+  },
+  {
+    ok: authorization.includes('authorizeDashboardRequest'),
+    message: 'Debe existir el helper compuesto de autenticación, rol y permiso.',
+  },
+  {
+    ok: authorization.includes('authorizationErrorResponse'),
+    message: 'Debe existir una respuesta uniforme 401/403 para errores de autorización.',
   },
   {
     ok: authorization.includes('requireOwnSocioOrRoles'),
@@ -53,6 +130,79 @@ for (const route of terminalRoutes) {
   );
 }
 
+for (const route of protectedLegacyApiRoutes) {
+  const source = read(route);
+  const handlerCount = countOccurrences(source, 'export async function ');
+
+  assertions.push(
+    {
+      ok: handlerCount > 0,
+      message: `${route} debe declarar al menos un handler HTTP.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizeDashboardRequest(') === handlerCount,
+      message: `${route} debe autorizar cada handler antes de acceder a datos.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizationErrorResponse(') === handlerCount,
+      message: `${route} debe conservar 401/403 en cada handler.`,
+    },
+    {
+      ok: !source.includes('authMiddleware('),
+      message: `${route} no debe usar autenticación sin permiso de módulo.`,
+    },
+  );
+}
+
+for (const client of clientAuthChecks) {
+  const source = read(client.path);
+  assertions.push(
+    {
+      ok: source.includes('authHeader'),
+      message: `${client.path} debe importar el encabezado de sesión.`,
+    },
+    {
+      ok: countOccurrences(source, 'authHeader()') >= client.minimumHeaders,
+      message: `${client.path} debe enviar Bearer en todas sus llamadas protegidas.`,
+    },
+  );
+}
+
+const actividadesRoute = read('src/app/api/actividades/route.ts');
+const productosRoute = read('src/app/api/productos/route.ts');
+const stockRoute = read('src/app/api/productos/stock-movimientos/route.ts');
+const cuotasBiRoute = read('src/app/api/admin/cuotas/dashboard-bi/route.ts');
+const qrResolveRoute = read('src/app/api/infraestructura/qr/resolve/route.ts');
+
+assertions.push(
+  {
+    ok:
+      actividadesRoute.includes("['admin', 'usuario', 'socio']") &&
+      countOccurrences(actividadesRoute, "['admin', 'usuario']") >= 3,
+    message:
+      'Actividades debe permitir lectura al socio pero reservar mutaciones para admin/usuario.',
+  },
+  {
+    ok: productosRoute.includes("'/dashboard/comercial/kiosco'"),
+    message:
+      'La lectura de productos debe conservar compatibilidad con POS/Kiosco autorizado.',
+  },
+  {
+    ok: stockRoute.includes("'/dashboard/comercial/stock-ledger'"),
+    message: 'Movimientos de stock debe exigir Stock Ledger o Productos.',
+  },
+  {
+    ok: cuotasBiRoute.includes("'/dashboard/bi-cuotas-pagos'"),
+    message: 'El BI de cuotas debe exigir el permiso Pagos asociado a su ruta.',
+  },
+  {
+    ok:
+      qrResolveRoute.includes("'/dashboard/infraestructura/lector-qr-barra'") &&
+      qrResolveRoute.includes("'/dashboard/infraestructura/etiquetas-qr'"),
+    message: 'La resolución QR debe aceptar únicamente los dos módulos autorizados.',
+  },
+);
+
 const failures = assertions.filter((assertion) => !assertion.ok);
 
 if (failures.length > 0) {
@@ -67,8 +217,14 @@ console.log(
   'Auth middleware OK: Bearer validation, JWT payload validation and terminal scope isolation are active.',
 );
 console.log(
-  'RBAC server helpers OK: role, dashboard permission and socio ownership guards are available.',
+  'RBAC server helpers OK: role, single/multi-module permission and socio ownership guards are available.',
 );
 console.log(
   'Terminal endpoints OK: terminal tokens are opt-in and constrained to the Asistencias permission.',
+);
+console.log(
+  `Legacy API families OK: ${protectedLegacyApiRoutes.length} routes enforce authentication, role and module permission.`,
+);
+console.log(
+  'Protected browser clients OK: infrastructure, preventive equipment, equipment BI and fees BI send Bearer headers.',
 );

--- a/scripts/verify-auth-rbac-security.mjs
+++ b/scripts/verify-auth-rbac-security.mjs
@@ -60,6 +60,56 @@ const protectedLegacyApiRoutes = [
   'src/app/api/servicios/route.ts',
 ];
 
+const protectedSensitiveDashboardRoutes = [
+  'src/app/api/admin/metricas/pagos/histograma/route.ts',
+  'src/app/api/admin/metricas/pagos/proyeccion-ingresos/route.ts',
+  'src/app/api/admin/metricas/pagos/segmentacion/route.ts',
+  'src/app/api/admin/metricas/rutinas/adherencia/route.ts',
+  'src/app/api/admin/metricas/rutinas/evolucion-promedio/route.ts',
+  'src/app/api/admin/metricas/rutinas/generar-rutina/route.ts',
+  'src/app/api/admin/metricas/rutinas/generar-rutina-personalizada/route.ts',
+  'src/app/api/admin/socios-mensajes/[id]/route.ts',
+  'src/app/api/admin/socios-mensajes/resumen/route.ts',
+  'src/app/api/admin/socios-mensajes/route.ts',
+  'src/app/api/dieta/todas/route.ts',
+  'src/app/api/dragon-pyramid/license/reactivate/route.ts',
+  'src/app/api/dragon-pyramid/license/route.ts',
+  'src/app/api/evolucion_socio/admin/resumen/route.ts',
+  'src/app/api/notificaciones/[id]/enviar/route.ts',
+  'src/app/api/notificaciones/[id]/route.ts',
+  'src/app/api/notificaciones/plantillas/route.ts',
+  'src/app/api/notificaciones/route.ts',
+  'src/app/api/pagos/[id]/route.ts',
+  'src/app/api/pagos/route.ts',
+  'src/app/api/socios/demografia-promociones-bi/route.ts',
+  'src/app/api/socios/mensajes/route.ts',
+  'src/app/api/socios/ranking-bonificacion-mensual/route.ts',
+  'src/app/api/socios/route.ts',
+];
+
+const protectedPersonalResourceRoutes = [
+  'src/app/api/dieta/[id]/route.ts',
+  'src/app/api/dieta/generar/route.ts',
+  'src/app/api/dieta/rag-assistant/generar/route.ts',
+  'src/app/api/dieta/socio/[id]/route.ts',
+  'src/app/api/evolucion_socio/[socio_id]/route.ts',
+  'src/app/api/evolucion_socio/rag-assistant/analizar/route.ts',
+  'src/app/api/evolucion_socio/registro/route.ts',
+  'src/app/api/rutina/[idSocio]/route.ts',
+  'src/app/api/rutina/delete/[id]/route.ts',
+  'src/app/api/rutina/generar/route.ts',
+  'src/app/api/rutina/historial/[id_socio]/route.ts',
+  'src/app/api/rutina/historial/route.ts',
+  'src/app/api/rutina/training-sessions/[id]/route.ts',
+  'src/app/api/rutina/training-sessions/route.ts',
+  'src/app/api/rutinas/rag-assistant/generar/route.ts',
+  'src/app/api/socios/[id]/ficha-medica/[id_ficha]/route.ts',
+  'src/app/api/socios/[id]/ficha-medica/actual/route.ts',
+  'src/app/api/socios/[id]/ficha-medica/historial/route.ts',
+  'src/app/api/socios/[id]/ficha-medica/route.ts',
+  'src/app/api/socios/[id]/route.ts',
+];
+
 const clientAuthChecks = [
   {
     path: 'src/services/infraestructuraMantenimientoClient.ts',
@@ -76,6 +126,39 @@ const clientAuthChecks = [
   {
     path: 'src/services/browser/cuotasPagosBiApiClient.ts',
     minimumHeaders: 1,
+  },
+];
+
+const sensitiveClientAuthChecks = [
+  {
+    path: 'src/services/apiClient.ts',
+    requiredSnippets: [
+      '/api/rutina/historial',
+      '/api/dieta/todas',
+      '/api/evolucion_socio/registro',
+      '/api/notificaciones',
+      '/api/dragon-pyramid/license',
+    ],
+  },
+  {
+    path: 'src/services/browser/pagoApiClient.ts',
+    requiredSnippets: ['/api/pagos', 'authHeader()'],
+  },
+  {
+    path: 'src/services/browser/socioApiClient.ts',
+    requiredSnippets: ['/api/socios', 'authHeader()'],
+  },
+  {
+    path: 'src/services/sociosDemografiaBiService.ts',
+    requiredSnippets: ['/api/socios/demografia-promociones-bi', 'authHeader()'],
+  },
+  {
+    path: 'src/services/sociosRankingBonificacionService.ts',
+    requiredSnippets: ['/api/socios/ranking-bonificacion-mensual', 'authHeader()'],
+  },
+  {
+    path: 'src/services/evolucionSocioClient.ts',
+    requiredSnippets: ['/api/evolucion_socio', 'authHeaders('],
   },
 ];
 
@@ -103,6 +186,10 @@ const assertions = [
   {
     ok: authorization.includes('authorizeDashboardRequest'),
     message: 'Debe existir el helper compuesto de autenticación, rol y permiso.',
+  },
+  {
+    ok: authorization.includes('authorizePersonalOrDashboardRequest'),
+    message: 'Debe existir el helper para recursos propios del socio o gestión autorizada.',
   },
   {
     ok: authorization.includes('authorizationErrorResponse'),
@@ -154,6 +241,56 @@ for (const route of protectedLegacyApiRoutes) {
   );
 }
 
+for (const route of protectedSensitiveDashboardRoutes) {
+  const source = read(route);
+  const handlerCount = countOccurrences(source, 'export async function ');
+
+  assertions.push(
+    {
+      ok: handlerCount > 0,
+      message: `${route} debe declarar al menos un handler HTTP.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizeDashboardRequest(') === handlerCount,
+      message: `${route} debe exigir rol y permiso de dashboard en cada handler.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizationErrorResponse(') >= handlerCount,
+      message: `${route} debe preservar respuestas 401/403 tipadas.`,
+    },
+    {
+      ok: !source.includes('authMiddleware('),
+      message: `${route} no debe limitarse a comprobar que exista un JWT.`,
+    },
+  );
+}
+
+for (const route of protectedPersonalResourceRoutes) {
+  const source = read(route);
+  const handlerCount = countOccurrences(source, 'export async function ');
+
+  assertions.push(
+    {
+      ok: handlerCount > 0,
+      message: `${route} debe declarar al menos un handler HTTP.`,
+    },
+    {
+      ok:
+        countOccurrences(source, 'authorizePersonalOrDashboardRequest(') ===
+        handlerCount,
+      message: `${route} debe autorizar cada recurso personal o de gestión.`,
+    },
+    {
+      ok: countOccurrences(source, 'authorizationErrorResponse(') >= handlerCount,
+      message: `${route} debe preservar respuestas 401/403 tipadas.`,
+    },
+    {
+      ok: !source.includes('authMiddleware('),
+      message: `${route} no debe autenticar sin aplicar alcance personal o permiso.`,
+    },
+  );
+}
+
 for (const client of clientAuthChecks) {
   const source = read(client.path);
   assertions.push(
@@ -166,6 +303,16 @@ for (const client of clientAuthChecks) {
       message: `${client.path} debe enviar Bearer en todas sus llamadas protegidas.`,
     },
   );
+}
+
+for (const client of sensitiveClientAuthChecks) {
+  const source = read(client.path);
+  for (const snippet of client.requiredSnippets) {
+    assertions.push({
+      ok: source.includes(snippet),
+      message: `${client.path} debe conservar autenticación para ${snippet}.`,
+    });
+  }
 }
 
 const actividadesRoute = read('src/app/api/actividades/route.ts');
@@ -203,6 +350,79 @@ assertions.push(
   },
 );
 
+const rutinaService = read('src/services/rutinaService.ts');
+const dietaService = read('src/services/dietaService.ts');
+const evolucionService = read('src/services/evolucionSocioService.ts');
+const socioServerService = read('src/services/server/socioServerService.ts');
+const miCuentaPagosRoute = read('src/app/api/mi-cuenta/pagos/route.ts');
+const pagoVerificationRoute = read('src/app/api/pagos/[id]/verificar/route.ts');
+const profileUploadRoute = read('src/app/api/file-upload/route.ts');
+const masterLicenseRoute = read('src/app/api/dragon-pyramid/license/route.ts');
+const masterReactivateRoute = read('src/app/api/dragon-pyramid/license/reactivate/route.ts');
+const licenseWarningRoute = read('src/app/api/dragon-pyramid/license/warning/route.ts');
+const suspensionStatusRoute = read('src/app/api/dragon-pyramid/license/suspension-status/route.ts');
+
+assertions.push(
+  {
+    ok:
+      rutinaService.includes('requestedSocioId.trim() !== ownSocioId') &&
+      rutinaService.includes('AUTH_SOCIO_SCOPE_FORBIDDEN'),
+    message: 'Rutinas debe rechazar generación y consulta para otro socio.',
+  },
+  {
+    ok:
+      dietaService.includes('requestedSocioId !== ownSocioId') &&
+      dietaService.includes('AUTH_SOCIO_SCOPE_FORBIDDEN'),
+    message: 'Dietas debe validar propiedad del socio solicitado.',
+  },
+  {
+    ok:
+      evolucionService.includes('createEvolucionSocio.socio_id !== ownSocioId') &&
+      evolucionService.includes('socio_id !== ownSocioId') &&
+      evolucionService.includes('AUTH_SOCIO_SCOPE_FORBIDDEN'),
+    message: 'Evolución física debe impedir altas y lecturas cruzadas entre socios.',
+  },
+  {
+    ok:
+      socioServerService.includes(".eq('usuario_id', user.id)") &&
+      socioServerService.includes('AUTH_SOCIO_SCOPE_FORBIDDEN'),
+    message: 'El detalle de socio debe resolver y validar la identidad propia.',
+  },
+  {
+    ok:
+      miCuentaPagosRoute.includes("requireRoles(user, ['socio'])") &&
+      miCuentaPagosRoute.includes(".eq('socio_id', socioId)"),
+    message: 'Mi Cuenta debe devolver pagos únicamente del socio autenticado.',
+  },
+  {
+    ok:
+      pagoVerificationRoute.includes('isPagoVerificationCodeValid') &&
+      !pagoVerificationRoute.includes('id_socio,nombre_completo,email'),
+    message: 'La verificación pública de recibos debe validar código y no exponer email.',
+  },
+  {
+    ok:
+      profileUploadRoute.includes("const folder = `${user.rol}/profile`") &&
+      profileUploadRoute.includes('updateFotoUsuarioById(user, uploadedUrl)') &&
+      profileUploadRoute.includes('authorizationErrorResponse(error)'),
+    message: 'La foto de perfil debe actualizar únicamente al usuario autenticado.',
+  },
+  {
+    ok:
+      masterLicenseRoute.includes("'/dashboard/masteradmin/license'") &&
+      masterLicenseRoute.includes("['masteradmin']") &&
+      masterReactivateRoute.includes("['masteradmin']"),
+    message: 'Licencia y reactivación deben quedar aisladas al Master Admin.',
+  },
+  {
+    ok:
+      licenseWarningRoute.includes("role !== 'admin' && role !== 'masteradmin'") &&
+      suspensionStatusRoute.includes("user.rol === 'socio'") &&
+      suspensionStatusRoute.includes('details: status.isSuspended ? [] : status.details'),
+    message: 'Avisos y suspensión deben conservar exposición mínima según el rol.',
+  },
+);
+
 const failures = assertions.filter((assertion) => !assertion.ok);
 
 if (failures.length > 0) {
@@ -224,6 +444,21 @@ console.log(
 );
 console.log(
   `Legacy API families OK: ${protectedLegacyApiRoutes.length} routes enforce authentication, role and module permission.`,
+);
+console.log(
+  `Sensitive dashboard APIs OK: ${protectedSensitiveDashboardRoutes.length} routes enforce role and module permission.`,
+);
+console.log(
+  `Personal resource APIs OK: ${protectedPersonalResourceRoutes.length} routes enforce socio scope or authorized management.`,
+);
+console.log(
+  'Socio ownership OK: member detail, medical records, payments, routines, diets and evolution reject cross-member access.',
+);
+console.log(
+  'Master Admin and public exposure OK: license controls are isolated and public receipt verification is redacted.',
+);
+console.log(
+  'Sensitive browser clients OK: personal, management and BI calls continue sending Bearer headers.',
 );
 console.log(
   'Protected browser clients OK: infrastructure, preventive equipment, equipment BI and fees BI send Bearer headers.',

--- a/scripts/verify-auth-rbac-security.mjs
+++ b/scripts/verify-auth-rbac-security.mjs
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relativePath) =>
+  fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const authMiddleware = read('src/middlewares/auth.middleware.ts');
+const authorization = read('src/lib/auth/serverAuthorization.ts');
+
+const terminalRoutes = [
+  'src/app/api/asistencias/qr-dia/route.ts',
+  'src/app/api/asistencias/recientes/route.ts',
+  'src/app/api/notificaciones/terminal/route.ts',
+];
+
+const assertions = [
+  {
+    ok: authMiddleware.includes('allowTerminalSession?: boolean'),
+    message: 'authMiddleware debe declarar el opt-in allowTerminalSession.',
+  },
+  {
+    ok: authMiddleware.includes('AUTH_TERMINAL_SCOPE_FORBIDDEN'),
+    message: 'authMiddleware debe rechazar tokens de Terminal por defecto.',
+  },
+  {
+    ok: authMiddleware.includes("scheme?.toLowerCase() !== 'bearer'"),
+    message: 'authMiddleware debe validar estrictamente el esquema Bearer.',
+  },
+  {
+    ok: authorization.includes('requireDashboardPermission'),
+    message: 'Debe existir el helper server-side de permisos por módulo.',
+  },
+  {
+    ok: authorization.includes('requireOwnSocioOrRoles'),
+    message: 'Debe existir el helper de aislamiento por socio.',
+  },
+];
+
+for (const route of terminalRoutes) {
+  const source = read(route);
+  assertions.push(
+    {
+      ok: source.includes('allowTerminalSession: true'),
+      message: `${route} debe habilitar explícitamente la sesión de Terminal.`,
+    },
+    {
+      ok: source.includes(
+        "requireDashboardPermission(user, '/dashboard/asistencias/terminal')",
+      ),
+      message: `${route} debe exigir el permiso de Terminal/Asistencias.`,
+    },
+  );
+}
+
+const failures = assertions.filter((assertion) => !assertion.ok);
+
+if (failures.length > 0) {
+  console.error('Auth/RBAC security verification failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  'Auth middleware OK: Bearer validation, JWT payload validation and terminal scope isolation are active.',
+);
+console.log(
+  'RBAC server helpers OK: role, dashboard permission and socio ownership guards are available.',
+);
+console.log(
+  'Terminal endpoints OK: terminal tokens are opt-in and constrained to the Asistencias permission.',
+);

--- a/scripts/verify-business-backup-export.mjs
+++ b/scripts/verify-business-backup-export.mjs
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const servicePath = path.join(root, 'src/services/adminRespaldoNegocioService.ts');
+const service = fs.readFileSync(servicePath, 'utf8');
+
+function fail(message) {
+  console.error(`Business backup export verification failed: ${message}`);
+  process.exit(1);
+}
+
+const requiredSnippets = [
+  'const EXCEL_WORKSHEET_NAME_MAX_LENGTH = 31;',
+  'const EXCEL_WORKSHEET_FORBIDDEN_CHARACTERS = /[\\\\/*?:\\[\\]]/g;',
+  'const EXCEL_WORKSHEET_CONTROL_CHARACTERS = /[\\u0000-\\u001f\\u007f]/g;',
+  'function normalizeBusinessBackupWorksheetName(',
+  'function reserveBusinessBackupWorksheetName(',
+  'const usedWorksheetNames = new Set<string>();',
+  'reserveBusinessBackupWorksheetName(',
+];
+
+for (const snippet of requiredSnippets) {
+  if (!service.includes(snippet)) fail(`missing source guard: ${snippet}`);
+}
+
+if (service.includes(".replace(/[\\/*?:[]]/g, ' - ')") || service.includes(".replace(/s+-s+/g, ' - ')") || service.includes(".replace(/s{2,}/g, ' ')")) {
+  fail('legacy malformed worksheet-name sanitizer is still present');
+}
+
+const MAX_LENGTH = 31;
+const forbidden = /[\\/*?:\[\]]/g;
+const controls = /[\u0000-\u001f\u007f]/g;
+
+function normalizeWorksheetName(name, fallback = 'Sheet') {
+  const safeFallback = String(fallback || 'Sheet')
+    .replace(forbidden, ' ')
+    .replace(controls, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/^'+|'+$/g, '')
+    .trim() || 'Sheet';
+
+  const normalized = String(name || '')
+    .replace(forbidden, ' - ')
+    .replace(controls, ' ')
+    .replace(/\s*-\s*/g, ' - ')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/^'+|'+$/g, '')
+    .trim();
+
+  return (normalized || safeFallback).slice(0, MAX_LENGTH).trim();
+}
+
+function reserveWorksheetName(name, used, fallback = 'Sheet') {
+  const base = normalizeWorksheetName(name, fallback);
+  let candidate = base;
+  let sequence = 2;
+
+  while (used.has(candidate.toLowerCase())) {
+    const suffix = ` (${sequence})`;
+    const availableLength = MAX_LENGTH - suffix.length;
+    const prefix = base.slice(0, availableLength).trimEnd();
+    candidate = `${prefix || normalizeWorksheetName(fallback, 'Sheet').slice(0, availableLength)}${suffix}`;
+    sequence += 1;
+  }
+
+  used.add(candidate.toLowerCase());
+  return candidate;
+}
+
+const sourceLabels = [...service.matchAll(/\n\s+label:\s+'([^']+)'/g)].map((match) => match[1]);
+if (!sourceLabels.includes('Gastos / egresos')) fail('expected Gastos / egresos module label was not found');
+
+const used = new Set();
+const names = [
+  'Resumen',
+  ...sourceLabels,
+  'Products / stock',
+  'Invalid:*?/\\[name]',
+  "'Quoted sheet'",
+  'A worksheet name that is intentionally longer than thirty-one characters',
+  'Resumen',
+].map((name) => reserveWorksheetName(name, used, 'Hoja'));
+
+for (const name of names) {
+  if (!name) fail('empty worksheet name generated');
+  if (name.length > MAX_LENGTH) fail(`worksheet name exceeds ${MAX_LENGTH} characters: ${name}`);
+  if (/[\\/*?:\[\]]/.test(name)) fail(`worksheet name still contains a forbidden character: ${name}`);
+  if (name.startsWith("'") || name.endsWith("'")) fail(`worksheet name starts or ends with apostrophe: ${name}`);
+}
+
+if (new Set(names.map((name) => name.toLowerCase())).size !== names.length) {
+  fail('duplicate worksheet names were not disambiguated');
+}
+
+const gastosName = normalizeWorksheetName('Gastos / egresos', 'Hoja');
+if (gastosName !== 'Gastos - egresos') fail(`unexpected Gastos worksheet name: ${gastosName}`);
+
+console.log('Business backup worksheet names OK: forbidden characters, control characters, length and duplicates are handled.');
+console.log(`Business backup worksheet names OK: ${sourceLabels.length} configured module labels are covered, including Gastos / egresos.`);

--- a/src/app/api/actividades/[id]/route.ts
+++ b/src/app/api/actividades/[id]/route.ts
@@ -1,16 +1,24 @@
 import { getActividadById } from '@/services/actividadService';
 import { NextResponse } from 'next/server';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export async function GET(
   req: Request,
   context: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/actividades', ['admin', 'usuario', 'socio']);
     const params = await context.params;
     const id = params.id;
     const actividad = await getActividadById(id);
     return NextResponse.json({ data: actividad }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message ?? String(error) },
       { status: 500 }

--- a/src/app/api/actividades/route.ts
+++ b/src/app/api/actividades/route.ts
@@ -1,11 +1,19 @@
 import { createActividad, deleteActividad, fetchAllActividades, updateActividad } from "@/services/actividadService";
 import { NextResponse } from "next/server";
 
-export async function GET(){
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
+export async function GET(req: Request){
     try {
+    await authorizeDashboardRequest(req, '/dashboard/actividades', ['admin', 'usuario', 'socio']);
         const actividades = await fetchAllActividades();
         return NextResponse.json(actividades,{status:200})
     } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.log("Error al obtener las actividades:", error);
         return  NextResponse.json({error:" Error al obtener las actividades"},{status:500})
     }
@@ -13,6 +21,7 @@ export async function GET(){
 
 export async function POST(req:Request){
     try {
+    await authorizeDashboardRequest(req, '/dashboard/actividades', ['admin', 'usuario']);
         const body = await req.json();
         console.log("Datos recibidos para la creacion de actividades ",body);
         if(!body.nombre_actividad){
@@ -24,6 +33,8 @@ export async function POST(req:Request){
             data:actividad
         }, {status:201});
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     
         console.log("Error al crear la actividad:", error.message);
         return NextResponse.json({error:"Error al crear la actividad"},{status:500});
@@ -32,10 +43,10 @@ export async function POST(req:Request){
 }
 
 export async function PUT(req:Request){
-const{id,updateData} = await req.json();
-console.log(id,updateData);
-
 try {
+    await authorizeDashboardRequest(req, '/dashboard/actividades', ['admin', 'usuario']);
+    const{id,updateData} = await req.json();
+    console.log(id,updateData);
     if (!id || typeof id !== 'string') {
           return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 })
         }
@@ -45,6 +56,8 @@ try {
         data:actividadModificada
     },{status:200});
 } catch (error : any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
       const msg = error.message || 'Error al actualizar actividad'
     return NextResponse.json({ error: msg }, { status: 500 })
   }
@@ -54,6 +67,7 @@ try {
 
 export async function DELETE(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/actividades', ['admin', 'usuario']);
     const { id } = await req.json()
 
     if (!id || typeof id !== 'string') {
@@ -63,6 +77,8 @@ export async function DELETE(req: Request) {
     await deleteActividad(id)
     return NextResponse.json({ message: 'Actividad eliminada con éxito' }, { status: 200 })
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const msg = error.message || 'Error al eliminar actividad'
     return NextResponse.json({ error: msg }, { status: 500 })
   }

--- a/src/app/api/actividades/turnos-cupos/inscripciones/[id]/route.ts
+++ b/src/app/api/actividades/turnos-cupos/inscripciones/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
+
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -47,7 +51,11 @@ async function assertCapacityForApproval(
 
 export async function PUT(req: Request, context: { params: Promise<{ id: string }> }) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(
+      req,
+      "/dashboard/actividades",
+      ["admin", "usuario", "socio"],
+    );
     const { id } = await context.params;
     const body = await req.json();
     const estado = cleanString(body.estado);
@@ -103,6 +111,9 @@ export async function PUT(req: Request, context: { params: Promise<{ id: string 
 
     return NextResponse.json({ message: "Inscripción actualizada correctamente", data }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al actualizar inscripción";
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }
@@ -110,7 +121,11 @@ export async function PUT(req: Request, context: { params: Promise<{ id: string 
 
 export async function DELETE(req: Request, context: { params: Promise<{ id: string }> }) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(
+      req,
+      "/dashboard/actividades",
+      ["admin", "usuario", "socio"],
+    );
     const { id } = await context.params;
     const supabase = getSupabaseServerClient();
 
@@ -133,6 +148,9 @@ export async function DELETE(req: Request, context: { params: Promise<{ id: stri
 
     return NextResponse.json({ message: "Inscripción eliminada correctamente" }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al eliminar inscripción";
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/actividades/turnos-cupos/inscripciones/route.ts
+++ b/src/app/api/actividades/turnos-cupos/inscripciones/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
+
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -34,7 +38,11 @@ async function resolveEstadoByCupo(supabase: ReturnType<typeof getSupabaseServer
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(
+      req,
+      "/dashboard/actividades",
+      ["admin", "usuario", "socio"],
+    );
     const body = await req.json();
     const turnoId = cleanString(body.turno_id);
     const isSocioRole = user.rol === "socio";
@@ -77,6 +85,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ message: estado === "lista_espera" ? "Solicitud registrada para revisión administrativa" : "Socio inscripto correctamente", data }, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al inscribir socio";
     const status = message.includes("oblig") || message.includes("invál")
       ? 400

--- a/src/app/api/actividades/turnos-cupos/route.ts
+++ b/src/app/api/actividades/turnos-cupos/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
 import type {
   ActividadBaseOption,
@@ -10,6 +9,11 @@ import type {
   ActividadTurnosCuposDashboard,
   ActividadUbicacionOption,
 } from "@/interfaces/actividadTurnosCupos.interface";
+
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -108,10 +112,11 @@ function buildEmptyDashboard(params: {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
-    }
+    const user = await authorizeDashboardRequest(
+      req,
+      "/dashboard/actividades",
+      ["admin", "usuario", "socio"],
+    );
 
     const supabase = getSupabaseServerClient();
     const warnings: string[] = [];
@@ -345,6 +350,9 @@ export async function GET(req: Request) {
 
     return NextResponse.json(dashboard, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al obtener actividades, turnos y cupos";
 
     if (message.toLowerCase().includes("token") || message.toLowerCase().includes("jwt")) {

--- a/src/app/api/actividades/turnos-cupos/turnos/[id]/route.ts
+++ b/src/app/api/actividades/turnos-cupos/turnos/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
+
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -48,7 +52,7 @@ function normalizePartialPayload(body: any) {
 
 export async function PUT(req: Request, context: { params: Promise<{ id: string }> }) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, "/dashboard/actividades", ["admin", "usuario"]);
     const { id } = await context.params;
     const body = await req.json();
     const payload = normalizePartialPayload(body);
@@ -65,6 +69,9 @@ export async function PUT(req: Request, context: { params: Promise<{ id: string 
 
     return NextResponse.json({ message: "Turno actualizado correctamente", data }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al actualizar turno";
     return NextResponse.json({ error: message }, { status: message.includes("invál") ? 400 : 500 });
   }
@@ -72,7 +79,7 @@ export async function PUT(req: Request, context: { params: Promise<{ id: string 
 
 export async function DELETE(req: Request, context: { params: Promise<{ id: string }> }) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, "/dashboard/actividades", ["admin", "usuario"]);
     const { id } = await context.params;
     const supabase = getSupabaseServerClient();
 
@@ -82,6 +89,9 @@ export async function DELETE(req: Request, context: { params: Promise<{ id: stri
 
     return NextResponse.json({ message: "Turno eliminado correctamente" }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al eliminar turno";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/actividades/turnos-cupos/turnos/route.ts
+++ b/src/app/api/actividades/turnos-cupos/turnos/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
+
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -50,7 +54,7 @@ function normalizePayload(body: any) {
 
 export async function POST(req: Request) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, "/dashboard/actividades", ["admin", "usuario"]);
     const body = await req.json();
     const payload = normalizePayload(body);
     const supabase = getSupabaseServerClient();
@@ -65,6 +69,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ message: "Turno creado correctamente", data }, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : "Error al crear turno";
     return NextResponse.json({ error: message }, { status: message.includes("oblig") || message.includes("invál") ? 400 : 500 });
   }

--- a/src/app/api/admin/cuotas/dashboard-bi/route.ts
+++ b/src/app/api/admin/cuotas/dashboard-bi/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { supabase } from "@/services/supabaseClient";
 import { CuotasPagosDashboardBiResponse } from "@/interfaces/cuotasPagosBi.interface";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = "force-dynamic";
 
 type SocioEstadoRow = {
@@ -39,8 +44,9 @@ function toNumber(value: unknown): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/bi-cuotas-pagos', ['admin', 'usuario']);
     const [estadoResult, pagosResult, evolucionResult] = await Promise.all([
       supabase.rpc("obtener_socios_estado_cuota"),
       supabase
@@ -161,6 +167,8 @@ export async function GET() {
 
     return NextResponse.json(response);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("ERROR dashboard BI cuotas/pagos:", error);
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Error al obtener dashboard BI de cuotas y pagos" },

--- a/src/app/api/admin/cuotas/estado-socios/route.ts
+++ b/src/app/api/admin/cuotas/estado-socios/route.ts
@@ -1,16 +1,26 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getAdminCuotasEstadoServer } from '@/services/server/cuotaEstadoServerService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/bi-cuotas-pagos',
+      ['admin', 'usuario'],
+    );
     const data = await getAdminCuotasEstadoServer(user);
 
     return NextResponse.json({ data }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('ERROR al obtener estado de cuotas admin:', error.message || error);
     const message = error.message || 'Error al obtener estado de cuotas';
     const status =

--- a/src/app/api/admin/cuotas/resumen/route.ts
+++ b/src/app/api/admin/cuotas/resumen/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getAdminCuotasEstadoServer } from '@/services/server/cuotaEstadoServerService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/bi-cuotas-pagos',
+      ['admin', 'usuario'],
+    );
     const data = await getAdminCuotasEstadoServer(user);
 
     return NextResponse.json(
@@ -22,6 +29,9 @@ export async function GET(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('ERROR al obtener resumen de cuotas admin:', error.message || error);
     const message = error.message || 'Error al obtener resumen de cuotas';
     const status =

--- a/src/app/api/admin/metricas/asistencia/[tipo]/route.ts
+++ b/src/app/api/admin/metricas/asistencia/[tipo]/route.ts
@@ -1,4 +1,3 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { rolAdminMiddleware } from '@/middlewares/rolAdmin.middleware';
 import {
   dataConcurrenciaAnual,
@@ -8,6 +7,11 @@ import {
 import { NextResponse } from 'next/server';
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -15,7 +19,7 @@ export async function GET(
   { params }: { params: Promise<{ tipo: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
 
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -54,6 +58,8 @@ export async function GET(
 
     return NextResponse.json(concurrencia);
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error en la concurrencia de asistencia:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/admin/metricas/asistencia/prediccion-abandono/route.ts
+++ b/src/app/api/admin/metricas/asistencia/prediccion-abandono/route.ts
@@ -1,13 +1,17 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { NextResponse } from "next/server";
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -22,6 +26,8 @@ export async function GET(req: Request) {
 
         return NextResponse.json({ error: "Endpoint no implementado" }, { status: 501 });
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error en la predicción de abandono:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/admin/metricas/asistencia/top-inactivos/route.ts
+++ b/src/app/api/admin/metricas/asistencia/top-inactivos/route.ts
@@ -1,13 +1,17 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { NextResponse } from "next/server";
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -22,6 +26,8 @@ export async function GET(req: Request) {
 
         return NextResponse.json({ error: "Endpoint no implementado" }, { status: 501 });
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error en el resumen de asistencias por periodo:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/admin/metricas/equipamiento/costo-beneficio/route.ts
+++ b/src/app/api/admin/metricas/equipamiento/costo-beneficio/route.ts
@@ -1,14 +1,18 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { dataAnalisisCostoBeneficio } from "@/services/equipamientoService";
 import { NextResponse } from "next/server";
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -27,6 +31,8 @@ export async function GET(req: Request) {
 
         return NextResponse.json(costoBeneficio);
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error en el análisis costo-beneficio:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/admin/metricas/equipamiento/estado-actual/route.ts
+++ b/src/app/api/admin/metricas/equipamiento/estado-actual/route.ts
@@ -1,14 +1,18 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { dataEstadoEquipamientoSemaforo } from "@/services/equipamientoService";
 import { NextResponse } from "next/server";
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -27,6 +31,8 @@ export async function GET(req: Request) {
 
         return NextResponse.json(estadoActual);
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error en el estado actual del equipamiento:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/admin/metricas/equipamiento/prediccion-fallo/route.ts
+++ b/src/app/api/admin/metricas/equipamiento/prediccion-fallo/route.ts
@@ -1,13 +1,17 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { NextResponse } from "next/server";
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -22,6 +26,8 @@ export async function GET(req: Request) {
 
         return NextResponse.json({ error: "Endpoint no implementado" }, { status: 501 });
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error en la predicción de fallos de equipamiento:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/admin/metricas/equipamiento/top-fallos/route.ts
+++ b/src/app/api/admin/metricas/equipamiento/top-fallos/route.ts
@@ -1,14 +1,18 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { dataRankingFallosEquipamiento } from "@/services/equipamientoService";
 import { NextResponse } from "next/server";
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
@@ -26,6 +30,8 @@ export async function GET(req: Request) {
 
         return NextResponse.json(topFallos);
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error en el ranking de fallos de equipamiento:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/admin/metricas/pagos/histograma/route.ts
+++ b/src/app/api/admin/metricas/pagos/histograma/route.ts
@@ -1,33 +1,38 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
-import { dataAnalisisConductaPagos } from "@/services/pagoService";
 import { NextResponse } from "next/server";
-
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
+import { dataAnalisisConductaPagos } from "@/services/pagoService";
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/finanzas',
+      ['admin', 'usuario'],
+    );
 
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
+    const histograma = await dataAnalisisConductaPagos(user);
 
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        const histograma = await dataAnalisisConductaPagos(user);
-
-        if (!histograma) {
-            return NextResponse.json({ error: "No se encontraron datos del histograma de pagos" }, { status: 404 });
-        }
-
-        return NextResponse.json(histograma);
-    } catch (error: any) {
-        console.error("Error en el histograma de pagos:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!histograma) {
+      return NextResponse.json(
+        { error: 'No se encontraron datos del histograma de pagos' },
+        { status: 404 },
+      );
     }
+
+    return NextResponse.json(histograma);
+  } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    console.error('Error en el histograma de pagos:', error);
+    return NextResponse.json(
+      { error: error.message || 'Error en el histograma de pagos' },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/admin/metricas/pagos/proyeccion-ingresos/route.ts
+++ b/src/app/api/admin/metricas/pagos/proyeccion-ingresos/route.ts
@@ -1,28 +1,29 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { NextResponse } from "next/server";
-
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
+  try {
+    await authorizeDashboardRequest(
+      req,
+      '/dashboard/finanzas',
+      ['admin', 'usuario'],
+    );
 
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
+    // TODO: implementar lógica de proyección de ingresos.
+    return NextResponse.json({ error: 'Endpoint no implementado' }, { status: 501 });
+  } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
 
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        //TODO IMPLEMENTAR LÓGICA DE PROYECCIÓN DE INGRESOS
-
-        return NextResponse.json({ error: "Endpoint no implementado" }, { status: 501 });
-    } catch (error: any) {
-        console.error("Error en la proyección de ingresos:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
-    }
+    console.error('Error en la proyección de ingresos:', error);
+    return NextResponse.json(
+      { error: error.message || 'Error en la proyección de ingresos' },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/admin/metricas/pagos/segmentacion/route.ts
+++ b/src/app/api/admin/metricas/pagos/segmentacion/route.ts
@@ -1,33 +1,38 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
-import { dataAnalisisConductaPagos } from "@/services/pagoService";
 import { NextResponse } from "next/server";
-
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
+import { dataAnalisisConductaPagos } from "@/services/pagoService";
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/finanzas',
+      ['admin', 'usuario'],
+    );
 
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
+    const segmentacion = await dataAnalisisConductaPagos(user);
 
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        const segmentacion = await dataAnalisisConductaPagos(user);
-
-        if (!segmentacion) {
-            return NextResponse.json({ error: "No se encontraron datos de segmentación de pagos" }, { status: 404 });
-        }
-
-        return NextResponse.json(segmentacion);
-    } catch (error: any) {
-        console.error("Error en la segmentación de pagos:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!segmentacion) {
+      return NextResponse.json(
+        { error: 'No se encontraron datos de segmentación de pagos' },
+        { status: 404 },
+      );
     }
+
+    return NextResponse.json(segmentacion);
+  } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    console.error('Error en la segmentación de pagos:', error);
+    return NextResponse.json(
+      { error: error.message || 'Error en la segmentación de pagos' },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/admin/metricas/retencion_por_combinacion/route.ts
+++ b/src/app/api/admin/metricas/retencion_por_combinacion/route.ts
@@ -1,14 +1,18 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import { dataRetencionPorCombinacion } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req:Request){
 try {
-    const {user} = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/gestor-rutinas', ['admin', 'usuario']);
     if(!user){
         return NextResponse.json({error: "Unauthorized"}, {status: 401});
     }
@@ -27,6 +31,8 @@ try {
     return NextResponse.json({data: retencion}, {status: 200});
 
 } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log("Error en la obtención de métricas:", error);
     return NextResponse.json({error: "Error en la obtención de métricas"}, {status: 500});
 }

--- a/src/app/api/admin/metricas/rutinas/adherencia/route.ts
+++ b/src/app/api/admin/metricas/rutinas/adherencia/route.ts
@@ -1,33 +1,28 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
-import { dataAdherenciaMensualRutinas } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
-
+import { dataAdherenciaMensualRutinas } from "@/services/rutinaService";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
-
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        const adherencia = await dataAdherenciaMensualRutinas(user);
-
-        if (!adherencia) {
-            return NextResponse.json({ error: "No se encontraron datos de adherencia de rutinas" }, { status: 404 });
-        }
-
-        return NextResponse.json(adherencia);
-    } catch (error: any) {
-        console.error("Error en la adherencia de rutinas:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/gestor-rutinas',
+      ['admin', 'usuario'],
+    );
+    const adherencia = await dataAdherenciaMensualRutinas(user);
+    if (!adherencia) {
+      return NextResponse.json({ error: "No se encontraron datos de adherencia de rutinas" }, { status: 404 });
     }
+    return NextResponse.json(adherencia, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/metricas/rutinas/evolucion-promedio/route.ts
+++ b/src/app/api/admin/metricas/rutinas/evolucion-promedio/route.ts
@@ -1,33 +1,28 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
-import { dataEvolucionPromedioPorObjetivo } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
-
+import { dataEvolucionPromedioPorObjetivo } from "@/services/rutinaService";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
-
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        const evolucionPromedio = await dataEvolucionPromedioPorObjetivo(user);
-
-        if (!evolucionPromedio) {
-            return NextResponse.json({ error: "No se encontraron datos de evolución promedio por objetivo" }, { status: 404 });
-        }
-
-        return NextResponse.json(evolucionPromedio);
-    } catch (error: any) {
-        console.error("Error en la evolución promedio por objetivo:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/gestor-rutinas',
+      ['admin', 'usuario'],
+    );
+    const evolucionPromedio = await dataEvolucionPromedioPorObjetivo(user);
+    if (!evolucionPromedio) {
+      return NextResponse.json({ error: "No se encontraron datos de evolución promedio por objetivo" }, { status: 404 });
     }
+    return NextResponse.json(evolucionPromedio, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/metricas/rutinas/generar-rutina-personalizada/route.ts
+++ b/src/app/api/admin/metricas/rutinas/generar-rutina-personalizada/route.ts
@@ -1,35 +1,29 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
-import { dataGeneracionRutinaPersonalizada } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
-
+import { dataGeneracionRutinaPersonalizada } from "@/services/rutinaService";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
-
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        const body = await req.json();
-
-        const generacionRutina = await dataGeneracionRutinaPersonalizada(user, body);
-
-        if (!generacionRutina) {
-            return NextResponse.json({ error: "No se encontraron datos de generación de rutina" }, { status: 404 });
-        }
-
-        return NextResponse.json("generacionRutinaPersonalizada", { status: 200 });
-    } catch (error: any) {
-        console.error("Error en la generación de rutina personalizada:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/gestor-rutinas',
+      ['admin', 'usuario'],
+    );
+    const body = await req.json();
+    const generacionRutina = await dataGeneracionRutinaPersonalizada(user, body);
+    if (!generacionRutina) {
+      return NextResponse.json({ error: "No se encontraron datos de generación de rutina" }, { status: 404 });
     }
+    return NextResponse.json({ message: "Rutina personalizada generada correctamente", data: generacionRutina }, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/metricas/rutinas/generar-rutina/route.ts
+++ b/src/app/api/admin/metricas/rutinas/generar-rutina/route.ts
@@ -1,35 +1,29 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
-import { dataGeneracionRutina } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
-
+import { dataGeneracionRutina } from "@/services/rutinaService";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
-
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-
-        const rolAdmin = rolAdminMiddleware(user);
-        if (!rolAdmin) {
-            return NextResponse.json({ error: "Unauthorized: User no tiene rol de admin" }, { status: 403 });
-        }
-
-        const body = await req.json();
-
-        const generacionRutina = await dataGeneracionRutina(user, body);
-
-        if (!generacionRutina) {
-            return NextResponse.json({ error: "No se encontraron datos de generación de rutina" }, { status: 404 });
-        }
-
-        return NextResponse.json({ message: "Rutina generada correctamente", data: generacionRutina }, { status: 200 });
-    } catch (error: any) {
-        console.error("Error en la generación de rutina:", error);
-        return NextResponse.json({ error: error.message }, { status: 500 });
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/gestor-rutinas',
+      ['admin', 'usuario'],
+    );
+    const body = await req.json();
+    const generacionRutina = await dataGeneracionRutina(user, body);
+    if (!generacionRutina) {
+      return NextResponse.json({ error: "No se encontraron datos de generación de rutina" }, { status: 404 });
     }
+    return NextResponse.json({ message: "Rutina generada correctamente", data: generacionRutina }, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error interno del servidor';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/admin/respaldo-negocio/exportar/route.ts
+++ b/src/app/api/admin/respaldo-negocio/exportar/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { exportRespaldoNegocio } from '@/services/adminRespaldoNegocioService';
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 // BUSINESS_BACKUP_I18N_EXPORTABLES_V1
 type BusinessBackupLocale = "es" | "en";
@@ -43,7 +47,7 @@ export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/respaldo-negocio', ['admin']);
     const body = await req.json().catch(() => ({}));
     const requestLocale = body?.locale ?? req.headers.get('x-gym-master-locale') ?? req.headers.get('accept-language');
     const result = await exportRespaldoNegocio(user, { ...body, locale: requestLocale });
@@ -60,6 +64,8 @@ export async function POST(req: Request) {
       },
     });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') || message.includes('Token') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/admin/respaldo-negocio/route.ts
+++ b/src/app/api/admin/respaldo-negocio/route.ts
@@ -1,15 +1,19 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   getRespaldoNegocioHistory,
   getRespaldoNegocioModules,
 } from '@/services/adminRespaldoNegocioService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/respaldo-negocio', ['admin']);
     const [modulos, historial] = await Promise.all([
       Promise.resolve(getRespaldoNegocioModules(user)),
       getRespaldoNegocioHistory(user),
@@ -17,6 +21,8 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ data: { modulos, historial } });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') || message.includes('Token') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/admin/socios-mensajes/[id]/route.ts
+++ b/src/app/api/admin/socios-mensajes/[id]/route.ts
@@ -1,20 +1,20 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import {
-  getMensajeAdminById,
-  updateMensajeAdmin,
-} from '@/services/socioMensajeService';
 import { NextResponse } from 'next/server';
+import { getMensajeAdminById, updateMensajeAdmin } from '@/services/socioMensajeService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
+    const user = await authorizeDashboardRequest(req, '/dashboard/mensajes-admin', ['admin', 'usuario']);
     const mensaje = await getMensajeAdminById(params.id, user);
     return NextResponse.json({ data: mensaje });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -23,13 +23,12 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const body = await req.json();
-    const mensaje = await updateMensajeAdmin(params.id, body, user);
+    const user = await authorizeDashboardRequest(req, '/dashboard/mensajes-admin', ['admin', 'usuario']);
+    const mensaje = await updateMensajeAdmin(params.id, await req.json(), user);
     return NextResponse.json({ data: mensaje });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/admin/socios-mensajes/resumen/route.ts
+++ b/src/app/api/admin/socios-mensajes/resumen/route.ts
@@ -1,45 +1,31 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { getMensajesAdmin } from '@/services/socioMensajeService';
 import { NextResponse } from 'next/server';
+import { getMensajesAdmin } from '@/services/socioMensajeService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 type EstadoMensaje = string | null | undefined;
-
-function normalizeEstado(estado: EstadoMensaje) {
-  return String(estado ?? '').trim().toLowerCase();
-}
-
-function isPendiente(estado: EstadoMensaje) {
-  return normalizeEstado(estado) === 'pendiente';
-}
-
-function isSinResponder(estado: EstadoMensaje) {
-  const normalized = normalizeEstado(estado);
-  return normalized === 'pendiente' || normalized === 'leido' || normalized === 'leído';
-}
+const normalizeEstado = (estado: EstadoMensaje) => String(estado ?? '').trim().toLowerCase();
+const isPendiente = (estado: EstadoMensaje) => normalizeEstado(estado) === 'pendiente';
+const isSinResponder = (estado: EstadoMensaje) => ['pendiente', 'leido', 'leído'].includes(normalizeEstado(estado));
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    if (user.rol !== 'admin' && user.rol !== 'usuario') {
-      return NextResponse.json({ error: 'No autorizado para ver mensajes de socios' }, { status: 403 });
-    }
-
+    const user = await authorizeDashboardRequest(req, '/dashboard/mensajes-admin', ['admin', 'usuario']);
     const mensajes = await getMensajesAdmin(user, {});
-    const nuevos = mensajes.filter((mensaje) => isPendiente(mensaje.estado)).length;
-    const sinResponder = mensajes.filter((mensaje) => isSinResponder(mensaje.estado)).length;
-
     return NextResponse.json({
       data: {
         total: mensajes.length,
-        nuevos,
-        sin_responder: sinResponder,
+        nuevos: mensajes.filter((mensaje) => isPendiente(mensaje.estado)).length,
+        sin_responder: mensajes.filter((mensaje) => isSinResponder(mensaje.estado)).length,
       },
     });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/admin/socios-mensajes/route.ts
+++ b/src/app/api/admin/socios-mensajes/route.ts
@@ -1,22 +1,28 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { getMensajesAdmin } from '@/services/socioMensajeService';
 import { NextResponse } from 'next/server';
+import { getMensajesAdmin } from '@/services/socioMensajeService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/mensajes-admin',
+      ['admin', 'usuario'],
+    );
     const url = new URL(req.url);
     const mensajes = await getMensajesAdmin(user, {
       estado: url.searchParams.get('estado'),
       q: url.searchParams.get('q'),
     });
-
     return NextResponse.json({ data: mensajes });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/asistencias/[id]/salida/route.ts
+++ b/src/app/api/asistencias/[id]/salida/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import {
   getAforoAsistencia,
   registrarSalidaAsistencia,
 } from "@/services/asistenciaService";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +19,7 @@ type RouteContext = {
 
 export async function POST(req: NextRequest, { params }: RouteContext) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias/aforo', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
@@ -32,6 +36,8 @@ export async function POST(req: NextRequest, { params }: RouteContext) {
 
     return NextResponse.json({ ...salida, aforo }, { status: 200 });
   } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message =
       error instanceof Error ? error.message : "Error al registrar salida";
     const status = message.toLowerCase().includes("no autorizado") ? 403 : 500;

--- a/src/app/api/asistencias/aforo/route.ts
+++ b/src/app/api/asistencias/aforo/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getAforoAsistencia } from "@/services/asistenciaService";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -18,7 +22,7 @@ function isAuthError(error: unknown) {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias/aforo', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
@@ -26,6 +30,8 @@ export async function GET(req: Request) {
     const aforo = await getAforoAsistencia(user);
     return NextResponse.json(aforo, { status: 200 });
   } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message =
       error instanceof Error ? error.message : "Error al obtener aforo";
 

--- a/src/app/api/asistencias/qr-dia/route.ts
+++ b/src/app/api/asistencias/qr-dia/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  AuthMiddlewareError,
+  authMiddleware,
+} from '@/middlewares/auth.middleware';
 import { createQRDiario } from '@/services/asistenciaService';
+import {
+  AuthorizationError,
+  requireDashboardPermission,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,20 +23,21 @@ function isAuthSessionError(error: unknown) {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Unauthorized', error_code: 'TERMINAL_SESSION_UNAUTHORIZED' },
-        { status: 401 }
-      );
-    }
-
+    const { user } = await authMiddleware(req, { allowTerminalSession: true });
+    requireDashboardPermission(user, '/dashboard/asistencias/terminal');
     const { qrCode, url, token } = await createQRDiario();
     return NextResponse.json({ qrCode, url, token });
   } catch (err) {
     console.error('Error al generar el QR:', err);
 
-    if (isAuthSessionError(err)) {
+    if (err instanceof AuthorizationError) {
+      return NextResponse.json(
+        { error: err.message, error_code: err.code },
+        { status: err.status },
+      );
+    }
+
+    if (err instanceof AuthMiddlewareError || isAuthSessionError(err)) {
       return NextResponse.json(
         {
           error: 'La sesión de Terminal expiró. Iniciá sesión nuevamente o renová la sesión.',

--- a/src/app/api/asistencias/ranking-mensual/route.ts
+++ b/src/app/api/asistencias/ranking-mensual/route.ts
@@ -1,14 +1,18 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rankingMensualAsistencia } from "@/services/asistenciaService";
 import { NextResponse } from "next/server";
 
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req : Request){
     try{
-    const {user} = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/socios-ranking-bonificacion', ['admin', 'usuario']);
     if(!user){
         return NextResponse.json({message: 'Unauthorized'}, {status: 401});
     }
@@ -21,6 +25,8 @@ export async function POST(req : Request){
 
     return NextResponse.json(rankingMensual);
     }catch(error:any){
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.log(error);
        return NextResponse.json({message: error.message}, {status: 500});
    }

--- a/src/app/api/asistencias/recientes/route.ts
+++ b/src/app/api/asistencias/recientes/route.ts
@@ -1,6 +1,13 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  AuthMiddlewareError,
+  authMiddleware,
+} from "@/middlewares/auth.middleware";
 import { NextResponse } from "next/server";
 import { conexionBD } from "@/middlewares/conexionBd.middleware";
+import {
+  AuthorizationError,
+  requireDashboardPermission,
+} from "@/lib/auth/serverAuthorization";
 
 export const dynamic = "force-dynamic";
 
@@ -109,11 +116,8 @@ async function enrichAsistenciaConEstadoCuota(supabase: any, row: any) {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
-    }
-
+    const { user } = await authMiddleware(req, { allowTerminalSession: true });
+    requireDashboardPermission(user, '/dashboard/asistencias/terminal');
     const supabase = conexionBD();
 
     // Últimas 4 asistencias con datos del socio.
@@ -151,7 +155,14 @@ export async function GET(req: Request) {
 
     return NextResponse.json(enriched, { status: 200 });
   } catch (error: unknown) {
-    if (isAuthSessionError(error)) {
+    if (error instanceof AuthorizationError) {
+      return NextResponse.json(
+        { error: error.message, error_code: error.code },
+        { status: error.status },
+      );
+    }
+
+    if (error instanceof AuthMiddlewareError || isAuthSessionError(error)) {
       return NextResponse.json(
         {
           error:

--- a/src/app/api/asistencias/registro-qr/route.ts
+++ b/src/app/api/asistencias/registro-qr/route.ts
@@ -1,9 +1,17 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { registrarAsistenciaDesdeQR } from '@/services/asistenciaService';
-
+import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
+
+const REGISTRO_QR_PATHS = [
+  '/dashboard/asistencias',
+  '/dashboard/control-asistencia',
+];
 
 function getInvalidRegistroStatus(registro: any) {
   if (registro?.access_status === 'desactivado') return 403;
@@ -11,20 +19,23 @@ function getInvalidRegistroStatus(registro: any) {
   return 400;
 }
 
-async function handleRegistroQR(req: NextRequest, tokenAsistencia: string | null) {
-  const { user } = await authMiddleware(req);
+async function authorizeRegistroQR(req: NextRequest) {
+  return authorizePersonalOrDashboardRequest(
+    req,
+    REGISTRO_QR_PATHS,
+    ['admin', 'usuario'],
+    ['socio'],
+  );
+}
 
-  if (!user) {
-    return NextResponse.json(
-      { valido: false, error: 'El usuario no esta logueado' },
-      { status: 400 }
-    );
-  }
-
+async function handleRegistroQR(
+  user: JwtUser,
+  tokenAsistencia: string | null,
+) {
   if (!tokenAsistencia) {
     return NextResponse.json(
       { valido: false, error: 'Falta el tokenAsistencia' },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -41,30 +52,38 @@ async function handleRegistroQR(req: NextRequest, tokenAsistencia: string | null
 
 export async function GET(req: NextRequest) {
   try {
+    const user = await authorizeRegistroQR(req);
     const { searchParams } = new URL(req.url);
-    const tokenAsistencia = searchParams.get('tokenAsistencia');
+    return handleRegistroQR(user, searchParams.get('tokenAsistencia'));
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
 
-    return handleRegistroQR(req, tokenAsistencia);
-  } catch (err: any) {
-    console.error(err);
+    const message =
+      error instanceof Error ? error.message : 'Error al registrar asistencia';
+    console.error(error);
     return NextResponse.json(
-      { valido: false, error: err.message },
-      { status: 401 }
+      { valido: false, error: message },
+      { status: 400 },
     );
   }
 }
 
 export async function POST(req: NextRequest) {
   try {
+    const user = await authorizeRegistroQR(req);
     const body = await req.json();
-    const tokenAsistencia = body.qr;
+    return handleRegistroQR(user, body.qr ?? null);
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
 
-    return handleRegistroQR(req, tokenAsistencia);
-  } catch (err: any) {
-    console.error(err);
+    const message =
+      error instanceof Error ? error.message : 'Error al registrar asistencia';
+    console.error(error);
     return NextResponse.json(
-      { valido: false, error: err.message },
-      { status: 401 }
+      { valido: false, error: message },
+      { status: 400 },
     );
   }
 }
@@ -74,7 +93,7 @@ export async function OPTIONS() {
     status: 200,
     headers: {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     },
   });

--- a/src/app/api/asistencias/route.ts
+++ b/src/app/api/asistencias/route.ts
@@ -1,4 +1,3 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import {
   getAllAsistencias,
   createAsistencia,
@@ -7,17 +6,24 @@ import {
 } from "@/services/asistenciaService";
 import { NextResponse } from "next/server";
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
     const asistencias = await getAllAsistencias(user);
     return NextResponse.json(asistencias, { status: 200 });
-  } catch {
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: "Error al obtener asistencias" },
       { status: 500 },
@@ -27,7 +33,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
@@ -45,6 +51,8 @@ export async function POST(req: Request) {
       { status: 201 },
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || "Error al registrar asistencia" },
       { status: 500 },
@@ -54,7 +62,7 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
@@ -74,6 +82,8 @@ export async function PUT(req: Request) {
       { status: 200 },
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || "Error al actualizar asistencia" },
       { status: 500 },
@@ -83,7 +93,7 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/asistencias', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "No autorizado" }, { status: 401 });
     }
@@ -100,6 +110,8 @@ export async function DELETE(req: Request) {
       { status: 200 },
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || "Error al eliminar asistencia" },
       { status: 500 },

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,6 +5,8 @@ import { createClient } from "@supabase/supabase-js";
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: PUBLIC_AUTH_PROVIDER
+
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -3,6 +3,7 @@ import * as jwt from 'jsonwebtoken';
 import { NextResponse } from 'next/server';
 
 import { authMiddleware } from '@/middlewares/auth.middleware';
+import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
 import { sanitizeMenuPermissionsForRole } from '@/lib/permissions/menuPermissions';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 import { getPasswordPolicyMessage, isStrongPassword } from '@/utils/passwordPolicy';
@@ -97,6 +98,9 @@ export async function POST(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     return NextResponse.json(
       { error: error.message || 'Error al cambiar contraseña' },
       { status: error.message?.includes('Token') ? 401 : 500 }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -7,6 +7,8 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: PUBLIC_RECOVERY
+
 export async function POST(req: Request) {
   try {
     const body = await req.json().catch(() => ({}));

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -8,6 +8,8 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: PUBLIC_RECOVERY_TOKEN
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const token = searchParams.get('token') ?? '';

--- a/src/app/api/auth/terminal-session/refresh/route.ts
+++ b/src/app/api/auth/terminal-session/refresh/route.ts
@@ -5,6 +5,8 @@ import { canAccessDashboardPath } from '@/lib/permissions/menuPermissions';
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: TERMINAL_BEARER_REFRESH
+
 type TerminalSessionPayload = JwtUser & {
   terminal_session?: boolean;
   terminal_issued_at?: string;

--- a/src/app/api/avisos/[id]/route.ts
+++ b/src/app/api/avisos/[id]/route.ts
@@ -6,6 +6,11 @@ import {
 } from '@/services/avisoService';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -13,6 +18,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(_req, '/dashboard/avisos', ['admin', 'usuario']);
     const { id } = await params;
     const aviso = await getAvisoById(id);
     if (!aviso)
@@ -22,6 +28,8 @@ export async function GET(
       );
     return NextResponse.json(aviso);
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }
@@ -31,11 +39,14 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/avisos', ['admin', 'usuario']);
     const { id } = await params;
     const body = await req.json();
     const aviso = await updateAviso(id, body);
     return NextResponse.json(aviso);
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }
@@ -45,10 +56,13 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(_req, '/dashboard/avisos', ['admin', 'usuario']);
     const { id } = await params;
     const aviso = await deleteAviso(id);
     return NextResponse.json(aviso);
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/avisos/route.ts
+++ b/src/app/api/avisos/route.ts
@@ -2,23 +2,34 @@ import { NextRequest, NextResponse } from "next/server";
 import { getAllAvisos, createAviso } from "@/services/avisoService";
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/avisos', ['admin', 'usuario']);
     const avisos = await getAllAvisos();
     return NextResponse.json(avisos);
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }
 
 export async function POST(req: NextRequest) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/avisos', ['admin', 'usuario']);
     const body = await req.json();
     const aviso = await createAviso(body);
     return NextResponse.json(aviso, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/comercial/caja/route.ts
+++ b/src/app/api/comercial/caja/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   abrirCaja,
   cerrarCaja,
@@ -7,14 +6,21 @@ import {
   registrarMovimientoCaja,
 } from '@/services/server/comercialCajaServerService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/caja', ['admin', 'usuario']);
     const dashboard = await getComercialCajaDashboard();
     return NextResponse.json({ data: dashboard }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al obtener caja comercial';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -23,7 +29,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/comercial/caja', ['admin', 'usuario']);
     const body = await req.json();
 
     if (body?.action === 'abrir') {
@@ -43,6 +49,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ error: 'Acción de caja inválida' }, { status: 400 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al operar caja comercial';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/codigos/labels/route.ts
+++ b/src/app/api/comercial/codigos/labels/route.ts
@@ -1,15 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getComercialCodigosLabelsDashboard } from '@/services/server/comercialCodigosServerService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/codigos-etiquetas', ['admin', 'usuario']);
     const dashboard = await getComercialCodigosLabelsDashboard();
     return NextResponse.json({ data: dashboard }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al consultar códigos comerciales.';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/codigos/qr/route.ts
+++ b/src/app/api/comercial/codigos/qr/route.ts
@@ -1,16 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { generateComercialQrCode } from '@/services/server/comercialCodigosServerService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/codigos-etiquetas', ['admin', 'usuario']);
     const body = await req.json();
     const qr = await generateComercialQrCode(body);
     return NextResponse.json({ data: qr, message: 'Código QR comercial generado' }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al generar QR comercial.';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/compras-reposicion/route.ts
+++ b/src/app/api/comercial/compras-reposicion/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   createComercialOrdenCompra,
   getComercialComprasReposicionDashboard,
@@ -7,14 +6,21 @@ import {
   upsertComercialProveedorProducto,
 } from '@/services/server/comercialComprasReposicionServerService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/compras-reposicion', ['admin', 'usuario']);
     const dashboard = await getComercialComprasReposicionDashboard();
     return NextResponse.json({ data: dashboard }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al obtener compras y reposición comercial';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -23,7 +29,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/comercial/compras-reposicion', ['admin', 'usuario']);
     const body = await req.json();
 
     if (body?.action === 'proveedor_producto') {
@@ -43,6 +49,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ error: 'Acción de compras/reposición inválida' }, { status: 400 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al operar compras y reposición comercial';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/kiosco-pos/route.ts
+++ b/src/app/api/comercial/kiosco-pos/route.ts
@@ -1,18 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   createComercialKioscoPosVenta,
   getComercialKioscoPosDashboard,
 } from '@/services/server/comercialKioscoPosServerService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/kiosco', ['admin', 'usuario']);
     const dashboard = await getComercialKioscoPosDashboard();
     return NextResponse.json({ data: dashboard }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al obtener POS/Kiosco';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -21,11 +27,13 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/comercial/kiosco', ['admin', 'usuario']);
     const body = await req.json();
     const venta = await createComercialKioscoPosVenta(body, user ?? null);
     return NextResponse.json({ data: venta, message: 'Venta POS/Kiosco registrada' }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al registrar venta POS/Kiosco';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/mobile-scanner/public/[token]/route.ts
+++ b/src/app/api/comercial/mobile-scanner/public/[token]/route.ts
@@ -1,10 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
 import {
   createPublicComercialScannerEvent,
   getPublicComercialScannerSession,
 } from '@/services/server/comercialMobileScannerServerService';
+import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
+
+// AUTH POLICY: PUBLIC_TOKEN
+// The scanner session is intentionally reachable without a user JWT. Access is
+// limited by a 144-bit random token, strict token format, expiry and session
+// state checks in the server service.
+const PUBLIC_SCANNER_TOKEN_RE = /^gm-pos-[a-f0-9]{36}$/;
 
 type Params = {
   params: {
@@ -12,21 +18,62 @@ type Params = {
   };
 };
 
+function getValidatedToken(token: string) {
+  const cleanToken = String(token ?? '').trim().toLowerCase();
+  if (!PUBLIC_SCANNER_TOKEN_RE.test(cleanToken)) {
+    throw new Error('Token de scanner inválido');
+  }
+  return cleanToken;
+}
+
+function publicScannerResponse<T>(payload: T, status: number) {
+  return NextResponse.json(payload, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}
+
 export async function GET(_req: NextRequest, { params }: Params) {
   try {
-    const session = await getPublicComercialScannerSession(params.token);
-    return NextResponse.json({ data: session }, { status: 200 });
-  } catch (error: any) {
-    return NextResponse.json({ error: error?.message || 'Error al obtener sesión pública de scanner' }, { status: 404 });
+    const session = await getPublicComercialScannerSession(
+      getValidatedToken(params.token),
+    );
+    return publicScannerResponse({ data: session }, 200);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Error al obtener sesión pública de scanner';
+    return publicScannerResponse({ error: message }, 404);
   }
 }
 
 export async function POST(req: NextRequest, { params }: Params) {
   try {
+    const token = getValidatedToken(params.token);
     const body = await req.json().catch(() => ({}));
-    const result = await createPublicComercialScannerEvent(params.token, body?.codigo);
-    return NextResponse.json({ data: result, message: result.message }, { status: 201 });
-  } catch (error: any) {
-    return NextResponse.json({ error: error?.message || 'Error al enviar código escaneado' }, { status: 400 });
+    const codigo = String(body?.codigo ?? '').trim();
+
+    if (!codigo || codigo.length > 160) {
+      return publicScannerResponse(
+        { error: 'El código escaneado es inválido' },
+        400,
+      );
+    }
+
+    const result = await createPublicComercialScannerEvent(token, codigo);
+    return publicScannerResponse(
+      { data: result, message: result.message },
+      201,
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Error al enviar código escaneado';
+    return publicScannerResponse({ error: message }, 400);
   }
 }

--- a/src/app/api/comercial/mobile-scanner/route.ts
+++ b/src/app/api/comercial/mobile-scanner/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   closeComercialMobileScannerSession,
   createComercialMobileScannerSession,
   getComercialMobileScannerState,
   markComercialMobileScannerEventProcessed,
 } from '@/services/server/comercialMobileScannerServerService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,12 +24,14 @@ function sanitizeScannerRouteError(value: unknown, fallback: string) {
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/kiosco', ['admin', 'usuario']);
     const { searchParams } = new URL(req.url);
     const sessionId = searchParams.get('session_id');
     const state = await getComercialMobileScannerState(sessionId);
     return NextResponse.json({ data: state }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = sanitizeScannerRouteError(error?.message, 'Error transitorio al obtener scanner móvil comercial');
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -34,7 +40,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/comercial/kiosco', ['admin', 'usuario']);
     const body = await req.json().catch(() => ({}));
     const action = String(body?.action ?? '');
 
@@ -55,6 +61,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ error: 'Acción de scanner no soportada' }, { status: 400 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = sanitizeScannerRouteError(error?.message, 'Error al operar scanner móvil comercial');
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/pack-analytics/route.ts
+++ b/src/app/api/comercial/pack-analytics/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getComercialPackAnalyticsDashboard } from '@/services/server/comercialPackAnalyticsServerService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/pack-analytics', ['admin', 'usuario']);
     const { searchParams } = new URL(req.url);
     const data = await getComercialPackAnalyticsDashboard({
       desde: searchParams.get('desde'),
@@ -15,6 +19,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al obtener analítica de packs comerciales';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/servicios-promociones/route.ts
+++ b/src/app/api/comercial/servicios-promociones/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   createComercialCupon,
   createComercialPack,
@@ -7,14 +6,21 @@ import {
   getComercialServiciosPromocionesDashboard,
 } from '@/services/server/comercialServiciosPromocionesServerService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/servicios-promociones', ['admin', 'usuario']);
     const dashboard = await getComercialServiciosPromocionesDashboard();
     return NextResponse.json({ data: dashboard }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al obtener servicios, packs y promociones';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -23,7 +29,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/servicios-promociones', ['admin', 'usuario']);
     const body = await req.json();
 
     if (body?.action === 'crear_pack') {
@@ -43,6 +49,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ error: 'Acción comercial inválida' }, { status: 400 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al operar servicios, packs y promociones';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/comercial/stock-ledger/route.ts
+++ b/src/app/api/comercial/stock-ledger/route.ts
@@ -1,18 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   createComercialStockMovimiento,
   getComercialStockLedgerDashboard,
 } from '@/services/server/comercialStockLedgerServerService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/comercial/stock-ledger', ['admin', 'usuario']);
     const dashboard = await getComercialStockLedgerDashboard();
     return NextResponse.json({ data: dashboard }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al obtener stock ledger comercial';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -21,11 +27,13 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/comercial/stock-ledger', ['admin', 'usuario']);
     const body = await req.json();
     const movimiento = await createComercialStockMovimiento(body, user?.id ?? null);
     return NextResponse.json({ data: movimiento }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al registrar movimiento de stock comercial';
     const status = message.includes('Token') || message.includes('JWT') ? 401 : 400;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/compras/[id]/route.ts
+++ b/src/app/api/compras/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,18 +25,20 @@ async function fetchCompraById(supabase: ReturnType<typeof conexionBD>, id: stri
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/compras', ['admin', 'usuario']);
     const supabase = conexionBD();
     const compra = await fetchCompraById(supabase, params.id);
     return NextResponse.json({ data: compra }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || 'Error al obtener compra' }, { status: 500 });
   }
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/compras', ['admin', 'usuario']);
     const supabase = conexionBD();
     const body = await req.json();
     const estado = body?.estado;
@@ -55,13 +61,15 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     const compra = await fetchCompraById(supabase, params.id);
     return NextResponse.json({ data: compra }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || 'Error al actualizar compra' }, { status: 500 });
   }
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/compras', ['admin', 'usuario']);
     const supabase = conexionBD();
     const compra = await fetchCompraById(supabase, params.id);
 
@@ -125,6 +133,8 @@ export async function DELETE(req: NextRequest, { params }: { params: { id: strin
     const updated = await fetchCompraById(supabase, params.id);
     return NextResponse.json({ data: updated }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || 'Error al anular compra' }, { status: 500 });
   }
 }

--- a/src/app/api/compras/route.ts
+++ b/src/app/api/compras/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -57,7 +61,7 @@ async function fetchCompraById(supabase: ReturnType<typeof conexionBD>, id: stri
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/compras', ['admin', 'usuario']);
     const supabase = conexionBD();
     const { searchParams } = new URL(req.url);
     const proveedorId = searchParams.get('proveedor_id');
@@ -81,6 +85,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data: data ?? [] }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener compras' },
       { status: 500 }
@@ -90,7 +96,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/compras', ['admin', 'usuario']);
     const supabase = conexionBD();
     const body = await req.json();
 
@@ -262,6 +268,8 @@ export async function POST(req: NextRequest) {
     const fullCompra = await fetchCompraById(supabase, compra.id);
     return NextResponse.json({ data: fullCompra }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al registrar compra' },
       { status: 500 }

--- a/src/app/api/cuota-estado/route.ts
+++ b/src/app/api/cuota-estado/route.ts
@@ -1,15 +1,19 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   getAdminCuotasEstadoServer,
   getEstadoCuotaSocioServer,
 } from '@/services/server/cuotaEstadoServerService';
 
+import {
+  authorizePersonalOrDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(req, ['/dashboard/cuotas', '/dashboard/mi-cuenta/pagar-cuota'], ['admin', 'usuario'], ['socio']);
     const url = new URL(req.url);
     const socioIdFromQuery = url.searchParams.get('socio_id');
 
@@ -33,6 +37,8 @@ export async function GET(req: Request) {
     const estadoGeneral = await getAdminCuotasEstadoServer(user);
     return NextResponse.json({ data: estadoGeneral }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('ERROR al obtener estado de cuota:', error.message || error);
     const message = error.message || 'Error al obtener estado de cuota';
     const status =

--- a/src/app/api/cuota/[id]/route.ts
+++ b/src/app/api/cuota/[id]/route.ts
@@ -2,6 +2,11 @@ import { getCuotaById } from '@/services/cuotaService';
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -9,10 +14,13 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/cuotas', ['admin', 'usuario']);
     const { id } = await params;
     const cuota = await getCuotaById(id);
     return NextResponse.json({ data: cuota }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message });
   }
 }

--- a/src/app/api/cuota/route.ts
+++ b/src/app/api/cuota/route.ts
@@ -1,64 +1,123 @@
-import { createCuota, deleteCuota, getAllCuotas, updateCuota } from "@/services/cuotaService";
-import { error } from "console";
-import { NextResponse } from "next/server";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+import {
+  createCuota,
+  deleteCuota,
+  getAllCuotas,
+  updateCuota,
+} from '@/services/cuotaService';
+import { NextResponse } from 'next/server';
 
-export async function GET(){
-    try{
-const cuotas = await getAllCuotas();
-return NextResponse.json({data:cuotas},{status:200})
-}catch(error:any){
-    console.log("error al obtener las cuotas:", error.message);
-    return NextResponse.json({error:"Error al obtener las cuotas"},{status:500})
-}
+const CUOTAS_PATH = '/dashboard/cuotas';
+const CUOTAS_ROLES = ['admin', 'usuario'] as const;
+
+export async function GET(req: Request) {
+  try {
+    await authorizeDashboardRequest(req, CUOTAS_PATH, [...CUOTAS_ROLES]);
+    const cuotas = await getAllCuotas();
+    return NextResponse.json({ data: cuotas }, { status: 200 });
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    console.error('Error al obtener las cuotas:', error);
+    return NextResponse.json(
+      { error: 'Error al obtener las cuotas' },
+      { status: 500 },
+    );
+  }
 }
 
-export async function POST(req: Request){
-    try {
-        const body = await req.json();
-        if(!body.descripcion || !body.monto || body.monto <= 0 || !body.fecha_inicio || !body.fecha_fin){
-            return NextResponse.json({error:"Todos los campos son obligatorios y el monto debe ser mayor que 0"},{status:400})
-        }
-        const cuota = await createCuota(body);
-        return NextResponse.json({
-            message:"Cuota creada con exito",
-            data:cuota
-        },{status:201})
-            
-    } catch (error:any) {
-        console.log("Error al crear la cuota: ", error.message);
-        return NextResponse.json({error:"Error al crear la cuota"},{status:500})
-        
+export async function POST(req: Request) {
+  try {
+    await authorizeDashboardRequest(req, CUOTAS_PATH, [...CUOTAS_ROLES]);
+    const body = await req.json();
+
+    if (
+      !body.descripcion ||
+      !body.monto ||
+      body.monto <= 0 ||
+      !body.fecha_inicio ||
+      !body.fecha_fin
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            'Todos los campos son obligatorios y el monto debe ser mayor que 0',
+        },
+        { status: 400 },
+      );
     }
 
+    const cuota = await createCuota(body);
+    return NextResponse.json(
+      { message: 'Cuota creada con éxito', data: cuota },
+      { status: 201 },
+    );
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    console.error('Error al crear la cuota:', error);
+    return NextResponse.json(
+      { error: 'Error al crear la cuota' },
+      { status: 500 },
+    );
+  }
 }
 
-export async function PUT(req:Request){
+export async function PUT(req: Request) {
+  try {
+    await authorizeDashboardRequest(req, CUOTAS_PATH, [...CUOTAS_ROLES]);
     const { id, updateData } = await req.json();
-    try {
-        if (!id || typeof id !== 'string') {
-            return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 })
-        }
-        const cuotaModificada = await updateCuota(id, updateData);
-        return NextResponse.json({
-            message: "Cuota actualizada con éxito",
-            data: cuotaModificada
-        }, { status: 200 });
-    } catch (error: any) {
-        const msg = error.message || 'Error al actualizar cuota'
-        return NextResponse.json({ error: msg }, { status: 500 })
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json(
+        { error: 'ID inválido para actualizar' },
+        { status: 400 },
+      );
     }
+
+    const cuotaModificada = await updateCuota(id, updateData);
+    return NextResponse.json(
+      { message: 'Cuota actualizada con éxito', data: cuotaModificada },
+      { status: 200 },
+    );
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    const message =
+      error instanceof Error ? error.message : 'Error al actualizar cuota';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }
 
-export async function DELETE(req:Request){
-     const { id } = await req.json();
-    try {
-        if (!id || typeof id !== 'string') {
-            return NextResponse.json({ error: 'ID inválido para eliminar' }, { status: 400 })
-        }
-           await deleteCuota(id)
-            return NextResponse.json({ message: 'Cuota eliminada con éxito' }, { status: 200 })
-          } catch (error: any) {
-            const msg = error.message || 'Error al eliminar cuota'
-            return NextResponse.json({ error: msg }, { status: 500 })
-          }
+export async function DELETE(req: Request) {
+  try {
+    await authorizeDashboardRequest(req, CUOTAS_PATH, [...CUOTAS_ROLES]);
+    const { id } = await req.json();
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json(
+        { error: 'ID inválido para eliminar' },
+        { status: 400 },
+      );
+    }
+
+    await deleteCuota(id);
+    return NextResponse.json(
+      { message: 'Cuota eliminada con éxito' },
+      { status: 200 },
+    );
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    const message =
+      error instanceof Error ? error.message : 'Error al eliminar cuota';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/custom-login/route.ts
+++ b/src/app/api/custom-login/route.ts
@@ -3,6 +3,8 @@ import { NextResponse } from "next/server";
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: PUBLIC_LOGIN
+
 type LoginError = Error & {
   code?: string;
   status?: number;

--- a/src/app/api/dieta/[id]/route.ts
+++ b/src/app/api/dieta/[id]/route.ts
@@ -1,39 +1,33 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { getDietaById } from '@/services/dietaService';
 import { NextResponse } from 'next/server';
+import { getDietaById } from '@/services/dietaService';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(
   req: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/dietas', '/dashboard/gestor-dietas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
     const { id } = await params;
-    if (!id) {
-      return NextResponse.json(
-        { error: 'ID de dieta es requerido' },
-        { status: 400 }
-      );
-    }
-
+    if (!id) return NextResponse.json({ error: 'ID de dieta es requerido' }, { status: 400 });
     const dieta = await getDietaById(id, user);
-    if (!dieta) {
-      return NextResponse.json(
-        { error: 'No se encontró la dieta solicitada' },
-        { status: 404 }
-      );
-    }
-
+    if (!dieta) return NextResponse.json({ error: 'No se encontró la dieta solicitada' }, { status: 404 });
     return NextResponse.json(dieta, { status: 200 });
-  } catch (error: any) {
-    const message = error?.message ?? 'Error al obtener la dieta';
-    const status = message.includes('Token') ? 401 : 500;
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener la dieta';
+    const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/dieta/generar/route.ts
+++ b/src/app/api/dieta/generar/route.ts
@@ -1,39 +1,31 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { createDietaSocio } from "@/services/dietaService";
-import { NextResponse } from "next/server";
-
+import { NextResponse } from 'next/server';
+import { createDietaSocio } from '@/services/dietaService';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
-export async function POST (req: Request){
-    try{
-    const {user} = await authMiddleware(req);
-    if (!user) {
-        return NextResponse.json(
-            { error: "Unauthorized" }, 
-            { status: 401 }
-        );
-    }
-
-    const body = await req.json();
-
-    if(!body.socio_id || !body.objetivo || !body.fecha_inicio || !body.fecha_fin ) {
-        return NextResponse.json(
-            { error: "Debe enviar todos los campos requeridos" }, 
-            { status: 400 }
-        );
-    }
-
-    const dieta = await createDietaSocio( body, user )
-
-    return NextResponse.json(dieta, { status: 201 });
-
-
-} catch (error:any) {
-    return NextResponse.json(
-        { error: error.message }, 
-        { status: 500 }
+export async function POST(req: Request) {
+  try {
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/dietas', '/dashboard/gestor-dietas'],
+      ['admin', 'usuario'],
+      ['socio'],
     );
+    const body = await req.json();
+    if (!body.socio_id || !body.objetivo || !body.fecha_inicio || !body.fecha_fin) {
+      return NextResponse.json({ error: 'Debe enviar todos los campos requeridos' }, { status: 400 });
     }
-
+    const dieta = await createDietaSocio(body, user);
+    return NextResponse.json(dieta, { status: 201 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al generar la dieta';
+    const status = message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
 }

--- a/src/app/api/dieta/rag-assistant/generar/route.ts
+++ b/src/app/api/dieta/rag-assistant/generar/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { createDietaSocio } from '@/services/dietaService';
 import { buildDietasRagContext } from '@/services/server/ragDietasCoachService';
 import type {
@@ -57,11 +60,13 @@ function validatePayload(body: Partial<RagDietasAssistantRequest>, fallbackSocio
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/dietas', '/dashboard/gestor-dietas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
-    if (!user) {
-      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = (await req.json().catch(() => ({}))) as Partial<RagDietasAssistantRequest>;
     const payload = validatePayload(body, user.id_socio);
@@ -72,6 +77,8 @@ export async function POST(req: Request) {
     try {
       ragContext = await buildDietasRagContext(user, payload);
     } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
       ragError = error instanceof Error ? translateAiGeneratedTechnicalText(error.message, payload.idioma) : translateAiGeneratedTechnicalText('Error desconocido al consultar RAG de dietas', payload.idioma);
       console.warn('RAG interno de dietas no disponible. Se usa fallback local:', ragError);
     }
@@ -121,7 +128,11 @@ export async function POST(req: Request) {
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : translateAiGeneratedTechnicalText('Error inesperado', 'es');
-    const status = message.toLowerCase().includes('token') ? 401 : (message.includes('Debe enviar') || message.toLowerCase().includes('must send')) ? 400 : 500;
+    const status = message.includes('No autorizado')
+      ? 403
+      : (message.includes('Debe enviar') || message.toLowerCase().includes('must send'))
+        ? 400
+        : 500;
 
     console.error('Error en asistente RAG de dietas:', error);
 

--- a/src/app/api/dieta/socio/[id]/route.ts
+++ b/src/app/api/dieta/socio/[id]/route.ts
@@ -1,32 +1,32 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { getAllDietasSocio } from '@/services/dietaService';
 import { NextResponse } from 'next/server';
+import { getAllDietasSocio } from '@/services/dietaService';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(
   req: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/dietas', '/dashboard/gestor-dietas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
     const { id } = await params;
-    if (!id) {
-      return NextResponse.json(
-        { error: 'ID del socio es requerido' },
-        { status: 400 }
-      );
-    }
-
+    if (!id) return NextResponse.json({ error: 'ID del socio es requerido' }, { status: 400 });
     const dietas = await getAllDietasSocio(id, user);
     return NextResponse.json(dietas ?? [], { status: 200 });
-  } catch (error: any) {
-    const message = error?.message ?? 'Error al obtener las dietas del socio';
-    const status = message.includes('Token') ? 401 : 500;
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener las dietas del socio';
+    const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/dieta/todas/route.ts
+++ b/src/app/api/dieta/todas/route.ts
@@ -1,34 +1,25 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
-import { getAllDietas } from "@/services/dietaService";
-import { NextResponse } from "next/server";
-
+import { NextResponse } from 'next/server';
+import { getAllDietas } from '@/services/dietaService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
-    try {
-        const { user } = await authMiddleware(req);
-        if (!user) {
-            return NextResponse.json(
-                { error: "Unauthorized" },
-                { status: 401 }
-            );
-        }
-
-        const dietas = await getAllDietas(user);
-        if (!dietas || dietas.length === 0) {
-            return NextResponse.json(
-                { message: "No se encontraron dietas" },
-                { status: 404 }
-            );
-        }
-
-        return NextResponse.json(dietas, { status: 200 });
-
-    } catch (error: any) {
-        return NextResponse.json(
-            { error: error.message },
-            { status: 500 }
-        );
-    }
-}   
+  try {
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/gestor-dietas',
+      ['admin', 'usuario'],
+    );
+    const dietas = await getAllDietas(user);
+    return NextResponse.json(dietas ?? [], { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener las dietas';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/dragon-pyramid/license/reactivate/route.ts
+++ b/src/app/api/dragon-pyramid/license/reactivate/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
-  assertMasterAdmin,
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+import {
   reactivateDragonPyramidLicenseAfterPayment,
 } from '@/services/server/dragonPyramidLicenseService';
 
@@ -15,8 +17,11 @@ function resolveStatus(message: string) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    assertMasterAdmin(user);
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/masteradmin/license',
+      ['masteradmin'],
+    );
 
     const body = await req.json().catch(() => ({}));
     const data = await reactivateDragonPyramidLicenseAfterPayment({
@@ -41,6 +46,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ data }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/dragon-pyramid/license/route.ts
+++ b/src/app/api/dragon-pyramid/license/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
-  assertMasterAdmin,
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+import {
   getDragonPyramidLicense,
   upsertDragonPyramidLicense,
 } from '@/services/server/dragonPyramidLicenseService';
@@ -16,8 +18,11 @@ function resolveStatus(message: string) {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    assertMasterAdmin(user);
+    await authorizeDashboardRequest(
+      req,
+      '/dashboard/masteradmin/license',
+      ['masteradmin'],
+    );
 
     const data = await getDragonPyramidLicense();
     return NextResponse.json(
@@ -28,6 +33,9 @@ export async function GET(req: Request) {
       },
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }
@@ -35,8 +43,11 @@ export async function GET(req: Request) {
 
 export async function PATCH(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    assertMasterAdmin(user);
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/masteradmin/license',
+      ['masteradmin'],
+    );
 
     const body = await req.json();
     const data = await upsertDragonPyramidLicense({
@@ -51,6 +62,9 @@ export async function PATCH(req: Request) {
 
     return NextResponse.json({ data }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/dragon-pyramid/license/suspension-status/route.ts
+++ b/src/app/api/dragon-pyramid/license/suspension-status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authMiddleware } from '@/middlewares/auth.middleware';
+import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
 import { getDragonPyramidLicense } from '@/services/server/dragonPyramidLicenseService';
 import { buildDragonPyramidSuspensionStatus } from '@/utils/dragonPyramidSuspension';
 
@@ -36,6 +37,9 @@ export async function GET(req: Request) {
       },
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/dragon-pyramid/license/warning/route.ts
+++ b/src/app/api/dragon-pyramid/license/warning/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authMiddleware } from '@/middlewares/auth.middleware';
+import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
 import { getDragonPyramidLicense } from '@/services/server/dragonPyramidLicenseService';
 import { buildDragonPyramidGraceWarning } from '@/utils/dragonPyramidLicenseWarning';
 import { normalizeLocale } from '@/i18n/config';
@@ -47,6 +48,9 @@ export async function GET(req: Request) {
       },
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/empleados-sueldos/[id]/route.ts
+++ b/src/app/api/empleados-sueldos/[id]/route.ts
@@ -1,10 +1,14 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import {
   anularEmpleadoSueldo,
   getEmpleadoSueldoById,
   updateEmpleadoSueldo,
 } from "@/services/empleadoSueldoService";
 import { NextResponse } from "next/server";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +17,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados-sueldos', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -26,6 +30,8 @@ export async function GET(
     const sueldo = await getEmpleadoSueldoById(id, user);
     return NextResponse.json(sueldo);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -36,7 +42,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados-sueldos', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -50,6 +56,8 @@ export async function PATCH(
     const sueldo = await updateEmpleadoSueldo(id, body, user);
     return NextResponse.json(sueldo);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -60,7 +68,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados-sueldos', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -73,6 +81,8 @@ export async function DELETE(
     const sueldo = await anularEmpleadoSueldo(id, user);
     return NextResponse.json(sueldo);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/empleados-sueldos/route.ts
+++ b/src/app/api/empleados-sueldos/route.ts
@@ -1,12 +1,16 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { createEmpleadoSueldo, getEmpleadoSueldos } from "@/services/empleadoSueldoService";
 import { NextResponse } from "next/server";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados-sueldos', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -14,6 +18,8 @@ export async function GET(req: Request) {
     const sueldos = await getEmpleadoSueldos(user);
     return NextResponse.json(sueldos);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -21,7 +27,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados-sueldos', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -30,6 +36,8 @@ export async function POST(req: Request) {
     const sueldo = await createEmpleadoSueldo(body, user);
     return NextResponse.json(sueldo, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/empleados/[id]/route.ts
+++ b/src/app/api/empleados/[id]/route.ts
@@ -1,6 +1,10 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { deactivateEmpleado, getEmpleadoById, updateEmpleado } from "@/services/empleadoService";
 import { NextResponse } from "next/server";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -9,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -22,6 +26,8 @@ export async function GET(
     const empleado = await getEmpleadoById(id, user);
     return NextResponse.json(empleado);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -32,7 +38,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -46,6 +52,8 @@ export async function PATCH(
     const empleado = await updateEmpleado(id, body, user);
     return NextResponse.json(empleado);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -56,7 +64,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -69,6 +77,8 @@ export async function DELETE(
     const empleado = await deactivateEmpleado(id, user);
     return NextResponse.json(empleado);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/empleados/route.ts
+++ b/src/app/api/empleados/route.ts
@@ -1,12 +1,16 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { createEmpleado, getEmpleados } from "@/services/empleadoService";
 import { NextResponse } from "next/server";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -14,6 +18,8 @@ export async function GET(req: Request) {
     const empleados = await getEmpleados(user);
     return NextResponse.json(empleados);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -21,7 +27,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -30,6 +36,8 @@ export async function POST(req: Request) {
     const empleado = await createEmpleado(body, user);
     return NextResponse.json(empleado, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : "Error interno del servidor";
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/entrenadores/[id]/horarios/route.ts
+++ b/src/app/api/entrenadores/[id]/horarios/route.ts
@@ -1,7 +1,11 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getHorariosByEntrenadorId } from '@/services/entrenadorHorarioService';
 import { NextResponse } from 'next/server';
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,7 +14,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -34,6 +38,8 @@ export async function GET(
 
     return NextResponse.json(horarios, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al obtener los horarios del entrenador:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/entrenadores/[id]/route.ts
+++ b/src/app/api/entrenadores/[id]/route.ts
@@ -1,10 +1,14 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   getEntrenadorById,
   updateEntrenador,
 } from '@/services/entrenadorService';
 import { NextResponse } from 'next/server';
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,7 +17,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -37,6 +41,8 @@ export async function GET(
 
     return NextResponse.json(entrenador, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al obtener el entrenador:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
@@ -47,7 +53,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -69,6 +75,8 @@ export async function PUT(
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al actualizar el entrenador:', error);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/entrenadores/route.ts
+++ b/src/app/api/entrenadores/route.ts
@@ -1,4 +1,3 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { rolAdminMiddleware } from "@/middlewares/rolAdmin.middleware";
 import {
   createEntrenador,
@@ -7,17 +6,24 @@ import {
 import { NextResponse } from "next/server";
 
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     const entrenadores = await getEntrenadores(user);
     return NextResponse.json(entrenadores);
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     if (error instanceof Error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
@@ -30,7 +36,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/empleados', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
@@ -54,6 +60,8 @@ export async function POST(req: Request) {
     );
     return NextResponse.json(entrenador, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     if (error instanceof Error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/equipamientos/[id]/route.ts
+++ b/src/app/api/equipamientos/[id]/route.ts
@@ -5,6 +5,11 @@ import {
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function PUT(
@@ -12,6 +17,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
     const { id } = await params;
     console.log(id);
 
@@ -30,6 +36,8 @@ export async function PUT(
       { status: 201 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error.message);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
@@ -40,6 +48,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
     const { id } = await params;
     console.log(id);
 
@@ -55,6 +64,8 @@ export async function DELETE(
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error.message);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/equipamientos/alertas-mantenimiento/route.ts
+++ b/src/app/api/equipamientos/alertas-mantenimiento/route.ts
@@ -7,6 +7,11 @@ import {
   SeveridadAlertaMantenimiento,
 } from "@/interfaces/equipamientoAlertas.interface";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = "force-dynamic";
 
 type EquipamientoRevisionRow = {
@@ -149,6 +154,7 @@ function buildResumen(alertas: AlertaMantenimientoEquipamiento[]) {
 
 export async function GET(request: NextRequest) {
   try {
+    await authorizeDashboardRequest(request, '/dashboard/equipamientos', ['admin', 'usuario']);
     const umbralDias = parseUmbralDias(request);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -192,6 +198,8 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(response, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al obtener alertas de mantenimiento:", error);
 
     return NextResponse.json(

--- a/src/app/api/equipamientos/mantenimiento-bi/route.ts
+++ b/src/app/api/equipamientos/mantenimiento-bi/route.ts
@@ -8,6 +8,11 @@ import {
   EquipamientoMantenimientoSerieMensual,
 } from "@/interfaces/equipamientoMantenimientoBi.interface";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = "force-dynamic";
 
 type EquipoRow = {
@@ -139,8 +144,9 @@ function buildRiskScore(args: {
   return Math.min(score, 100);
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const since90 = new Date(today);
@@ -341,6 +347,8 @@ export async function GET() {
 
     return NextResponse.json(response, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al obtener BI de mantenimiento de equipamiento:", error);
     return NextResponse.json(
       {

--- a/src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts
+++ b/src/app/api/equipamientos/preventivos/ordenes/[id]/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server';
 import { updateEquipamientoOrdenTecnica } from '@/services/server/equipamientoPreventivoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function PATCH(
@@ -8,11 +13,14 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/equipamientos/preventivos', ['admin', 'usuario']);
     const { id } = await params;
     const body = await req.json();
     const orden = await updateEquipamientoOrdenTecnica(id, body);
     return NextResponse.json({ message: 'Orden técnica actualizada con éxito', data: orden }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message || 'Error al actualizar orden técnica.' },
       { status: 500 },

--- a/src/app/api/equipamientos/preventivos/ordenes/route.ts
+++ b/src/app/api/equipamientos/preventivos/ordenes/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createEquipamientoOrdenTecnica } from '@/services/server/equipamientoPreventivoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/equipamientos/preventivos', ['admin', 'usuario']);
     const body = await req.json();
     const orden = await createEquipamientoOrdenTecnica(body);
     return NextResponse.json({ message: 'Orden técnica creada con éxito', data: orden }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al crear orden técnica.';
     const status = message.includes('obligatorio') || message.includes('Seleccioná') ? 400 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/equipamientos/preventivos/planes/route.ts
+++ b/src/app/api/equipamientos/preventivos/planes/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createEquipamientoPlanPreventivo } from '@/services/server/equipamientoPreventivoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/equipamientos/preventivos', ['admin', 'usuario']);
     const body = await req.json();
     const plan = await createEquipamientoPlanPreventivo(body);
     return NextResponse.json({ message: 'Plan preventivo creado con éxito', data: plan }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al crear plan preventivo.';
     return NextResponse.json({ error: message }, { status: message.includes('obligatorio') ? 400 : 500 });
   }

--- a/src/app/api/equipamientos/preventivos/route.ts
+++ b/src/app/api/equipamientos/preventivos/route.ts
@@ -1,13 +1,21 @@
 import { NextResponse } from 'next/server';
 import { getEquipamientosPreventivosDashboard } from '@/services/server/equipamientoPreventivoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/equipamientos/preventivos', ['admin', 'usuario']);
     const dashboard = await getEquipamientosPreventivosDashboard();
     return NextResponse.json(dashboard, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message || 'Error al consultar preventivos de equipamientos.' },
       { status: 500 },

--- a/src/app/api/equipamientos/route.ts
+++ b/src/app/api/equipamientos/route.ts
@@ -1,11 +1,19 @@
 import { createEquipamiento, getAllEquipamientos } from "@/services/equipamientoService";
 import { NextResponse } from "next/server";
 
-export async function GET(){
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
+export async function GET(req: Request){
     try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
         const equipamientos = await getAllEquipamientos();
         return NextResponse.json({data:equipamientos},{status:200})
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.log(error.message);
         return NextResponse.json({ error: error.message }, { status: 500 });        
     }
@@ -13,6 +21,7 @@ export async function GET(){
 
 export async function POST(req : Request){
     try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
 const body = await req.json();
 if (!body || !body.nombre || !body.tipo || !body.marca || !body.modelo || !body.ubicacion) {
     return NextResponse.json({ error: "El cuerpo de la solicitud no puede estar vacío" }, { status: 400 });
@@ -21,6 +30,8 @@ if (!body || !body.nombre || !body.tipo || !body.marca || !body.modelo || !body.
     const equipamiento = await createEquipamiento(body);
     return NextResponse.json({message:"Equipamiento creado",data: equipamiento}, {status:201});
 } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.log(error.message);
         return NextResponse.json({ error: error.message }, { status: 500 });        
 }

--- a/src/app/api/evolucion_socio/[socio_id]/route.ts
+++ b/src/app/api/evolucion_socio/[socio_id]/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import { findAllEvolucionesSocioByIdSocio } from "@/services/evolucionSocioService";
 import { NextResponse } from "next/server";
 
@@ -9,11 +12,11 @@ const getStatusFromError = (message?: string) => {
   if (!message) return 500;
   if (
     message.includes("Token") ||
-    message.includes("Unauthorized") ||
-    message.includes("No autorizado")
+    message.includes("Unauthorized")
   ) {
     return 401;
   }
+  if (message.includes("No autorizado")) return 403;
   if (message.includes("Debe") || message.includes("socio asociado")) {
     return 400;
   }
@@ -25,7 +28,12 @@ export async function GET(
   context: { params: { socio_id: string } }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/evolucion-fisica', '/dashboard/gestor-evolucion-fisica'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
     const requestedSocioId = context.params.socio_id;
     const socioId = requestedSocioId === "me" ? user.id_socio : requestedSocioId;
 
@@ -40,6 +48,8 @@ export async function GET(
 
     return NextResponse.json({ data: evolucionSocio }, { status: 200 });
   } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message =
       error instanceof Error ? error.message : "Error al obtener evolución";
 

--- a/src/app/api/evolucion_socio/admin/resumen/route.ts
+++ b/src/app/api/evolucion_socio/admin/resumen/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import { conexionBD } from "@/middlewares/conexionBd.middleware";
 import type { TipoCorporal, SexoReferencia } from "@/interfaces/evolucionSocio.interface";
 
@@ -32,11 +35,6 @@ interface EvolucionAccumulator {
   latest: EvolucionResumenRow | null;
 }
 
-const isAdminRole = (rol?: string | null) => {
-  const normalized = rol?.trim().toLowerCase();
-  return normalized === "admin" || normalized === "administrador";
-};
-
 const getStatusFromError = (message?: string) => {
   if (!message) return 500;
   if (message.includes("Token") || message.includes("Unauthorized")) return 401;
@@ -46,14 +44,11 @@ const getStatusFromError = (message?: string) => {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-
-    if (!isAdminRole(user.rol)) {
-      return NextResponse.json(
-        { error: "No autorizado para consultar el resumen administrativo de evolución física" },
-        { status: 403 }
-      );
-    }
+    await authorizeDashboardRequest(
+      req,
+      "/dashboard/gestor-evolucion-fisica",
+      ["admin", "usuario"],
+    );
 
     const supabase = conexionBD();
 
@@ -131,6 +126,8 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ data: rows }, { status: 200 });
   } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message =
       error instanceof Error
         ? error.message

--- a/src/app/api/evolucion_socio/rag-assistant/analizar/route.ts
+++ b/src/app/api/evolucion_socio/rag-assistant/analizar/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import type {
   RagEvolucionFisicaAssistantRequest,
   RagEvolucionFisicaIdioma,
@@ -40,11 +43,13 @@ function getStatusFromError(message: string) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/evolucion-fisica', '/dashboard/gestor-evolucion-fisica'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
-    if (!user) {
-      return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = (await req.json().catch(() => ({}))) as Partial<RagEvolucionFisicaAssistantRequest>;
     const payload = validatePayload(body);
@@ -65,6 +70,8 @@ export async function POST(req: Request) {
       { status: 200 },
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : translateAiGeneratedTechnicalText('Error inesperado', 'es');
 
     console.error('Error en RAG Coach evolución física:', error);

--- a/src/app/api/evolucion_socio/registro/route.ts
+++ b/src/app/api/evolucion_socio/registro/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import { createEvolucionSocio } from "@/services/evolucionSocioService";
 import { NextResponse } from "next/server";
 
@@ -9,11 +12,11 @@ const getStatusFromError = (message?: string) => {
   if (!message) return 500;
   if (
     message.includes("Token") ||
-    message.includes("Unauthorized") ||
-    message.includes("No autorizado")
+    message.includes("Unauthorized")
   ) {
     return 401;
   }
+  if (message.includes("No autorizado")) return 403;
   if (
     message.includes("obligatorio") ||
     message.includes("obligatoria") ||
@@ -27,7 +30,12 @@ const getStatusFromError = (message?: string) => {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/evolucion-fisica', '/dashboard/gestor-evolucion-fisica'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
     const body = await req.json();
 
     const evolucion = await createEvolucionSocio(
@@ -46,6 +54,8 @@ export async function POST(req: Request) {
       { status: 201 }
     );
   } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message =
       error instanceof Error ? error.message : "Error al registrar evolución";
 

--- a/src/app/api/file-upload/route.ts
+++ b/src/app/api/file-upload/route.ts
@@ -1,5 +1,6 @@
 import { FileUploadDTO } from '@/interfaces/fileUpload.interface';
 import { authMiddleware } from '@/middlewares/auth.middleware';
+import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
 import { uploadFile } from '@/services/fileUploadService';
 import { updateFotoUsuarioById } from '@/services/usuarioService';
 import { NextResponse } from 'next/server';
@@ -76,13 +77,11 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('error file:', error);
     const message = error?.message || 'Error al subir la imagen.';
-    const status =
-      message.includes('Token no proporcionado') || message.includes('Token inválido')
-        ? 401
-        : 500;
-
-    return NextResponse.json({ error: message }, { status });
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/file-upload/route.ts
+++ b/src/app/api/file-upload/route.ts
@@ -3,12 +3,15 @@ import { authMiddleware } from '@/middlewares/auth.middleware';
 import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
 import { uploadFile } from '@/services/fileUploadService';
 import { updateFotoUsuarioById } from '@/services/usuarioService';
+import {
+  hasSafeUploadSignature,
+  isSafeUploadMimeType,
+} from '@/lib/security/uploadValidation';
 import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
-const VALID_IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|svg\+xml|heic|heif)$/i;
 
 export async function POST(request: Request) {
   try {
@@ -35,7 +38,7 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!VALID_IMAGE_TYPES.test(file.type)) {
+    if (!isSafeUploadMimeType(file.type) || file.type === 'application/pdf') {
       return NextResponse.json(
         {
           error:
@@ -47,6 +50,13 @@ export async function POST(request: Request) {
 
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+
+    if (!hasSafeUploadSignature(buffer, file.type)) {
+      return NextResponse.json(
+        { error: 'El contenido del archivo no coincide con una imagen permitida.' },
+        { status: 400 }
+      );
+    }
 
     const fileDto: FileUploadDTO = {
       fieldName: file.name,

--- a/src/app/api/finanzas/dashboard-bi/route.ts
+++ b/src/app/api/finanzas/dashboard-bi/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 import type {
   FinanzasCategoriaResumen,
   FinanzasDashboardResponse,
   FinanzasSerieMensual,
 } from '@/interfaces/finanzas.interface';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -142,7 +146,7 @@ function isVencido(value: unknown) {
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/finanzas', ['admin', 'usuario']);
     const supabase = conexionBD();
     const { searchParams } = new URL(req.url);
 
@@ -328,6 +332,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener BI financiero' },
       { status: error.message?.includes('Token') ? 401 : 500 }

--- a/src/app/api/gimnasio-parametrizacion/logo-upload/route.ts
+++ b/src/app/api/gimnasio-parametrizacion/logo-upload/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { uploadFileCloudinaryWithResult } from '@/lib/cloudinary';
+import {
+  hasSafeUploadSignature,
+  isSafeUploadMimeType,
+} from '@/lib/security/uploadValidation';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
-const VALID_IMAGE_TYPES = /^image\/(png|jpe?g|webp|gif|svg\+xml)$/i;
 
 function normalizeRole(role?: string | null) {
   return role?.trim().toLowerCase() ?? '';
@@ -20,7 +27,7 @@ function getStatusFromError(error: unknown) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/gimnasio-parametrizacion', ['admin']);
     const role = normalizeRole(user.rol);
 
     if (role !== 'admin' && role !== 'administrador') {
@@ -44,15 +51,23 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!VALID_IMAGE_TYPES.test(file.type)) {
+    if (!isSafeUploadMimeType(file.type) || file.type === 'application/pdf') {
       return NextResponse.json(
-        { error: 'Formato no válido. Usá PNG, JPG, WEBP, GIF o SVG.' },
+        { error: 'Formato no válido. Usá PNG, JPG, WEBP, GIF, HEIC o HEIF.' },
         { status: 400 }
       );
     }
 
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+
+    if (!hasSafeUploadSignature(buffer, file.type)) {
+      return NextResponse.json(
+        { error: 'El contenido del archivo no coincide con una imagen permitida.' },
+        { status: 400 }
+      );
+    }
+
     const folder = 'gym-master/gimnasio/branding';
 
     const result = await uploadFileCloudinaryWithResult(buffer, file.name, folder);
@@ -71,6 +86,8 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getStatusFromError(error);
 
     if (status === 500) {

--- a/src/app/api/gimnasio-parametrizacion/route.ts
+++ b/src/app/api/gimnasio-parametrizacion/route.ts
@@ -1,18 +1,24 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   getGimnasioParametrizacion,
   updateGimnasioParametrizacion,
 } from '@/services/gimnasioParametrizacionServerService';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/gimnasio-parametrizacion', ['admin']);
     const data = await getGimnasioParametrizacion();
     return NextResponse.json({ data });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('Token') || message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -21,11 +27,13 @@ export async function GET(req: Request) {
 
 export async function PATCH(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/gimnasio-parametrizacion', ['admin']);
     const body = await req.json();
     const data = await updateGimnasioParametrizacion(body, user);
     return NextResponse.json({ data });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') || message.includes('Token') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/gimnasio-parametrizacion/stripe-status/route.ts
+++ b/src/app/api/gimnasio-parametrizacion/stripe-status/route.ts
@@ -1,15 +1,25 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getGimnasioStripeStatus } from '@/services/gimnasioParametrizacionServerService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(
+      req,
+      ['/dashboard/gimnasio-parametrizacion', '/dashboard/mi-cuenta/pagar-cuota'],
+      ['admin', 'socio'],
+    );
     const data = await getGimnasioStripeStatus();
     return NextResponse.json({ data }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('Token') || message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/image-proxy/route.ts
+++ b/src/app/api/image-proxy/route.ts
@@ -1,67 +1,201 @@
-import { NextResponse } from "next/server";
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import { NextResponse } from 'next/server';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
-const isAllowedImageUrl = (url: string): boolean => {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "https:" || parsed.protocol === "http:";
-  } catch {
-    return false;
+// AUTH POLICY: PUBLIC_CONTROLLED
+// The proxy is intentionally public because browser-generated PDFs load images
+// through <img>. Every destination and redirect is validated to prevent access
+// to loopback, private, link-local and reserved network ranges.
+const MAX_REDIRECTS = 3;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+function isBlockedIpv4(address: string) {
+  const parts = address.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return true;
   }
-};
+
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0) ||
+    (a === 192 && b === 168) ||
+    (a === 192 && b === 0 && parts[2] === 2) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && parts[2] === 100) ||
+    (a === 203 && b === 0 && parts[2] === 113) ||
+    a >= 224
+  );
+}
+
+function isBlockedIp(address: string) {
+  const normalized = address.toLowerCase().split('%')[0];
+  const mappedIpv4 = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)?.[1];
+
+  if (mappedIpv4) return isBlockedIpv4(mappedIpv4);
+  if (isIP(normalized) === 4) return isBlockedIpv4(normalized);
+  if (isIP(normalized) !== 6) return true;
+
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    /^fe[89ab]/.test(normalized) ||
+    normalized.startsWith('ff') ||
+    normalized.startsWith('2001:db8')
+  );
+}
+
+async function assertSafeImageUrl(value: string) {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error('URL de imagen inválida');
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('Protocolo de imagen no permitido');
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new Error('La URL de imagen no puede contener credenciales');
+  }
+
+  if (parsed.port && !['80', '443'].includes(parsed.port)) {
+    throw new Error('Puerto de imagen no permitido');
+  }
+
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, '');
+  if (
+    !hostname ||
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname.endsWith('.internal')
+  ) {
+    throw new Error('Host de imagen no permitido');
+  }
+
+  if (isIP(hostname)) {
+    if (isBlockedIp(hostname)) {
+      throw new Error('Red de imagen no permitida');
+    }
+    return parsed;
+  }
+
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  if (addresses.length === 0 || addresses.some(({ address }: { address: string }) => isBlockedIp(address))) {
+    throw new Error('El host de imagen resuelve a una red no permitida');
+  }
+
+  return parsed;
+}
+
+async function fetchSafeImage(initialUrl: string) {
+  let currentUrl = await assertSafeImageUrl(initialUrl);
+
+  for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect += 1) {
+    const response = await fetch(currentUrl, {
+      cache: 'force-cache',
+      redirect: 'manual',
+      headers: {
+        Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+        'User-Agent': 'GymMaster-PDF-Image-Proxy/1.0',
+      },
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location || redirect === MAX_REDIRECTS) {
+        throw new Error('Redirección de imagen inválida');
+      }
+
+      currentUrl = await assertSafeImageUrl(
+        new URL(location, currentUrl).toString(),
+      );
+      continue;
+    }
+
+    return response;
+  }
+
+  throw new Error('Demasiadas redirecciones de imagen');
+}
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const imageUrl = searchParams.get("url");
+  const imageUrl = new URL(request.url).searchParams.get('url');
 
-  if (!imageUrl || !isAllowedImageUrl(imageUrl)) {
+  if (!imageUrl) {
     return NextResponse.json(
-      { message: "URL de imagen inválida" },
-      { status: 400 }
+      { message: 'URL de imagen inválida' },
+      { status: 400 },
     );
   }
 
   try {
-    const response = await fetch(imageUrl, {
-      cache: "force-cache",
-      headers: {
-        Accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
-        "User-Agent": "GymMaster-PDF-Image-Proxy/1.0",
-      },
-    });
+    const response = await fetchSafeImage(imageUrl);
 
     if (!response.ok) {
       return NextResponse.json(
-        { message: "No se pudo obtener la imagen" },
-        { status: response.status }
+        { message: 'No se pudo obtener la imagen' },
+        { status: response.status },
       );
     }
 
-    const contentType = response.headers.get("content-type") || "image/png";
-
-    if (!contentType.startsWith("image/")) {
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.toLowerCase().startsWith('image/')) {
       return NextResponse.json(
-        { message: "El recurso no es una imagen" },
-        { status: 415 }
+        { message: 'El recurso no es una imagen' },
+        { status: 415 },
+      );
+    }
+
+    const declaredLength = Number(response.headers.get('content-length') || 0);
+    if (declaredLength > MAX_IMAGE_BYTES) {
+      return NextResponse.json(
+        { message: 'La imagen supera el tamaño permitido' },
+        { status: 413 },
       );
     }
 
     const imageBuffer = await response.arrayBuffer();
+    if (imageBuffer.byteLength > MAX_IMAGE_BYTES) {
+      return NextResponse.json(
+        { message: 'La imagen supera el tamaño permitido' },
+        { status: 413 },
+      );
+    }
 
     return new NextResponse(imageBuffer, {
       status: 200,
       headers: {
-        "Content-Type": contentType,
-        "Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
-        "Access-Control-Allow-Origin": "*",
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+        'Access-Control-Allow-Origin': '*',
+        'X-Content-Type-Options': 'nosniff',
       },
     });
   } catch (error) {
-    console.error("Error en image-proxy:", error);
+    const message =
+      error instanceof Error ? error.message : 'Error al obtener la imagen';
+    const isPolicyError = /no permitid|inválid|credenciales|redirecci/i.test(
+      message,
+    );
+
+    console.error('Error en image-proxy:', message);
     return NextResponse.json(
-      { message: "Error al obtener la imagen" },
-      { status: 500 }
+      { message: isPolicyError ? message : 'Error al obtener la imagen' },
+      { status: isPolicyError ? 400 : 502 },
     );
   }
 }

--- a/src/app/api/infraestructura/activos/route.ts
+++ b/src/app/api/infraestructura/activos/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createInfraestructuraActivo } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/mantenimiento-edilicio', ['admin', 'usuario']);
     const body = await req.json();
     const activo = await createInfraestructuraActivo(body);
     return NextResponse.json({ message: 'Activo edilicio creado con éxito', data: activo }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message || 'Error al crear activo edilicio.' },
       { status: error?.message?.includes('obligatorio') ? 400 : 500 },

--- a/src/app/api/infraestructura/checklists/ejecuciones/route.ts
+++ b/src/app/api/infraestructura/checklists/ejecuciones/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createInfraestructuraChecklistEjecucion } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/mantenimiento-edilicio', ['admin', 'usuario']);
     const body = await req.json();
     const ejecucion = await createInfraestructuraChecklistEjecucion(body);
     return NextResponse.json({ message: 'Checklist edilicio ejecutado con éxito', data: ejecucion }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al ejecutar checklist edilicio.';
     const status = message.includes('Seleccioná') || message.includes('asociada') || message.includes('No se encontró') ? 400 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/infraestructura/mantenimiento-edilicio/route.ts
+++ b/src/app/api/infraestructura/mantenimiento-edilicio/route.ts
@@ -1,13 +1,21 @@
 import { NextResponse } from 'next/server';
 import { getInfraestructuraMantenimientoDashboard } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/mantenimiento-edilicio', ['admin', 'usuario']);
     const dashboard = await getInfraestructuraMantenimientoDashboard();
     return NextResponse.json(dashboard, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al consultar mantenimiento edilicio:', error?.message ?? error);
     return NextResponse.json(
       { error: error?.message || 'Error al consultar mantenimiento edilicio.' },

--- a/src/app/api/infraestructura/ordenes/[id]/route.ts
+++ b/src/app/api/infraestructura/ordenes/[id]/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from 'next/server';
 import { updateMantenimientoEdilicioOrden } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function PATCH(
@@ -8,6 +13,7 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/mantenimiento-edilicio', ['admin', 'usuario']);
     const { id } = await params;
     if (!id) {
       return NextResponse.json({ error: 'ID de orden requerido.' }, { status: 400 });
@@ -17,6 +23,8 @@ export async function PATCH(
     const orden = await updateMantenimientoEdilicioOrden(id, body);
     return NextResponse.json({ message: 'Orden de mantenimiento edilicio actualizada con éxito', data: orden }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message || 'Error al actualizar orden de mantenimiento edilicio.' },
       { status: 500 },

--- a/src/app/api/infraestructura/ordenes/route.ts
+++ b/src/app/api/infraestructura/ordenes/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createMantenimientoEdilicioOrden } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/mantenimiento-edilicio', ['admin', 'usuario']);
     const body = await req.json();
     const orden = await createMantenimientoEdilicioOrden(body);
     return NextResponse.json({ message: 'Orden de mantenimiento edilicio creada con éxito', data: orden }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al crear orden de mantenimiento edilicio.';
     const status = message.includes('obligatorio') || message.includes('asociada') ? 400 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/infraestructura/qr/labels/route.ts
+++ b/src/app/api/infraestructura/qr/labels/route.ts
@@ -1,13 +1,21 @@
 import { NextResponse } from 'next/server';
 import { getInfraestructuraQrLabelsDashboard } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/etiquetas-qr', ['admin', 'usuario']);
     const dashboard = await getInfraestructuraQrLabelsDashboard();
     return NextResponse.json(dashboard, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al consultar etiquetas QR:', error?.message ?? error);
     return NextResponse.json(
       { error: error?.message || 'Error al consultar etiquetas QR.' },

--- a/src/app/api/infraestructura/qr/resolve/route.ts
+++ b/src/app/api/infraestructura/qr/resolve/route.ts
@@ -1,15 +1,23 @@
 import { NextResponse } from 'next/server';
 import { resolveInfraestructuraQrCode } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, ['/dashboard/infraestructura/lector-qr-barra', '/dashboard/infraestructura/etiquetas-qr'], ['admin', 'usuario']);
     const { searchParams } = new URL(req.url);
     const codigo = searchParams.get('codigo') || '';
     const result = await resolveInfraestructuraQrCode(codigo);
     return NextResponse.json({ data: result }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message || 'Error al resolver código QR/barra.' },
       { status: error?.message?.includes('Ingresá') ? 400 : 500 },

--- a/src/app/api/infraestructura/qr/route.ts
+++ b/src/app/api/infraestructura/qr/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createInfraestructuraQrCode } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, ['/dashboard/infraestructura/etiquetas-qr', '/dashboard/infraestructura/lector-qr-barra'], ['admin', 'usuario']);
     const body = await req.json();
     const qr = await createInfraestructuraQrCode(body);
     return NextResponse.json({ message: 'Código QR/barra generado con éxito', data: qr }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al generar código QR/barra.';
     const status = message.includes('obligatorio') || message.includes('No se encontró') || message.includes('no soportado') ? 400 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/infraestructura/sectores/route.ts
+++ b/src/app/api/infraestructura/sectores/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from 'next/server';
 import { createInfraestructuraSector } from '@/services/server/infraestructuraMantenimientoService';
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/infraestructura/mantenimiento-edilicio', ['admin', 'usuario']);
     const body = await req.json();
     const sector = await createInfraestructuraSector(body);
     return NextResponse.json({ message: 'Sector edilicio creado con éxito', data: sector }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error?.message || 'Error al crear sector edilicio.' },
       { status: error?.message?.includes('obligatorio') ? 400 : 500 },

--- a/src/app/api/internal/dragon-pyramid/license-sync/route.ts
+++ b/src/app/api/internal/dragon-pyramid/license-sync/route.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import {
   reactivateDragonPyramidLicenseAfterPayment,
@@ -6,8 +7,22 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: INTERNAL_SHARED_SECRET
+// This endpoint is used only by Dragon Pyramid's billing platform and requires
+// a dedicated server-to-server secret. It never accepts a browser JWT.
+
 function getSyncSecret() {
   return process.env.DRAGON_PYRAMID_LICENSE_SYNC_SECRET?.trim() || '';
+}
+
+function secretsMatch(provided: string, expected: string) {
+  const providedBuffer = Buffer.from(provided, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+
+  return (
+    providedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(providedBuffer, expectedBuffer)
+  );
 }
 
 function resolveStatus(message: string) {
@@ -25,7 +40,7 @@ export async function POST(req: Request) {
     }
 
     const providedSecret = req.headers.get('x-dragon-pyramid-sync-key')?.trim() || '';
-    if (!providedSecret || providedSecret !== expectedSecret) {
+    if (!providedSecret || !secretsMatch(providedSecret, expectedSecret)) {
       throw new Error('Sincronización no autorizada');
     }
 

--- a/src/app/api/mantenimientos/[id]/route.ts
+++ b/src/app/api/mantenimientos/[id]/route.ts
@@ -2,6 +2,11 @@ import { getMantenimientoByIdEquipamiento } from '@/services/mantenimientoServic
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -9,6 +14,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
     const { id } = await params;
     if (!id || id === '') {
       return NextResponse.json(
@@ -23,6 +29,8 @@ export async function GET(
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error.message);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/mantenimientos/completado/[id]/route.ts
+++ b/src/app/api/mantenimientos/completado/[id]/route.ts
@@ -2,6 +2,11 @@ import { mantenimientoCompletado } from '@/services/mantenimientoService';
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function PUT(
@@ -9,6 +14,7 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
     const { id } = await params;
     if (!id || typeof id !== 'string') {
       return NextResponse.json(
@@ -26,6 +32,8 @@ export async function PUT(
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error.message);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }

--- a/src/app/api/mantenimientos/route.ts
+++ b/src/app/api/mantenimientos/route.ts
@@ -2,10 +2,16 @@ import { createMantenimiento, getAllMantenimientos, updateMantenimiento } from "
 import { NextRequest, NextResponse } from "next/server";
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest){
 try{
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
     const body = await req.json();
 if(!body || !body.id_equipamiento || !body.tipo_mantenimiento || !body.descripcion  || !body.tecnico_responsable || !body.costo){
     return NextResponse.json({ error: "El cuerpo de la solicitud no puede estar vacío" }, { status: 400 });
@@ -16,24 +22,30 @@ const mantenimiento = await createMantenimiento(body);
 return NextResponse.json({message:"Mantenimiento creado",data: mantenimiento}, {status:201});
 
 }catch(error:any){
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error.message);
     return NextResponse.json({ error: error.message }, { status: 500 });
 }
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
         const mantenimientos = await getAllMantenimientos();
         return NextResponse.json({data:mantenimientos},{status:200})
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.log(error.message);
         return NextResponse.json({ error: error.message }, { status: 500 });        
     }
 }
 
 export async function PUT(req: NextRequest) {
-    const { id, updateData } = await req.json();
     try {
+    await authorizeDashboardRequest(req, '/dashboard/equipamientos', ['admin', 'usuario']);
+        const { id, updateData } = await req.json();
         if (!id || typeof id !== 'string') {
             return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 })
         }
@@ -43,6 +55,8 @@ export async function PUT(req: NextRequest) {
             data: mantenimiento
         }, { status: 200 });
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
        console.log(error.message);
         return NextResponse.json({ error: "error al modificar el mantenimiento"}, { status: 500 })
     }

--- a/src/app/api/mi-cuenta/pagos/route.ts
+++ b/src/app/api/mi-cuenta/pagos/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  requireRoles,
+} from '@/lib/auth/serverAuthorization';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 import { getSocioByIdUsuario } from '@/services/socioService';
 
@@ -34,12 +38,7 @@ export async function GET(req: Request) {
   try {
     const { user } = await authMiddleware(req);
 
-    if (user.rol !== 'socio') {
-      return NextResponse.json(
-        { error: 'Este endpoint corresponde al historial del socio autenticado' },
-        { status: 403 }
-      );
-    }
+    requireRoles(user, ['socio']);
 
     let socioId = user.id_socio;
     let socioFallback: { id_socio: string; nombre_completo: string; email?: string | null } | null = null;
@@ -109,6 +108,9 @@ export async function GET(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('ERROR al obtener historial de pagos del socio:', error);
     return NextResponse.json(
       { error: error.message || 'Error al obtener historial de pagos' },

--- a/src/app/api/niveles/route.ts
+++ b/src/app/api/niveles/route.ts
@@ -1,13 +1,17 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getAllNiveles } from "@/services/nivelesService";
 import { NextResponse } from "next/server";
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, ['/dashboard/gestor-rutinas', '/dashboard/rutinas/asistente', '/dashboard/rutinas/media', '/dashboard/gestor-dietas', '/dashboard/dietas'], ['admin', 'usuario', 'socio']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -17,6 +21,8 @@ export async function GET(req: Request) {
         return NextResponse.json(niveles, { status: 200 });
 
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error al traer los niveles", error);
         return NextResponse.json({ error: "Error al traer los niveles" }, { status: 500 });
     }

--- a/src/app/api/notificaciones/[id]/enviar/route.ts
+++ b/src/app/api/notificaciones/[id]/enviar/route.ts
@@ -1,17 +1,16 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { enviarNotificacion } from '@/services/notificacionService';
 import { NextResponse } from 'next/server';
+import { enviarNotificacion } from '@/services/notificacionService';
+import { authorizationErrorResponse, authorizeDashboardRequest } from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const notificacion = await enviarNotificacion(params.id, user);
-    return NextResponse.json(notificacion);
-  } catch (error) {
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    return NextResponse.json(await enviarNotificacion(params.id, user));
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/notificaciones/[id]/route.ts
+++ b/src/app/api/notificaciones/[id]/route.ts
@@ -1,21 +1,16 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import {
-  cancelarNotificacion,
-  getNotificacionById,
-  updateNotificacion,
-} from '@/services/notificacionService';
 import { NextResponse } from 'next/server';
+import { cancelarNotificacion, getNotificacionById, updateNotificacion } from '@/services/notificacionService';
+import { authorizationErrorResponse, authorizeDashboardRequest } from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const notificacion = await getNotificacionById(params.id, user);
-    return NextResponse.json(notificacion);
-  } catch (error) {
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    return NextResponse.json(await getNotificacionById(params.id, user));
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -23,13 +18,11 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const body = await req.json();
-    const notificacion = await updateNotificacion(params.id, body, user);
-    return NextResponse.json(notificacion);
-  } catch (error) {
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    return NextResponse.json(await updateNotificacion(params.id, await req.json(), user));
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -37,12 +30,11 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
 
 export async function DELETE(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const notificacion = await cancelarNotificacion(params.id, user);
-    return NextResponse.json(notificacion);
-  } catch (error) {
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    return NextResponse.json(await cancelarNotificacion(params.id, user));
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/notificaciones/header/route.ts
+++ b/src/app/api/notificaciones/header/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authMiddleware } from '@/middlewares/auth.middleware';
+import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
 import { getHeaderNotificationsServer } from '@/services/server/headerNotificationsServerService';
 
 export const dynamic = 'force-dynamic';
@@ -7,13 +8,11 @@ export const dynamic = 'force-dynamic';
 export async function GET(req: Request) {
   try {
     const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'No se pudo obtener el usuario' }, { status: 401 });
-    }
-
     const data = await getHeaderNotificationsServer(user);
     return NextResponse.json({ data }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al obtener notificaciones del header:', error);
     return NextResponse.json(
       { error: error.message || 'Error al obtener notificaciones del header' },

--- a/src/app/api/notificaciones/plantillas/route.ts
+++ b/src/app/api/notificaciones/plantillas/route.ts
@@ -1,17 +1,16 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { getNotificacionPlantillas } from '@/services/notificacionService';
 import { NextResponse } from 'next/server';
+import { getNotificacionPlantillas } from '@/services/notificacionService';
+import { authorizationErrorResponse, authorizeDashboardRequest } from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const plantillas = await getNotificacionPlantillas(user);
-    return NextResponse.json(plantillas);
-  } catch (error) {
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    return NextResponse.json(await getNotificacionPlantillas(user));
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/notificaciones/route.ts
+++ b/src/app/api/notificaciones/route.ts
@@ -1,17 +1,16 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { createNotificacion, getNotificaciones } from '@/services/notificacionService';
 import { NextResponse } from 'next/server';
+import { createNotificacion, getNotificaciones } from '@/services/notificacionService';
+import { authorizationErrorResponse, authorizeDashboardRequest } from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const notificaciones = await getNotificaciones(user);
-    return NextResponse.json(notificaciones);
-  } catch (error) {
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    return NextResponse.json(await getNotificaciones(user));
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -19,13 +18,12 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const body = await req.json();
-    const notificacion = await createNotificacion(body, user);
+    const user = await authorizeDashboardRequest(req, '/dashboard/notificaciones', ['admin', 'usuario']);
+    const notificacion = await createNotificacion(await req.json(), user);
     return NextResponse.json(notificacion, { status: 201 });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/notificaciones/terminal/route.ts
+++ b/src/app/api/notificaciones/terminal/route.ts
@@ -1,6 +1,13 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  AuthMiddlewareError,
+  authMiddleware,
+} from '@/middlewares/auth.middleware';
 import { getNotificacionesTerminalActivas } from '@/services/notificacionService';
 import { NextResponse } from 'next/server';
+import {
+  AuthorizationError,
+  requireDashboardPermission,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,18 +23,19 @@ function isAuthSessionError(error: unknown) {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Unauthorized', error_code: 'TERMINAL_SESSION_UNAUTHORIZED' },
-        { status: 401 }
-      );
-    }
-
+    const { user } = await authMiddleware(req, { allowTerminalSession: true });
+    requireDashboardPermission(user, '/dashboard/asistencias/terminal');
     const notificaciones = await getNotificacionesTerminalActivas(user);
     return NextResponse.json(notificaciones);
   } catch (error) {
-    if (isAuthSessionError(error)) {
+    if (error instanceof AuthorizationError) {
+      return NextResponse.json(
+        { error: error.message, error_code: error.code },
+        { status: error.status },
+      );
+    }
+
+    if (error instanceof AuthMiddlewareError || isAuthSessionError(error)) {
       return NextResponse.json(
         {
           error: 'La sesión de Terminal expiró. Iniciá sesión nuevamente o renová la sesión.',

--- a/src/app/api/objetivos/route.ts
+++ b/src/app/api/objetivos/route.ts
@@ -1,13 +1,17 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getAllObjetivos } from "@/services/objetivoService";
 import { NextResponse } from "next/server";
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizeDashboardRequest(req, ['/dashboard/gestor-rutinas', '/dashboard/rutinas/asistente', '/dashboard/rutinas/media', '/dashboard/gestor-dietas', '/dashboard/dietas'], ['admin', 'usuario', 'socio']);
 
         if (!user) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -17,6 +21,8 @@ export async function GET(req: Request) {
         return NextResponse.json(objetivos, { status: 200 });
 
     } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         console.error("Error al traer los objetivos", error);
         return NextResponse.json({ error: "Error al traer los objetivos" }, { status: 500 });
     }

--- a/src/app/api/otros_gastos/comprobante-upload/route.ts
+++ b/src/app/api/otros_gastos/comprobante-upload/route.ts
@@ -1,15 +1,22 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { uploadFileCloudinary } from '@/lib/cloudinary';
+import {
+  hasSafeUploadSignature,
+  isSafeUploadMimeType,
+} from '@/lib/security/uploadValidation';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const VALID_TYPES = /^(application\/pdf|image\/(png|jpe?g|webp|gif|heic|heif))$/i;
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/otros-gastos', ['admin', 'usuario']);
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
 
@@ -27,7 +34,7 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!VALID_TYPES.test(file.type)) {
+    if (!isSafeUploadMimeType(file.type)) {
       return NextResponse.json(
         { error: 'Formato no válido. Usá PDF, PNG, JPG, WEBP, GIF, HEIC o HEIF.' },
         { status: 400 }
@@ -36,7 +43,15 @@ export async function POST(request: Request) {
 
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
-    const folder = `gastos/comprobantes/${user?.id ?? 'admin'}`;
+
+    if (!hasSafeUploadSignature(buffer, file.type)) {
+      return NextResponse.json(
+        { error: 'El contenido del archivo no coincide con el formato declarado.' },
+        { status: 400 }
+      );
+    }
+
+    const folder = `gastos/comprobantes/${user.id}`;
     const url = await uploadFileCloudinary(buffer, file.name, folder);
 
     if (!url) {
@@ -58,6 +73,8 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message || 'Error al subir comprobante.';
     const status =
       message.includes('Token no proporcionado') || message.includes('Token inválido')

--- a/src/app/api/otros_gastos/route.ts
+++ b/src/app/api/otros_gastos/route.ts
@@ -1,10 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 import {
   OtrosGastosEstado,
   OtrosGastosMedioPago,
 } from '@/interfaces/otros_gastos.interface';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -154,7 +158,7 @@ async function fetchGastoById(supabase: ReturnType<typeof conexionBD>, id: strin
 
 export async function GET(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/otros-gastos', ['admin', 'usuario']);
     const supabase = conexionBD();
     const { searchParams } = new URL(req.url);
     const estado = searchParams.get('estado');
@@ -184,6 +188,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data: data ?? [] }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener los gastos' },
       { status: 500 }
@@ -193,7 +199,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/otros-gastos', ['admin', 'usuario']);
     const supabase = conexionBD();
     const body = await req.json();
     const payload = buildPayload(body, 'create');
@@ -214,6 +220,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ message: 'Gasto creado con éxito', data }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al crear el gasto' },
       { status: 500 }
@@ -223,7 +231,7 @@ export async function POST(req: NextRequest) {
 
 export async function PUT(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/otros-gastos', ['admin', 'usuario']);
     const supabase = conexionBD();
     const { id, updateData } = await req.json();
 
@@ -247,6 +255,8 @@ export async function PUT(req: NextRequest) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al actualizar gasto' },
       { status: 500 }
@@ -256,7 +266,7 @@ export async function PUT(req: NextRequest) {
 
 export async function DELETE(req: NextRequest) {
   try {
-    await authMiddleware(req);
+    await authorizeDashboardRequest(req, '/dashboard/otros-gastos', ['admin', 'usuario']);
     const supabase = conexionBD();
     const { id } = await req.json();
 
@@ -277,6 +287,8 @@ export async function DELETE(req: NextRequest) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al eliminar gasto' },
       { status: 500 }

--- a/src/app/api/pagar-cuota/confirmar/route.ts
+++ b/src/app/api/pagar-cuota/confirmar/route.ts
@@ -1,13 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { stripe } from '@/lib/stripe';
 import { registerStripeCheckoutPago } from '@/services/server/stripePagoRegistrationService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(
+      req,
+      '/dashboard/mi-cuenta/pagar-cuota',
+      ['socio']
+    );
 
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -35,18 +43,18 @@ export async function POST(req: NextRequest) {
     });
 
     const metadata = session.metadata ?? {};
-    const metadataUsuarioId = metadata.usuario_id;
+    const metadataUsuarioId = metadata.usuario_id?.trim();
+    const metadataSocioId = metadata.socio_id?.trim();
 
-    if (user.rol === 'socio' && metadataUsuarioId && metadataUsuarioId !== user.id) {
+    if (
+      !metadataUsuarioId ||
+      !metadataSocioId ||
+      !user.id_socio ||
+      metadataUsuarioId !== user.id ||
+      metadataSocioId !== user.id_socio
+    ) {
       return NextResponse.json(
         { error: 'La sesión de Stripe no corresponde al socio autenticado' },
-        { status: 403 }
-      );
-    }
-
-    if (!['socio', 'admin', 'usuario'].includes(user.rol)) {
-      return NextResponse.json(
-        { error: 'Rol no autorizado para confirmar pagos Stripe' },
         { status: 403 }
       );
     }
@@ -67,6 +75,8 @@ export async function POST(req: NextRequest) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al confirmar pago Stripe:', error);
     return NextResponse.json(
       { error: error.message || 'Error al confirmar pago Stripe' },

--- a/src/app/api/pagar-cuota/route.ts
+++ b/src/app/api/pagar-cuota/route.ts
@@ -1,13 +1,17 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { NextRequest, NextResponse } from 'next/server';
 import { createSessionPago, previewSessionPago } from '@/services/stripeService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 
 export async function GET(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/mi-cuenta/pagar-cuota', ['socio']);
 
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -28,6 +32,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data: preview }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al obtener vista previa de pago:', error);
     const message = error.message || 'Error al obtener vista previa de pago';
     const status = message.includes('pagos online') || message.includes('no están habilitados') ? 403 : 500;
@@ -40,7 +46,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/mi-cuenta/pagar-cuota', ['socio']);
 
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -67,6 +73,8 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ url: session.url }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al crear la sesión de pago:', error);
     const message = error.message || 'Error al crear la sesión de pago';
     const status = message.includes('pagos online') || message.includes('no están habilitados') ? 403 : 500;

--- a/src/app/api/pagos/[id]/route.ts
+++ b/src/app/api/pagos/[id]/route.ts
@@ -1,18 +1,26 @@
-import { getPagoById } from '@/services/pagoService';
 import { NextRequest, NextResponse } from 'next/server';
-
+import { getPagoById } from '@/services/pagoService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/pagos', ['admin', 'usuario']);
     const { id } = await params;
     const pago = await getPagoById(id);
     return NextResponse.json({ data: pago }, { status: 200 });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener el pago';
+    const status = message.includes('No se encontró') ? 404 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/pagos/[id]/verificar/route.ts
+++ b/src/app/api/pagos/[id]/verificar/route.ts
@@ -68,7 +68,7 @@ export async function GET(
         metodo_pago,
         estado,
         activo,
-        socio:socio_id(id_socio,nombre_completo,email),
+        socio:socio_id(id_socio,nombre_completo),
         cuota:cuota_id(id,descripcion,monto,periodo)
       `
       )

--- a/src/app/api/pagos/[id]/verificar/route.ts
+++ b/src/app/api/pagos/[id]/verificar/route.ts
@@ -8,6 +8,8 @@ import {
 
 export const dynamic = "force-dynamic";
 
+// AUTH POLICY: PUBLIC_VERIFICATION_CODE
+
 export async function GET(
   req: Request,
   { params }: { params: Promise<{ id: string }> }

--- a/src/app/api/pagos/route.ts
+++ b/src/app/api/pagos/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   createPagoManualServer,
   deactivatePagoServer,
@@ -7,93 +6,77 @@ import {
   fetchPagosServer,
   updatePagoServer,
 } from '@/services/server/pagoServerService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
+const PAGOS_PATH = '/dashboard/pagos';
+const MANAGER_ROLES = ['admin', 'usuario'] as const;
+
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, PAGOS_PATH, [...MANAGER_ROLES]);
     const url = new URL(req.url);
-
     if (url.searchParams.get('options') === 'true') {
       const options = await fetchPagoFormOptionsServer(user);
       return NextResponse.json({ data: options }, { status: 200 });
     }
-
     const pagos = await fetchPagosServer(user);
     return NextResponse.json({ data: pagos }, { status: 200 });
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message || 'Error al obtener pagos' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener pagos';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    const body = await req.json();
-    const pago = await createPagoManualServer(user, body);
-
-    return NextResponse.json(
-      { message: 'Pago registrado con éxito', data: pago },
-      { status: 201 }
-    );
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message || 'Error al registrar el pago' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+    const user = await authorizeDashboardRequest(req, PAGOS_PATH, [...MANAGER_ROLES]);
+    const pago = await createPagoManualServer(user, await req.json());
+    return NextResponse.json({ message: 'Pago registrado con éxito', data: pago }, { status: 201 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al registrar el pago';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function PUT(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, PAGOS_PATH, [...MANAGER_ROLES]);
     const { id, updateData } = await req.json();
-
     if (!id || typeof id !== 'string') {
-      return NextResponse.json(
-        { error: 'ID inválido para actualizar' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 });
     }
-
     const pago = await updatePagoServer(user, id, updateData);
-    return NextResponse.json(
-      { message: 'Pago actualizado con éxito', data: pago },
-      { status: 200 }
-    );
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message || 'Error al actualizar pago' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+    return NextResponse.json({ message: 'Pago actualizado con éxito', data: pago }, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al actualizar pago';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function DELETE(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, PAGOS_PATH, [...MANAGER_ROLES]);
     const { id } = await req.json();
-
     if (!id || typeof id !== 'string') {
-      return NextResponse.json(
-        { error: 'ID inválido para eliminar' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'ID inválido para eliminar' }, { status: 400 });
     }
-
     const pago = await deactivatePagoServer(user, id);
-    return NextResponse.json(
-      { message: 'Pago eliminado con éxito', data: pago },
-      { status: 200 }
-    );
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message || 'Error al eliminar pago' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+    return NextResponse.json({ message: 'Pago eliminado con éxito', data: pago }, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al eliminar pago';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/parametrizacion/catalogos/route.ts
+++ b/src/app/api/parametrizacion/catalogos/route.ts
@@ -6,6 +6,11 @@ import {
   CatalogoParametrizableStatus,
 } from "@/interfaces/parametrizacion.interface";
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = "force-dynamic";
 
 type CatalogDefinition = {
@@ -301,8 +306,9 @@ function buildCatalogPayload(
   return payload;
 }
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/parametrizacion', ['admin']);
     const supabase = getSupabaseServerClient();
 
     const catalogos = await Promise.all(
@@ -336,6 +342,8 @@ export async function GET() {
       catalogos,
     });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al obtener catálogos de parametrización:", error);
 
     return NextResponse.json(
@@ -347,6 +355,7 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    await authorizeDashboardRequest(request, '/dashboard/parametrizacion', ['admin']);
     const body = (await request.json()) as Record<string, unknown>;
     const definition = getCatalogDefinition(body.catalogo);
 
@@ -376,6 +385,8 @@ export async function POST(request: NextRequest) {
       { status: 201 }
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al crear catálogo de parametrización:", error);
 
     return NextResponse.json(
@@ -387,6 +398,7 @@ export async function POST(request: NextRequest) {
 
 export async function PATCH(request: NextRequest) {
   try {
+    await authorizeDashboardRequest(request, '/dashboard/parametrizacion', ['admin']);
     const body = (await request.json()) as Record<string, unknown>;
     const definition = getCatalogDefinition(body.catalogo);
     const id = parseString(body.id);
@@ -419,6 +431,8 @@ export async function PATCH(request: NextRequest) {
       message: "Registro actualizado correctamente",
     });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al actualizar catálogo de parametrización:", error);
 
     return NextResponse.json(

--- a/src/app/api/parametrizacion/cuotas-descuento/route.ts
+++ b/src/app/api/parametrizacion/cuotas-descuento/route.ts
@@ -1,10 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
 import {
   fetchCuotaDescuentoConfig,
   upsertCuotaDescuentoConfig,
 } from "@/services/cuotaDescuentoService";
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = "force-dynamic";
 
@@ -38,7 +42,7 @@ function toNullableString(value: unknown): string | null {
 
 export async function GET(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/parametrizacion', ['admin']);
     assertAdminRole(user?.rol);
 
     const supabase = getSupabaseServerClient();
@@ -46,6 +50,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data: config }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || "Error al obtener descuento por pago adelantado" },
       { status: error.message?.includes("No autorizado") ? 403 : 500 }
@@ -55,7 +61,7 @@ export async function GET(req: NextRequest) {
 
 export async function PATCH(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/parametrizacion', ['admin']);
     assertAdminRole(user?.rol);
 
     const body = await req.json();
@@ -76,6 +82,8 @@ export async function PATCH(req: NextRequest) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || "Error al actualizar descuento por pago adelantado" },
       { status: error.message?.includes("No autorizado") ? 403 : 500 }

--- a/src/app/api/productos/[id]/route.ts
+++ b/src/app/api/productos/[id]/route.ts
@@ -2,6 +2,11 @@ import { getProductoById } from '@/services/productoService';
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -9,10 +14,24 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(
+      req,
+      [
+        '/dashboard/productos',
+        '/dashboard/comercial',
+        '/dashboard/comercial/kiosco',
+        '/dashboard/compras',
+        '/dashboard/comercial/compras-reposicion',
+        '/dashboard/ventas',
+      ],
+      ['admin', 'usuario'],
+    );
     const { id } = await params;
     const producto = await getProductoById(id);
     return NextResponse.json({ data: producto }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message });
   }
 }

--- a/src/app/api/productos/historial-precios-costos/route.ts
+++ b/src/app/api/productos/historial-precios-costos/route.ts
@@ -1,10 +1,16 @@
 import { getProductoHistorialPreciosCostos } from "@/services/productoService";
 import { NextResponse } from "next/server";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/productos', ['admin', 'usuario']);
     const { searchParams } = new URL(req.url);
     const productoId = searchParams.get("producto_id");
 
@@ -18,6 +24,8 @@ export async function GET(req: Request) {
     const historial = await getProductoHistorialPreciosCostos(productoId);
     return NextResponse.json({ data: historial }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || "Error al obtener historial de precios/costos" },
       { status: 500 }

--- a/src/app/api/productos/route.ts
+++ b/src/app/api/productos/route.ts
@@ -1,19 +1,39 @@
 import { createProducto, deleteProducto, getAllProductos, updateProducto } from "@/services/productoService";
 import { NextResponse } from "next/server";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(
+      req,
+      [
+        '/dashboard/productos',
+        '/dashboard/comercial',
+        '/dashboard/comercial/kiosco',
+        '/dashboard/compras',
+        '/dashboard/comercial/compras-reposicion',
+        '/dashboard/ventas',
+      ],
+      ['admin', 'usuario'],
+    );
     const productos = await getAllProductos();
     return NextResponse.json({ data: productos }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: "Error al obtener los productos" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/productos', ['admin', 'usuario']);
     const body = await req.json();
     if (!body.nombre || body.precio === undefined || body.stock === undefined || !body.proveedor_id) {
       return NextResponse.json({ error: "Todos los campos son obligatorios" }, { status: 400 });
@@ -21,32 +41,40 @@ export async function POST(req: Request) {
     const producto = await createProducto(body);
     return NextResponse.json({ message: "Producto creado con éxito", data: producto }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al crear el producto" }, { status: 500 });
   }
 }
 
 export async function PUT(req: Request) {
-  const { id, updateData } = await req.json();
   try {
+    await authorizeDashboardRequest(req, '/dashboard/productos', ['admin', 'usuario']);
+    const { id, updateData } = await req.json();
     if (!id || typeof id !== "string") {
       return NextResponse.json({ error: "ID inválido para actualizar" }, { status: 400 });
     }
     const productoModificado = await updateProducto(id, updateData);
     return NextResponse.json({ message: "Producto actualizado con éxito", data: productoModificado }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al actualizar producto" }, { status: 500 });
   }
 }
 
 export async function DELETE(req: Request) {
-  const { id } = await req.json();
   try {
+    await authorizeDashboardRequest(req, '/dashboard/productos', ['admin', 'usuario']);
+    const { id } = await req.json();
     if (!id || typeof id !== "string") {
       return NextResponse.json({ error: "ID inválido para eliminar" }, { status: 400 });
     }
     await deleteProducto(id);
     return NextResponse.json({ message: "Producto eliminado con éxito" }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al eliminar producto" }, { status: 500 });
   }
 }

--- a/src/app/api/productos/stock-movimientos/route.ts
+++ b/src/app/api/productos/stock-movimientos/route.ts
@@ -1,6 +1,10 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -59,10 +63,11 @@ function buildMotivo(operacion: OperacionStock, motivo: string): string {
 
 export async function GET(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'No se pudo obtener el usuario' }, { status: 401 });
-    }
+    const user = await authorizeDashboardRequest(
+      req,
+      ['/dashboard/comercial/stock-ledger', '/dashboard/productos'],
+      ['admin', 'usuario'],
+    );
 
     const supabase = conexionBD();
     const { searchParams } = new URL(req.url);
@@ -89,6 +94,9 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ data: data ?? [] }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     return NextResponse.json(
       { error: error.message || 'Error al obtener movimientos de stock' },
       { status: 500 }
@@ -98,10 +106,11 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'No se pudo obtener el usuario' }, { status: 401 });
-    }
+    const user = await authorizeDashboardRequest(
+      req,
+      ['/dashboard/comercial/stock-ledger', '/dashboard/productos'],
+      ['admin', 'usuario'],
+    );
 
     const body = await req.json();
     const productoId = String(body?.producto_id ?? '').trim();
@@ -208,6 +217,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ data: movimiento }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     return NextResponse.json(
       { error: error.message || 'Error al registrar movimiento de stock' },
       { status: 500 }

--- a/src/app/api/proveedores/[id]/route.ts
+++ b/src/app/api/proveedores/[id]/route.ts
@@ -2,6 +2,11 @@ import { getProveedorById } from '@/services/proveedorService';
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -9,10 +14,22 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(
+      req,
+      [
+        '/dashboard/proveedores',
+        '/dashboard/productos',
+        '/dashboard/compras',
+        '/dashboard/comercial/compras-reposicion',
+      ],
+      ['admin', 'usuario'],
+    );
     const { id } = await params;
     const proveedor = await getProveedorById(id);
     return NextResponse.json({ data: proveedor }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message });
   }
 }

--- a/src/app/api/proveedores/route.ts
+++ b/src/app/api/proveedores/route.ts
@@ -1,19 +1,39 @@
 import { getAllProveedores, createProveedor, updateProveedor, deleteProveedor } from "@/services/proveedorService";
 import { NextResponse } from "next/server";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(
+      req,
+      [
+        '/dashboard/proveedores',
+        '/dashboard/productos',
+        '/dashboard/comercial',
+        '/dashboard/comercial/kiosco',
+        '/dashboard/compras',
+        '/dashboard/comercial/compras-reposicion',
+      ],
+      ['admin', 'usuario'],
+    );
     const proveedores = await getAllProveedores();
     return NextResponse.json({ data: proveedores }, { status: 200 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: "Error al obtener los proveedores" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/proveedores', ['admin', 'usuario']);
     const body = await req.json();
     if (!body.nombre || typeof body.nombre !== "string" || body.nombre.trim().length === 0) {
       return NextResponse.json({ error: "El nombre comercial del proveedor es obligatorio" }, { status: 400 });
@@ -22,12 +42,15 @@ export async function POST(req: Request) {
     const proveedor = await createProveedor(body);
     return NextResponse.json({ message: "Proveedor creado con éxito", data: proveedor }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al crear el proveedor" }, { status: 500 });
   }
 }
 
 export async function PUT(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/proveedores', ['admin', 'usuario']);
     const { id, updateData } = await req.json();
     if (!id || typeof id !== "string") {
       return NextResponse.json({ error: "ID inválido para actualizar" }, { status: 400 });
@@ -36,12 +59,15 @@ export async function PUT(req: Request) {
     const proveedorActualizado = await updateProveedor(id, updateData ?? {});
     return NextResponse.json({ message: "Proveedor actualizado con éxito", data: proveedorActualizado }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al actualizar el proveedor" }, { status: 500 });
   }
 }
 
 export async function DELETE(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/proveedores', ['admin', 'usuario']);
     const { id } = await req.json();
     if (!id || typeof id !== "string") {
       return NextResponse.json({ error: "ID requerido para desactivar" }, { status: 400 });
@@ -50,6 +76,8 @@ export async function DELETE(req: Request) {
     await deleteProveedor(id);
     return NextResponse.json({ message: "Proveedor desactivado con éxito" }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al desactivar el proveedor" }, { status: 500 });
   }
 }

--- a/src/app/api/rag/coach/chat/route.ts
+++ b/src/app/api/rag/coach/chat/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import type { RagCoachChatRequest } from '@/interfaces/ragCoachChat.interface';
 import { handleUnifiedRagCoachChat } from '@/services/server/ragCoachUnifiedChatService';
 import { aiGeneratedContentTx, normalizeAiGeneratedContentLocale } from '@/utils/aiGeneratedContentI18n';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +20,7 @@ function getStatusFromError(message: string) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/coach', ['admin', 'socio']);
     if (!user) {
       return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
     }
@@ -42,6 +46,8 @@ export async function POST(req: Request) {
       { status: 200 },
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error inesperado';
 
     console.error('Error en chat unificado RAG Coach:', error);

--- a/src/app/api/rag/coach/corpus/run/route.ts
+++ b/src/app/api/rag/coach/corpus/run/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { runRagCorpusBatch } from '@/services/server/ragCorpusAdminService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,11 +17,13 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rag-corpus', ['admin']);
     const payload = await request.json().catch(() => ({}));
     const result = await runRagCorpusBatch(user, payload);
     return NextResponse.json(result, { status: result.ok ? 200 : 207 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error al ejecutar tanda de corpus RAG:', error);
     return NextResponse.json(

--- a/src/app/api/rag/coach/corpus/status/route.ts
+++ b/src/app/api/rag/coach/corpus/status/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getRagCorpusStatus } from '@/services/server/ragCorpusAdminService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,10 +17,12 @@ function getAuthStatus(error: any) {
 
 export async function GET(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rag-corpus', ['admin']);
     const status = await getRagCorpusStatus(user);
     return NextResponse.json(status, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error al consultar estado del corpus RAG:', error);
     return NextResponse.json(

--- a/src/app/api/rag/coach/ingest/dietas/route.ts
+++ b/src/app/api/rag/coach/ingest/dietas/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { ingestDietRulesForRag } from '@/services/server/ragCoachIngestionService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,11 +17,13 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rag-corpus', ['admin']);
     const payload = await request.json().catch(() => ({}));
     const result = await ingestDietRulesForRag(user, payload);
     return NextResponse.json(result, { status: result.ok ? 200 : 207 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error en ingesta RAG de dietas:', error);
     return NextResponse.json(

--- a/src/app/api/rag/coach/ingest/ejercicios/route.ts
+++ b/src/app/api/rag/coach/ingest/ejercicios/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { ingestExercisesForRag } from '@/services/server/ragCoachIngestionService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,11 +17,13 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rag-corpus', ['admin']);
     const payload = await request.json().catch(() => ({}));
     const result = await ingestExercisesForRag(user, payload);
     return NextResponse.json(result, { status: result.ok ? 200 : 207 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error en ingesta RAG de ejercicios:', error);
     return NextResponse.json(

--- a/src/app/api/rag/coach/search/route.ts
+++ b/src/app/api/rag/coach/search/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { searchRagKnowledge } from '@/services/server/ragCoachSearchService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,11 +17,13 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/coach', ['admin', 'socio']);
     const payload = await request.json();
     const result = await searchRagKnowledge(user, payload);
     return NextResponse.json(result, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error en búsqueda RAG:', error);
     return NextResponse.json(

--- a/src/app/api/rag/coach/status/route.ts
+++ b/src/app/api/rag/coach/status/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getRagHealth } from '@/services/server/ragCoachSearchService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,10 +17,12 @@ function getAuthStatus(error: any) {
 
 export async function GET(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/coach', ['admin', 'socio']);
     const status = await getRagHealth(user);
     return NextResponse.json(status, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error al consultar estado RAG:', error);
     return NextResponse.json(

--- a/src/app/api/rag/coach/vectorize/pending/route.ts
+++ b/src/app/api/rag/coach/vectorize/pending/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { vectorizePendingRagChunks } from '@/services/server/ragCoachIngestionService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,11 +17,13 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rag-corpus', ['admin']);
     const payload = await request.json().catch(() => ({}));
     const result = await vectorizePendingRagChunks(user, payload);
     return NextResponse.json(result, { status: result.ok ? 200 : 207 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
     if (status === 500) console.error('Error al vectorizar chunks RAG pendientes:', error);
     return NextResponse.json(

--- a/src/app/api/rutina/[idSocio]/route.ts
+++ b/src/app/api/rutina/[idSocio]/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { historialRutinaSocio } from '@/services/rutinaService';
 import { deleteRutinaById } from '@/services/server/rutinaServerService';
 import { NextResponse } from 'next/server';
@@ -11,10 +14,12 @@ export async function GET(
   { params }: { params: Promise<{ idSocio: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const { idSocio } = await params;
     if (!idSocio) {
@@ -35,6 +40,8 @@ export async function GET(
 
     return NextResponse.json(rutinas, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message ?? 'Error al obtener las rutinas del socio';
 
     if (
@@ -55,10 +62,12 @@ export async function DELETE(
   { params }: { params: Promise<{ idSocio: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const { idSocio: idRutina } = await params;
     const deletedRutina = await deleteRutinaById(user, idRutina);
@@ -71,6 +80,8 @@ export async function DELETE(
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al eliminar rutina:', error);
 
     const message = error?.message ?? 'Error al eliminar rutina';

--- a/src/app/api/rutina/delete/[id]/route.ts
+++ b/src/app/api/rutina/delete/[id]/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import {
   eliminarRutina,
   historialRutinaSocio,
@@ -8,10 +11,14 @@ import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-const isAdmin = (rol?: string | null): boolean => {
+const isManager = (rol?: string | null): boolean => {
   const normalizedRol = rol?.trim().toLowerCase();
 
-  return normalizedRol === "admin" || normalizedRol === "administrador";
+  return (
+    normalizedRol === "admin" ||
+    normalizedRol === "administrador" ||
+    normalizedRol === "usuario"
+  );
 };
 
 export async function GET(
@@ -19,13 +26,15 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
-    const rutinas = isAdmin(user.rol)
+    const rutinas = isManager(user.rol)
       ? await historialRutinaSocio(user, params.id)
       : await historialRutinaSocioLogueado(user);
 
@@ -36,6 +45,8 @@ export async function GET(
       },
     });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al obtener rutinas:", error);
 
     return NextResponse.json(
@@ -50,11 +61,13 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const deleted = await eliminarRutina(user, params.id);
 
@@ -71,6 +84,8 @@ export async function DELETE(
       }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error("Error al eliminar rutina:", error);
 
     const message = error.message || "Error al eliminar la rutina";

--- a/src/app/api/rutina/generar/route.ts
+++ b/src/app/api/rutina/generar/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import { dataGeneracionRutina } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
 
@@ -7,11 +10,13 @@ export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
     try {
-        const { user } = await authMiddleware(req);
+        const user = await authorizePersonalOrDashboardRequest(
+            req,
+            ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+            ['admin', 'usuario'],
+            ['socio'],
+        );
 
-        if (!user) {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
 
         const body = await req.json();
 
@@ -23,6 +28,8 @@ export async function POST(req: Request) {
 
         return NextResponse.json({ message: "Rutina generada correctamente", data: generacionRutina }, { status: 200 });
     } catch (error: any) {
+        const authResponse = authorizationErrorResponse(error);
+        if (authResponse) return authResponse;
         console.error("Error en la generación de rutina:", error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }

--- a/src/app/api/rutina/historial/[id_socio]/route.ts
+++ b/src/app/api/rutina/historial/[id_socio]/route.ts
@@ -1,20 +1,31 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { historialRutinaSocio } from '@/services/rutinaService';
 import { NextResponse } from 'next/server';
-
+import { historialRutinaSocio } from '@/services/rutinaService';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(
   req: Request,
-  { params }: { params: Promise<{ id_socio: string }> }
+  { params }: { params: Promise<{ id_socio: string }> },
 ) {
-  const { user } = await authMiddleware(req);
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  try {
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
+    const { id_socio } = await params;
+    const historialRutina = await historialRutinaSocio(user, id_socio);
+    return NextResponse.json(historialRutina, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener historial de rutinas';
+    const status = message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
-  const { id_socio } = await params;
-
-  const historialRutina = await historialRutinaSocio(user, id_socio);
-  return NextResponse.json(historialRutina, { status: 200 });
 }

--- a/src/app/api/rutina/historial/route.ts
+++ b/src/app/api/rutina/historial/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import { historialRutinaSocioLogueado } from "@/services/rutinaService";
 import { NextResponse } from "next/server";
 
@@ -6,11 +9,13 @@ export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
 
     const historialRutina = await historialRutinaSocioLogueado(user);
 
@@ -21,6 +26,8 @@ export async function GET(req: Request) {
       },
     });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error?.message ?? "Error al obtener historial de rutinas";
 
     if (

--- a/src/app/api/rutina/training-sessions/[id]/route.ts
+++ b/src/app/api/rutina/training-sessions/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import {
   cancelTrainingSession,
   finishTrainingSession,
@@ -21,10 +24,12 @@ export async function PATCH(
   { params }: { params: { id: string } },
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const body = await req.json();
     const action = String(body?.action ?? 'update_exercise');
@@ -46,6 +51,8 @@ export async function PATCH(
 
     return NextResponse.json({ error: 'Acción no soportada' }, { status: 400 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/rutina/training-sessions/route.ts
+++ b/src/app/api/rutina/training-sessions/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import {
   listTrainingSessions,
   startTrainingSession,
@@ -16,10 +19,12 @@ const resolveStatus = (message: string): number => {
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const { searchParams } = new URL(req.url);
     const rutinaId = searchParams.get('rutinaId');
@@ -43,6 +48,8 @@ export async function GET(req: Request) {
       },
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }
@@ -50,16 +57,20 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const body = await req.json();
     const data = await startTrainingSession(user, body);
 
     return NextResponse.json({ data }, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     return NextResponse.json({ error: message }, { status: resolveStatus(message) });
   }

--- a/src/app/api/rutinas/ejercicios-media/equivalence-sync/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/equivalence-sync/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { syncExerciseMediaEquivalences } from '@/services/ejercicioMediaCatalogService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,7 +24,7 @@ function getStatusFromError(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const payload = await request.json().catch(() => ({}));
 
     const result = await syncExerciseMediaEquivalences(user, {
@@ -38,6 +42,8 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getStatusFromError(error);
 
     if (status === 500) {

--- a/src/app/api/rutinas/ejercicios-media/import/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/import/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { importExerciseMediaFromRemoteUrl } from '@/services/ejercicioMediaCatalogService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,7 +36,7 @@ function getStatusFromError(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const payload = await request.json();
 
     if (!payload?.id_ejercicio || !Number.isInteger(Number(payload.id_ejercicio))) {
@@ -55,6 +59,8 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getStatusFromError(error);
 
     if (status === 500) {

--- a/src/app/api/rutinas/ejercicios-media/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   getExerciseMediaCatalog,
   updateExerciseMediaCatalogItem,
 } from '@/services/ejercicioMediaCatalogService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -23,12 +27,14 @@ function getAuthStatus(error: any) {
 
 export async function GET(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const url = new URL(request.url);
     const catalog = await getExerciseMediaCatalog(user, url.searchParams);
 
     return NextResponse.json(catalog, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
 
     if (status === 500) {
@@ -44,7 +50,7 @@ export async function GET(request: Request) {
 
 export async function PATCH(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const payload = await request.json();
 
     if (!payload?.id_ejercicio || !Number.isInteger(Number(payload.id_ejercicio))) {
@@ -67,6 +73,8 @@ export async function PATCH(request: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
 
     if (status === 500) {

--- a/src/app/api/rutinas/ejercicios-media/upload/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/upload/route.ts
@@ -1,12 +1,19 @@
 import { NextResponse } from 'next/server';
 import { FileUploadDTO } from '@/interfaces/fileUpload.interface';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { uploadFileCloudinaryWithResult } from '@/lib/cloudinary';
+import {
+  hasSafeUploadSignature,
+  isSafeUploadMimeType,
+} from '@/lib/security/uploadValidation';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const VALID_MEDIA_TYPES = /^image\/(png|jpe?g|webp|gif|svg\+xml|heic|heif)$/i;
 
 function getStatusFromError(error: any) {
   const message = error?.message ?? '';
@@ -24,7 +31,7 @@ function normalizeRole(role?: string | null) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const role = normalizeRole(user.rol);
 
     if (role !== 'admin' && role !== 'administrador') {
@@ -52,15 +59,22 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!VALID_MEDIA_TYPES.test(file.type)) {
+    if (!isSafeUploadMimeType(file.type) || file.type === 'application/pdf') {
       return NextResponse.json(
-        { error: 'Formato no válido. Usá PNG, JPG, WEBP, GIF, SVG, HEIC o HEIF.' },
+        { error: 'Formato no válido. Usá PNG, JPG, WEBP, GIF, HEIC o HEIF.' },
         { status: 400 }
       );
     }
 
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
+
+    if (!hasSafeUploadSignature(buffer, file.type)) {
+      return NextResponse.json(
+        { error: 'El contenido del archivo no coincide con una imagen permitida.' },
+        { status: 400 }
+      );
+    }
 
     const fileDto: FileUploadDTO = {
       fieldName: file.name,
@@ -95,6 +109,8 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getStatusFromError(error);
 
     if (status === 500) {

--- a/src/app/api/rutinas/ejercicios-media/youtube-auto-discovery/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/youtube-auto-discovery/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { autoDiscoverExerciseYoutubeVideos } from '@/services/ejercicioMediaCatalogService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,7 +28,7 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const payload = await request.json().catch(() => ({}));
 
     const result = await autoDiscoverExerciseYoutubeVideos(user, {
@@ -38,6 +42,8 @@ export async function POST(request: Request) {
 
     return NextResponse.json(result, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
 
     if (status === 500) {

--- a/src/app/api/rutinas/ejercicios-media/youtube-import/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/youtube-import/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { importExerciseYoutubeVideos } from '@/services/ejercicioMediaCatalogService';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -20,7 +24,7 @@ function getAuthStatus(error: any) {
 
 export async function POST(request: Request) {
   try {
-    const { user } = await authMiddleware(request);
+    const user = await authorizeDashboardRequest(request, '/dashboard/rutinas/media', ['admin', 'usuario']);
     const payload = await request.json();
 
     if (!Array.isArray(payload?.items)) {
@@ -37,6 +41,8 @@ export async function POST(request: Request) {
 
     return NextResponse.json(result, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const status = getAuthStatus(error);
 
     if (status === 500) {

--- a/src/app/api/rutinas/rag-assistant/generar/route.ts
+++ b/src/app/api/rutinas/rag-assistant/generar/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { dataGeneracionRutina } from '@/services/rutinaService';
 import { buildRutinasRagContext } from '@/services/server/ragRutinasCoachService';
 import type {
@@ -127,11 +130,13 @@ async function callRagCoach(payload: RagCoachPayload): Promise<RagCoachResponse>
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      ['/dashboard/rutinas/asistente', '/dashboard/gestor-rutinas'],
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = (await req.json().catch(() => ({}))) as RagRutinasAssistantRequest;
 
@@ -180,6 +185,8 @@ export async function POST(req: Request) {
         id_socio: body.id_socio,
       });
     } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
       internalRagError = error instanceof Error ? translateAiGeneratedTechnicalText(error.message, idioma) : translateAiGeneratedTechnicalText('Error desconocido al consultar RAG interno', idioma);
       console.warn('RAG interno de rutinas no disponible. Se usa fallback local:', internalRagError);
     }
@@ -192,6 +199,8 @@ export async function POST(req: Request) {
       try {
         ragRespuesta = await callRagCoach(ragPayload);
       } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
         ragError = error instanceof Error ? translateAiGeneratedTechnicalText(error.message, idioma) : translateAiGeneratedTechnicalText('Error desconocido del RAG Coach', idioma);
         console.warn('RAG Coach no disponible. Se usa fallback local:', ragError);
       }
@@ -254,6 +263,8 @@ export async function POST(req: Request) {
       { status: 200 }
     );
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : translateAiGeneratedTechnicalText('Error inesperado', 'es');
     const status = message.toLowerCase().includes('token') ? 401 : 500;
 

--- a/src/app/api/servicios/[id]/route.ts
+++ b/src/app/api/servicios/[id]/route.ts
@@ -2,6 +2,11 @@ import { getServicioById } from '@/services/servicioService';
 import { NextRequest, NextResponse } from 'next/server';
 
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(
@@ -9,10 +14,22 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    await authorizeDashboardRequest(
+      req,
+      [
+        '/dashboard/servicios',
+        '/dashboard/comercial',
+        '/dashboard/comercial/kiosco',
+        '/dashboard/comercial/servicios-promociones',
+      ],
+      ['admin', 'usuario'],
+    );
     const { id } = await params;
     const servicio = await getServicioById(id);
     return NextResponse.json({ data: servicio }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message });
   }
 }

--- a/src/app/api/servicios/route.ts
+++ b/src/app/api/servicios/route.ts
@@ -1,19 +1,37 @@
 import { createServicio, deleteServicio, getAllServicios, updateServicio } from "@/services/servicioService";
 import { NextResponse } from "next/server";
 
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    await authorizeDashboardRequest(
+      req,
+      [
+        '/dashboard/servicios',
+        '/dashboard/comercial',
+        '/dashboard/comercial/kiosco',
+        '/dashboard/comercial/servicios-promociones',
+      ],
+      ['admin', 'usuario'],
+    );
     const servicios = await getAllServicios();
     return NextResponse.json({ data: servicios }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: "Error al obtener los servicios" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/servicios', ['admin', 'usuario']);
     const body = await req.json();
     if (!body.nombre || !body.descripcion || body.precio === undefined || body.precio === null || Number(body.precio) < 0) {
       return NextResponse.json({ error: "Nombre, descripción y precio válido son obligatorios" }, { status: 400 });
@@ -21,32 +39,40 @@ export async function POST(req: Request) {
     const servicio = await createServicio(body);
     return NextResponse.json({ message: "Servicio creado con éxito", data: servicio }, { status: 201 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al crear el servicio" }, { status: 500 });
   }
 }
 
 export async function PUT(req: Request) {
-  const { id, updateData } = await req.json();
   try {
+    await authorizeDashboardRequest(req, '/dashboard/servicios', ['admin', 'usuario']);
+    const { id, updateData } = await req.json();
     if (!id || typeof id !== "string") {
       return NextResponse.json({ error: "ID inválido para actualizar" }, { status: 400 });
     }
     const servicioModificado = await updateServicio(id, updateData);
     return NextResponse.json({ message: "Servicio actualizado con éxito", data: servicioModificado }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al actualizar servicio" }, { status: 500 });
   }
 }
 
 export async function DELETE(req: Request) {
-  const { id } = await req.json();
   try {
+    await authorizeDashboardRequest(req, '/dashboard/servicios', ['admin', 'usuario']);
+    const { id } = await req.json();
     if (!id || typeof id !== "string") {
       return NextResponse.json({ error: "ID inválido para eliminar" }, { status: 400 });
     }
     await deleteServicio(id);
     return NextResponse.json({ message: "Servicio eliminado con éxito" }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message || "Error al eliminar servicio" }, { status: 500 });
   }
 }

--- a/src/app/api/socios/[id]/ficha-medica/[id_ficha]/route.ts
+++ b/src/app/api/socios/[id]/ficha-medica/[id_ficha]/route.ts
@@ -1,4 +1,7 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { FindOneFichaMedicaSocio, resolveFichaMedicaSocioId } from '@/services/fichaMedicaService';
 import { NextResponse } from 'next/server';
 
@@ -18,13 +21,12 @@ export async function GET(
   { params }: { params: Promise<{ id: string; id_ficha: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Usuario no autorizado' },
-        { status: 401 }
-      );
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      '/dashboard/ficha-medica',
+      ['admin', 'usuario'],
+      ['socio'],
+    );
     const { id, id_ficha } = await params;
 
     if (!id) {
@@ -46,6 +48,8 @@ export async function GET(
 
     return NextResponse.json({ data: ficha }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error);
     const status = getFichaMedicaErrorStatus(error?.message);
     return NextResponse.json({ error: error.message }, { status });

--- a/src/app/api/socios/[id]/ficha-medica/actual/route.ts
+++ b/src/app/api/socios/[id]/ficha-medica/actual/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { FindFichaMedicaSocio, resolveFichaMedicaSocioId } from '@/services/fichaMedicaService';
 
 
@@ -18,13 +21,12 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Usuario no autorizado' },
-        { status: 401 }
-      );
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      '/dashboard/ficha-medica',
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const { id } = await params;
     if (!id) {
@@ -39,6 +41,8 @@ export async function GET(
 
     return NextResponse.json({ data: ficha }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error);
     const status = getFichaMedicaErrorStatus(error?.message);
     return NextResponse.json({ error: error.message }, { status });

--- a/src/app/api/socios/[id]/ficha-medica/historial/route.ts
+++ b/src/app/api/socios/[id]/ficha-medica/historial/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { FindAllFichaMedicaSocio, resolveFichaMedicaSocioId } from '@/services/fichaMedicaService';
 
 
@@ -18,13 +21,12 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Usuario no autorizado' },
-        { status: 401 }
-      );
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      '/dashboard/ficha-medica',
+      ['admin', 'usuario'],
+      ['socio'],
+    );
     const { id } = await params;
     if (!id) {
       return NextResponse.json(
@@ -49,6 +51,8 @@ export async function GET(
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.log(error);
     const status = getFichaMedicaErrorStatus(error?.message);
     return NextResponse.json(

--- a/src/app/api/socios/[id]/ficha-medica/route.ts
+++ b/src/app/api/socios/[id]/ficha-medica/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { createFichaMedicaSocio, resolveFichaMedicaSocioId } from '@/services/fichaMedicaService';
 import { FileUploadDTO } from '@/interfaces/fileUpload.interface';
 
@@ -50,13 +53,12 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Usuario no autorizado', code: 'unauthorized' },
-        { status: 401 }
-      );
-    }
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      '/dashboard/ficha-medica',
+      ['admin', 'usuario'],
+      ['socio'],
+    );
 
     const paramsResolved = await params;
     const id = paramsResolved?.id;
@@ -138,6 +140,8 @@ export async function POST(
       { status: 201 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     console.error('Error al crear ficha médica:', error);
     const status = getFichaMedicaErrorStatus(error?.message);
     return NextResponse.json(

--- a/src/app/api/socios/[id]/route.ts
+++ b/src/app/api/socios/[id]/route.ts
@@ -1,21 +1,31 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { getSocioById } from '@/services/socioService';
 import { NextRequest, NextResponse } from 'next/server';
-
+import { getSocioByIdServer } from '@/services/server/socioServerService';
+import {
+  authorizationErrorResponse,
+  authorizePersonalOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await authMiddleware(req);
-
     const { id } = await params;
-    const socio = await getSocioById(id);
+    const user = await authorizePersonalOrDashboardRequest(
+      req,
+      '/dashboard/socios',
+      ['admin', 'usuario'],
+      ['socio'],
+    );
+    const socio = await getSocioByIdServer(user, id);
     return NextResponse.json({ data: socio }, { status: 200 });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener el socio';
+    const status = message.includes('No se encontró') ? 404 : message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/socios/demografia-promociones-bi/route.ts
+++ b/src/app/api/socios/demografia-promociones-bi/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
 import type {
   GeneroBi,
@@ -241,11 +244,11 @@ function buildPromotions(params: {
 
 export async function GET(request: NextRequest) {
   try {
-    const { user } = await authMiddleware(request);
-
-    if (user.rol !== 'admin' && user.rol !== 'usuario') {
-      return NextResponse.json({ error: 'No autorizado para consultar BI de socios' }, { status: 403 });
-    }
+    await authorizeDashboardRequest(
+      request,
+      '/dashboard/bi-socios-demografia-promociones',
+      ['admin', 'usuario'],
+    );
 
     const { searchParams } = new URL(request.url);
     const desde = normalizeDateParam(searchParams.get('desde'), firstDayOfCurrentYearISO(), 'Fecha desde');
@@ -502,10 +505,13 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ data: response }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
     console.error('ERROR en BI demográfico de socios:', error.message || error);
     return NextResponse.json(
       { error: error.message || 'Error al obtener BI demográfico de socios' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
+      { status: 500 }
     );
   }
 }

--- a/src/app/api/socios/mensajes/route.ts
+++ b/src/app/api/socios/mensajes/route.ts
@@ -1,35 +1,36 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import {
-  createMensajeSocio,
-  getMensajesSocio,
-} from '@/services/socioMensajeService';
 import { NextResponse } from 'next/server';
+import { createMensajeSocio, getMensajesSocio } from '@/services/socioMensajeService';
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
+    const user = await authorizeDashboardRequest(req, '/dashboard/mensajes', ['socio']);
     const mensajes = await getMensajesSocio(user);
     return NextResponse.json({ data: mensajes });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const status = message.includes('Solo los socios') || message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-    const body = await req.json();
-    const mensaje = await createMensajeSocio(body, user);
+    const user = await authorizeDashboardRequest(req, '/dashboard/mensajes', ['socio']);
+    const mensaje = await createMensajeSocio(await req.json(), user);
     return NextResponse.json({ data: mensaje }, { status: 201 });
-  } catch (error) {
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
-    return NextResponse.json({ error: message }, { status: 500 });
+    const status = message.includes('Solo los socios') || message.includes('No autorizado') ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/socios/ranking-bonificacion-mensual/route.ts
+++ b/src/app/api/socios/ranking-bonificacion-mensual/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { authMiddleware } from "@/middlewares/auth.middleware";
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from "@/lib/auth/serverAuthorization";
 import { getSupabaseServerClient } from "@/services/supabaseServerClient";
 import type {
   SocioRankingBonificacionItem,
@@ -37,14 +40,6 @@ type PagoRow = {
 };
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function unauthorized(message = "No autorizado") {
-  return NextResponse.json({ error: message }, { status: 401 });
-}
-
-function forbidden(message = "Permiso insuficiente") {
-  return NextResponse.json({ error: message }, { status: 403 });
-}
 
 function getPeriod(anioParam?: string | null, mesParam?: string | null) {
   const now = new Date();
@@ -284,8 +279,11 @@ async function buildResponse(anio: number, mes: number): Promise<SociosRankingBo
 
 export async function GET(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user || !["admin", "usuario"].includes(user.rol)) return forbidden();
+    await authorizeDashboardRequest(
+      req,
+      "/dashboard/socios-ranking-bonificacion",
+      ["admin", "usuario"],
+    );
 
     const { searchParams } = new URL(req.url);
     const { anio, mes } = getPeriod(searchParams.get("anio"), searchParams.get("mes"));
@@ -293,9 +291,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(response);
   } catch (error: any) {
-    if (error?.message === "Token no proporcionado" || error?.message === "Token inválido") {
-      return unauthorized(error.message);
-    }
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
 
     return NextResponse.json({ error: error?.message || "Error al calcular ranking mensual" }, { status: 500 });
   }
@@ -303,8 +300,11 @@ export async function GET(req: NextRequest) {
 
 export async function PATCH(req: NextRequest) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user || !["admin", "usuario"].includes(user.rol)) return forbidden();
+    const user = await authorizeDashboardRequest(
+      req,
+      "/dashboard/socios-ranking-bonificacion",
+      ["admin", "usuario"],
+    );
 
     const payload = (await req.json()) as SocioRankingBonificacionMutationPayload;
     const { anio, mes } = getPeriod(String(payload.anio), String(payload.mes));
@@ -379,9 +379,8 @@ export async function PATCH(req: NextRequest) {
     const refreshed = await buildResponse(anio, mes);
     return NextResponse.json(refreshed);
   } catch (error: any) {
-    if (error?.message === "Token no proporcionado" || error?.message === "Token inválido") {
-      return unauthorized(error.message);
-    }
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
 
     return NextResponse.json({ error: error?.message || "Error al actualizar bonificación mensual" }, { status: 500 });
   }

--- a/src/app/api/socios/route.ts
+++ b/src/app/api/socios/route.ts
@@ -5,96 +5,75 @@ import {
   fetchSociosServer,
   updateSocioServer,
 } from '@/services/server/socioServerService';
-import { authMiddleware } from '@/middlewares/auth.middleware';
-
+import {
+  authorizationErrorResponse,
+  authorizeDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
+const SOCIOS_PATH = '/dashboard/socios';
+const MANAGER_ROLES = ['admin', 'usuario'] as const;
+
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, SOCIOS_PATH, [...MANAGER_ROLES]);
     const socios = await fetchSociosServer(user);
     return NextResponse.json(socios, { status: 200 });
-  } catch (error: any) {
-    console.error('ERROR al obtener socios:', error.message || error);
-    return NextResponse.json(
-      { error: error.message || 'Error al obtener socios' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al obtener socios';
+    console.error('ERROR al obtener socios:', message);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, SOCIOS_PATH, [...MANAGER_ROLES]);
     const body = await req.json();
     const creado = await createSocioServer(user, body);
-
-    return NextResponse.json(
-      {
-        message: 'Socio creado con éxito',
-        data: creado,
-      },
-      { status: 201 }
-    );
-  } catch (error: any) {
-    console.error('ERROR al crear socio:', error.message || error);
-    return NextResponse.json(
-      { error: error.message || 'Error al crear socio' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+    return NextResponse.json({ message: 'Socio creado con éxito', data: creado }, { status: 201 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al crear socio';
+    console.error('ERROR al crear socio:', message);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function PUT(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, SOCIOS_PATH, [...MANAGER_ROLES]);
     const { id, ...updateData } = await req.json();
-
     if (!id || typeof id !== 'string') {
-      return NextResponse.json(
-        { error: 'ID inválido para actualizar' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'ID inválido para actualizar' }, { status: 400 });
     }
-
     const actualizado = await updateSocioServer(user, id, updateData);
-    return NextResponse.json(
-      {
-        message: 'Socio actualizado con éxito',
-        data: actualizado,
-      },
-      { status: 200 }
-    );
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message || 'Error al actualizar socio' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+    return NextResponse.json({ message: 'Socio actualizado con éxito', data: actualizado }, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al actualizar socio';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }
 
 export async function DELETE(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, SOCIOS_PATH, [...MANAGER_ROLES]);
     const { id } = await req.json();
-
     if (!id || typeof id !== 'string') {
-      return NextResponse.json(
-        { error: 'ID requerido para eliminar' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'ID requerido para eliminar' }, { status: 400 });
     }
-
     const desactivado = await deactivateSocioServer(user, id);
-    return NextResponse.json(
-      { message: 'Socio desactivado con éxito', data: desactivado },
-      { status: 200 }
-    );
-  } catch (error: any) {
-    return NextResponse.json(
-      { error: error.message || 'Error al desactivar socio' },
-      { status: error.message?.includes('No autorizado') ? 403 : 500 }
-    );
+    return NextResponse.json({ message: 'Socio desactivado con éxito', data: desactivado }, { status: 200 });
+  } catch (error: unknown) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+    const message = error instanceof Error ? error.message : 'Error al desactivar socio';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/soporte/tickets/[id]/route.ts
+++ b/src/app/api/soporte/tickets/[id]/route.ts
@@ -1,20 +1,26 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   getSoporteTicketById,
   updateSoporteTicket,
 } from '@/services/soporteTicketService';
 import { NextResponse } from 'next/server';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(_req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(_req);
+    const user = await authorizeDashboardRequest(_req, '/dashboard/soporte-dragon-pyramid', ['admin', 'usuario']);
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const ticket = await getSoporteTicketById(params.id, user);
     return NextResponse.json({ data: ticket });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -23,13 +29,15 @@ export async function GET(_req: Request, { params }: { params: { id: string } })
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/soporte-dragon-pyramid', ['admin', 'usuario']);
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const body = await req.json();
     const ticket = await updateSoporteTicket(params.id, body, user);
     return NextResponse.json({ data: ticket });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/soporte/tickets/route.ts
+++ b/src/app/api/soporte/tickets/route.ts
@@ -1,15 +1,19 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import {
   createSoporteTicket,
   getSoporteTickets,
 } from '@/services/soporteTicketService';
 import { NextResponse } from 'next/server';
 
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/soporte-dragon-pyramid', ['admin', 'usuario']);
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const url = new URL(req.url);
@@ -20,6 +24,8 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ data: tickets });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });
@@ -28,13 +34,15 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/soporte-dragon-pyramid', ['admin', 'usuario']);
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const body = await req.json();
     const ticket = await createSoporteTicket(body, user);
     return NextResponse.json({ data: ticket }, { status: 201 });
   } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     const message = error instanceof Error ? error.message : 'Error interno del servidor';
     const status = message.includes('No autorizado') ? 403 : 500;
     return NextResponse.json({ error: message }, { status });

--- a/src/app/api/stripe-webhook/route.ts
+++ b/src/app/api/stripe-webhook/route.ts
@@ -5,6 +5,8 @@ import { registerStripeCheckoutPago } from '@/services/server/stripePagoRegistra
 
 export const dynamic = 'force-dynamic';
 
+// AUTH POLICY: PUBLIC_SIGNED_WEBHOOK
+
 if (!process.env.STRIPE_WEBHOOK_SECRET) {
   throw new Error('STRIPE_WEBHOOK_SECRET no está definido');
 }

--- a/src/app/api/swagger-json/route.ts
+++ b/src/app/api/swagger-json/route.ts
@@ -3,6 +3,8 @@ import { openApiSpec } from "@/lib/swagger/openApiSpec";
 
 export const dynamic = "force-static";
 
+// AUTH POLICY: PUBLIC_DOCUMENTATION
+
 export async function GET() {
   return NextResponse.json(openApiSpec);
 }

--- a/src/app/api/test-alertas/route.ts
+++ b/src/app/api/test-alertas/route.ts
@@ -1,12 +1,27 @@
 import { desactivarSociosPorDeuda, obtenerSociosDeudores } from "@/services/brevoService";
 import { NextResponse } from "next/server";
 
-export async function POST() {
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
+
+export async function POST(req: Request) {
   try {
+    await authorizeDashboardRequest(req, '/dashboard/socios', ['admin']);
+
+    if (process.env.NODE_ENV === 'production') {
+      return NextResponse.json(
+        { error: 'Endpoint de diagnóstico no disponible en producción' },
+        { status: 404 }
+      );
+    }
     const deudores = await obtenerSociosDeudores();
     const deudoresDesactivados= await desactivarSociosPorDeuda();
    return NextResponse.json({message:"Obteniendo socios con la cuota vencida", data:deudores, message2: "Deudores desactivados", data2: deudoresDesactivados},{status:200});
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/usuarios/[id]/perfil/route.ts
+++ b/src/app/api/usuarios/[id]/perfil/route.ts
@@ -1,24 +1,32 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
+import {
+  authorizationErrorResponse,
+  authorizeOwnUserOrDashboardRequest,
+} from '@/lib/auth/serverAuthorization';
 import { getUsuarioById } from '@/services/usuarioService';
 import { NextRequest, NextResponse } from 'next/server';
-
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await authMiddleware(req);
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     const { id } = await params;
+    const user = await authorizeOwnUserOrDashboardRequest(
+      req,
+      id,
+      '/dashboard/usuarios',
+      ['admin'],
+    );
     const usuario = await getUsuarioById(user, id);
     return NextResponse.json({ data: usuario }, { status: 200 });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message });
+  } catch (error) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
+
+    const message =
+      error instanceof Error ? error.message : 'Error al obtener el perfil';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/usuarios/[id]/route.ts
+++ b/src/app/api/usuarios/[id]/route.ts
@@ -1,7 +1,11 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getUsuarioById } from '@/services/usuarioService';
 import { NextRequest, NextResponse } from 'next/server';
 
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -10,7 +14,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/usuarios', ['admin']);
     if (!user) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
     }
@@ -19,6 +23,8 @@ export async function GET(
     const usuario = await getUsuarioById(user, id);
     return NextResponse.json({ data: usuario }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json({ error: error.message });
   }
 }

--- a/src/app/api/usuarios/route.ts
+++ b/src/app/api/usuarios/route.ts
@@ -5,17 +5,21 @@ import {
   fetchUsuariosServer,
   updateUsuarioServer,
 } from '@/services/server/usuarioServerService';
-import { authMiddleware } from '@/middlewares/auth.middleware';
-
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/usuarios', ['admin']);
     const usuarios = await fetchUsuariosServer(user);
     return NextResponse.json({ data: usuarios }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener usuarios' },
       { status: error.message?.includes('No autorizado') ? 403 : 500 }
@@ -25,7 +29,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/usuarios', ['admin']);
     const body = await req.json();
     const {
       nombre,
@@ -95,6 +99,8 @@ export async function POST(req: Request) {
       { status: 201 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al crear usuario' },
       { status: error.message?.includes('No autorizado') ? 403 : 500 }
@@ -104,7 +110,7 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/usuarios', ['admin']);
     const { id, updateData } = await req.json();
 
     if (!id || typeof id !== 'string') {
@@ -123,6 +129,8 @@ export async function PUT(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al actualizar usuario' },
       { status: error.message?.includes('No autorizado') ? 403 : 500 }
@@ -132,7 +140,7 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/usuarios', ['admin']);
     const { id } = await req.json();
 
     if (!id || typeof id !== 'string') {
@@ -148,6 +156,8 @@ export async function DELETE(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al desactivar usuario' },
       { status: error.message?.includes('No autorizado') ? 403 : 500 }

--- a/src/app/api/ventas/[id]/route.ts
+++ b/src/app/api/ventas/[id]/route.ts
@@ -1,6 +1,10 @@
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getVentaById } from '@/services/ventaService';
 import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,7 +13,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -21,6 +25,8 @@ export async function GET(
     const venta = await getVentaById(user, id);
     return NextResponse.json({ data: venta }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener la venta' },
       { status: 500 }

--- a/src/app/api/ventas/route.ts
+++ b/src/app/api/ventas/route.ts
@@ -4,14 +4,18 @@ import {
   getAllVentas,
   updateVenta,
 } from '@/services/ventaService';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { NextResponse } from 'next/server';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -22,6 +26,8 @@ export async function GET(req: Request) {
     const ventas = await getAllVentas(user);
     return NextResponse.json({ data: ventas }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener las ventas' },
       { status: 500 }
@@ -31,7 +37,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -62,6 +68,8 @@ export async function POST(req: Request) {
       { status: 201 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al registrar la venta' },
       { status: 500 }
@@ -71,7 +79,7 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -93,6 +101,8 @@ export async function PUT(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al actualizar venta' },
       { status: 500 }
@@ -102,7 +112,7 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -124,6 +134,8 @@ export async function DELETE(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al anular venta' },
       { status: 500 }

--- a/src/app/api/ventas_detalles/route.ts
+++ b/src/app/api/ventas_detalles/route.ts
@@ -4,14 +4,18 @@ import {
   getAllVentaDetalles,
   updateVentaDetalle,
 } from '@/services/ventaDetalleService';
-import { authMiddleware } from '@/middlewares/auth.middleware';
 import { NextResponse } from 'next/server';
+
+import {
+  authorizeDashboardRequest,
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -22,6 +26,8 @@ export async function GET(req: Request) {
     const detalles = await getAllVentaDetalles(user);
     return NextResponse.json({ data: detalles }, { status: 200 });
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al obtener los detalles de venta' },
       { status: 500 }
@@ -31,7 +37,7 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -53,6 +59,8 @@ export async function POST(req: Request) {
       { status: 201 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al crear el detalle de venta' },
       { status: 500 }
@@ -62,7 +70,7 @@ export async function POST(req: Request) {
 
 export async function PUT(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -84,6 +92,8 @@ export async function PUT(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al actualizar detalle de venta' },
       { status: 500 }
@@ -93,7 +103,7 @@ export async function PUT(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const { user } = await authMiddleware(req);
+    const user = await authorizeDashboardRequest(req, '/dashboard/ventas', ['admin', 'usuario']);
     if (!user) {
       return NextResponse.json(
         { error: 'No se pudo obtener el usuario' },
@@ -115,6 +125,8 @@ export async function DELETE(req: Request) {
       { status: 200 }
     );
   } catch (error: any) {
+    const authResponse = authorizationErrorResponse(error);
+    if (authResponse) return authResponse;
     return NextResponse.json(
       { error: error.message || 'Error al eliminar detalle de venta' },
       { status: 500 }

--- a/src/lib/auth/serverAuthorization.ts
+++ b/src/lib/auth/serverAuthorization.ts
@@ -111,6 +111,42 @@ export async function authorizePersonalOrDashboardRequest(
   return user;
 }
 
+export function requireOwnUserOrRoles(
+  user: JwtUser,
+  userId: string,
+  elevatedRoles: AppRole[] = ['admin'],
+) {
+  if (user.id === userId) {
+    return user;
+  }
+
+  if (!elevatedRoles.includes(user.rol as AppRole)) {
+    throw new AuthorizationError(
+      'El usuario no puede consultar el perfil de otra cuenta',
+      'AUTH_USER_SCOPE_FORBIDDEN',
+    );
+  }
+
+  return user;
+}
+
+export async function authorizeOwnUserOrDashboardRequest(
+  req: Request,
+  userId: string,
+  pathname: string,
+  elevatedRoles: AppRole[] = ['admin'],
+) {
+  const { user } = await authMiddleware(req);
+
+  if (user.id === userId) {
+    return user;
+  }
+
+  requireRoles(user, elevatedRoles);
+  requireDashboardPermission(user, pathname);
+  return user;
+}
+
 export function requireOwnSocioOrRoles(
   user: JwtUser,
   socioId: string,

--- a/src/lib/auth/serverAuthorization.ts
+++ b/src/lib/auth/serverAuthorization.ts
@@ -88,6 +88,29 @@ export async function authorizeDashboardRequest(
   return user;
 }
 
+export async function authorizePersonalOrDashboardRequest(
+  req: Request,
+  pathnames: string | string[],
+  elevatedRoles: AppRole[] = ['admin', 'usuario'],
+  personalRoles: AppRole[] = ['socio'],
+) {
+  const { user } = await authMiddleware(req);
+
+  if (personalRoles.includes(user.rol as AppRole)) {
+    return user;
+  }
+
+  requireRoles(user, elevatedRoles);
+
+  if (Array.isArray(pathnames)) {
+    requireAnyDashboardPermission(user, pathnames);
+  } else {
+    requireDashboardPermission(user, pathnames);
+  }
+
+  return user;
+}
+
 export function requireOwnSocioOrRoles(
   user: JwtUser,
   socioId: string,

--- a/src/lib/auth/serverAuthorization.ts
+++ b/src/lib/auth/serverAuthorization.ts
@@ -3,6 +3,11 @@ import {
   canAccessDashboardPath,
   type AppRole,
 } from '@/lib/permissions/menuPermissions';
+import {
+  AuthMiddlewareError,
+  authMiddleware,
+} from '@/middlewares/auth.middleware';
+import { NextResponse } from 'next/server';
 
 export class AuthorizationError extends Error {
   code: string;
@@ -44,6 +49,45 @@ export function requireDashboardPermission(user: JwtUser, pathname: string) {
   return user;
 }
 
+export function requireAnyDashboardPermission(
+  user: JwtUser,
+  pathnames: string[],
+) {
+  const canAccess = pathnames.some((pathname) =>
+    canAccessDashboardPath(
+      user.rol,
+      user.permisos_menu ?? null,
+      pathname,
+    ),
+  );
+
+  if (!canAccess) {
+    throw new AuthorizationError(
+      'El usuario no tiene permisos para acceder a este módulo',
+      'AUTH_PERMISSION_FORBIDDEN',
+    );
+  }
+
+  return user;
+}
+
+export async function authorizeDashboardRequest(
+  req: Request,
+  pathnames: string | string[],
+  roles: AppRole[],
+) {
+  const { user } = await authMiddleware(req);
+  requireRoles(user, roles);
+
+  if (Array.isArray(pathnames)) {
+    requireAnyDashboardPermission(user, pathnames);
+  } else {
+    requireDashboardPermission(user, pathnames);
+  }
+
+  return user;
+}
+
 export function requireOwnSocioOrRoles(
   user: JwtUser,
   socioId: string,
@@ -61,4 +105,15 @@ export function requireOwnSocioOrRoles(
   }
 
   return user;
+}
+
+export function authorizationErrorResponse(error: unknown) {
+  if (error instanceof AuthMiddlewareError || error instanceof AuthorizationError) {
+    return NextResponse.json(
+      { error: error.message, error_code: error.code },
+      { status: error.status },
+    );
+  }
+
+  return null;
 }

--- a/src/lib/auth/serverAuthorization.ts
+++ b/src/lib/auth/serverAuthorization.ts
@@ -1,0 +1,64 @@
+import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import {
+  canAccessDashboardPath,
+  type AppRole,
+} from '@/lib/permissions/menuPermissions';
+
+export class AuthorizationError extends Error {
+  code: string;
+  status: number;
+
+  constructor(message: string, code = 'AUTH_FORBIDDEN', status = 403) {
+    super(message);
+    this.name = 'AuthorizationError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export function requireRoles(user: JwtUser, roles: AppRole[]) {
+  if (!roles.includes(user.rol as AppRole)) {
+    throw new AuthorizationError(
+      'El usuario no tiene permisos para realizar esta operación',
+      'AUTH_ROLE_FORBIDDEN',
+    );
+  }
+
+  return user;
+}
+
+export function requireDashboardPermission(user: JwtUser, pathname: string) {
+  const canAccess = canAccessDashboardPath(
+    user.rol,
+    user.permisos_menu ?? null,
+    pathname,
+  );
+
+  if (!canAccess) {
+    throw new AuthorizationError(
+      'El usuario no tiene permisos para acceder a este módulo',
+      'AUTH_PERMISSION_FORBIDDEN',
+    );
+  }
+
+  return user;
+}
+
+export function requireOwnSocioOrRoles(
+  user: JwtUser,
+  socioId: string,
+  elevatedRoles: AppRole[] = ['admin', 'usuario'],
+) {
+  if (elevatedRoles.includes(user.rol as AppRole)) {
+    return user;
+  }
+
+  if (user.rol !== 'socio' || !user.id_socio || user.id_socio !== socioId) {
+    throw new AuthorizationError(
+      'El usuario no puede consultar información de otro socio',
+      'AUTH_SOCIO_SCOPE_FORBIDDEN',
+    );
+  }
+
+  return user;
+}

--- a/src/lib/permissions/menuPermissions.ts
+++ b/src/lib/permissions/menuPermissions.ts
@@ -565,6 +565,14 @@ export const DASHBOARD_ROUTE_PERMISSIONS: DashboardRoutePermission[] = [
     exact: false,
   },
   {
+    // Ruta heredada que redirige a Empleados. Debe conservar el mismo
+    // permiso para no bloquear a usuarios internos autorizados antes del redirect.
+    path: "/dashboard/entrenadores",
+    permissionKey: "Empleados",
+    roles: ["admin", "usuario"],
+    exact: false,
+  },
+  {
     path: "/dashboard/asistencias/terminal",
     permissionKey: "Asistencias",
     roles: ["admin", "usuario"],

--- a/src/lib/security/uploadValidation.ts
+++ b/src/lib/security/uploadValidation.ts
@@ -1,0 +1,83 @@
+const MIME_ALIASES: Record<string, string> = {
+  'image/jpg': 'image/jpeg',
+};
+
+const SAFE_UPLOAD_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+function normalizeMimeType(value: string) {
+  const normalized = value.trim().toLowerCase();
+  return MIME_ALIASES[normalized] ?? normalized;
+}
+
+function startsWithBytes(buffer: Buffer, expected: number[]) {
+  if (buffer.length < expected.length) return false;
+  return expected.every((value, index) => buffer[index] === value);
+}
+
+function hasAscii(buffer: Buffer, offset: number, value: string) {
+  if (buffer.length < offset + value.length) return false;
+  return buffer.subarray(offset, offset + value.length).toString('ascii') === value;
+}
+
+function isHeifFamily(buffer: Buffer) {
+  if (!hasAscii(buffer, 4, 'ftyp') || buffer.length < 12) return false;
+
+  const majorBrand = buffer.subarray(8, 12).toString('ascii').toLowerCase();
+  return new Set([
+    'heic',
+    'heix',
+    'hevc',
+    'hevx',
+    'heim',
+    'heis',
+    'hevm',
+    'hevs',
+    'mif1',
+    'msf1',
+  ]).has(majorBrand);
+}
+
+export function isSafeUploadMimeType(mimeType: string) {
+  return SAFE_UPLOAD_MIME_TYPES.has(normalizeMimeType(mimeType));
+}
+
+export function hasSafeUploadSignature(buffer: Buffer, mimeType: string) {
+  const normalizedMimeType = normalizeMimeType(mimeType);
+
+  if (!isSafeUploadMimeType(normalizedMimeType)) return false;
+
+  switch (normalizedMimeType) {
+    case 'application/pdf':
+      return hasAscii(buffer, 0, '%PDF-');
+    case 'image/png':
+      return startsWithBytes(buffer, [
+        0x89,
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a,
+      ]);
+    case 'image/jpeg':
+      return startsWithBytes(buffer, [0xff, 0xd8, 0xff]);
+    case 'image/gif':
+      return hasAscii(buffer, 0, 'GIF87a') || hasAscii(buffer, 0, 'GIF89a');
+    case 'image/webp':
+      return hasAscii(buffer, 0, 'RIFF') && hasAscii(buffer, 8, 'WEBP');
+    case 'image/heic':
+    case 'image/heif':
+      return isHeifFamily(buffer);
+    default:
+      return false;
+  }
+}

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -1,22 +1,105 @@
 import { JwtUser } from '@/interfaces/jwtUser.interface';
-import * as jwt  from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
 
-export async function authMiddleware(req: Request) : Promise<{ user: JwtUser }> {
-    const token = req.headers.get("authorization")?.split(' ')[1];
-    
-    if (!token) {
-     throw new Error("Token no proporcionado");
-   }
-    
-    if(!process.env.JWT_SECRET){
-        throw new Error("JWT_SECRET no está definido en las variables de entorno");
+const APP_ROLES = new Set(['admin', 'usuario', 'socio', 'masteradmin']);
+
+export type AuthMiddlewareOptions = {
+  allowTerminalSession?: boolean;
+};
+
+export class AuthMiddlewareError extends Error {
+  code: string;
+  status: number;
+
+  constructor(message: string, code: string, status = 401) {
+    super(message);
+    this.name = 'AuthMiddlewareError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function getBearerToken(req: Request) {
+  const authorization = req.headers.get('authorization')?.trim() ?? '';
+  const [scheme, token, ...rest] = authorization.split(/\s+/);
+
+  if (scheme?.toLowerCase() !== 'bearer' || !token || rest.length > 0) {
+    return '';
+  }
+
+  return token;
+}
+
+function isValidJwtUser(value: unknown): value is JwtUser {
+  if (!value || typeof value !== 'object') return false;
+
+  const user = value as Partial<JwtUser>;
+
+  return Boolean(
+    typeof user.id === 'string' &&
+      user.id.trim().length > 0 &&
+      typeof user.email === 'string' &&
+      user.email.trim().length > 0 &&
+      typeof user.rol === 'string' &&
+      APP_ROLES.has(user.rol),
+  );
+}
+
+export async function authMiddleware(
+  req: Request,
+  options: AuthMiddlewareOptions = {},
+): Promise<{ user: JwtUser }> {
+  const token = getBearerToken(req);
+
+  if (!token) {
+    throw new AuthMiddlewareError(
+      'Token no proporcionado',
+      'AUTH_TOKEN_MISSING',
+    );
+  }
+
+  if (!process.env.JWT_SECRET) {
+    throw new AuthMiddlewareError(
+      'JWT_SECRET no está definido en las variables de entorno',
+      'AUTH_JWT_SECRET_MISSING',
+      500,
+    );
+  }
+
+  let decoded: string | jwt.JwtPayload;
+
+  try {
+    decoded = jwt.verify(token, process.env.JWT_SECRET);
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      throw new AuthMiddlewareError(
+        'Token expirado',
+        'AUTH_TOKEN_EXPIRED',
+      );
     }
 
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    if (!decoded || typeof decoded === 'string') {
-        throw new Error("Token inválido");
-    }
-    const user: JwtUser = decoded as JwtUser;
-    return { user };
+    throw new AuthMiddlewareError(
+      'Token inválido',
+      'AUTH_TOKEN_INVALID',
+    );
+  }
 
-    }
+  if (typeof decoded === 'string' || !isValidJwtUser(decoded)) {
+    throw new AuthMiddlewareError(
+      'Token inválido',
+      'AUTH_TOKEN_INVALID',
+    );
+  }
+
+  const user = decoded as JwtUser;
+
+  if (user.terminal_session && !options.allowTerminalSession) {
+    throw new AuthMiddlewareError(
+      'No autorizado: la sesión de Terminal no puede utilizarse en este endpoint',
+      'AUTH_TERMINAL_SCOPE_FORBIDDEN',
+      403,
+    );
+  }
+
+  return { user };
+}

--- a/src/services/adminRespaldoNegocioService.ts
+++ b/src/services/adminRespaldoNegocioService.ts
@@ -238,15 +238,50 @@ function businessBackupColumnLabel(column: ExportColumn, locale: BusinessBackupL
   return locale === 'en' ? BUSINESS_BACKUP_COLUMN_LABELS_EN[column.key] ?? column.label : column.label;
 }
 
-function safeBusinessBackupWorksheetName(name: string): string {
-  const safeName = String(name || 'Sheet')
-    .replace(/[\/*?:[]]/g, ' - ')
-    .replace(/s+-s+/g, ' - ')
-    .replace(/s{2,}/g, ' ')
-    .trim()
-    .slice(0, 31);
+const EXCEL_WORKSHEET_NAME_MAX_LENGTH = 31;
+const EXCEL_WORKSHEET_FORBIDDEN_CHARACTERS = /[\\/*?:\[\]]/g;
+const EXCEL_WORKSHEET_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/g;
 
-  return safeName || 'Sheet';
+function normalizeBusinessBackupWorksheetName(name: string, fallback: string): string {
+  const normalizedFallback = String(fallback || 'Sheet')
+    .replace(EXCEL_WORKSHEET_FORBIDDEN_CHARACTERS, ' ')
+    .replace(EXCEL_WORKSHEET_CONTROL_CHARACTERS, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/^'+|'+$/g, '')
+    .trim() || 'Sheet';
+
+  const normalizedName = String(name || '')
+    .replace(EXCEL_WORKSHEET_FORBIDDEN_CHARACTERS, ' - ')
+    .replace(EXCEL_WORKSHEET_CONTROL_CHARACTERS, ' ')
+    .replace(/\s*-\s*/g, ' - ')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/^'+|'+$/g, '')
+    .trim();
+
+  return (normalizedName || normalizedFallback)
+    .slice(0, EXCEL_WORKSHEET_NAME_MAX_LENGTH)
+    .trim();
+}
+
+function reserveBusinessBackupWorksheetName(
+  name: string,
+  usedNames: Set<string>,
+  fallback: string
+): string {
+  const baseName = normalizeBusinessBackupWorksheetName(name, fallback);
+  let candidate = baseName;
+  let sequence = 2;
+
+  while (usedNames.has(candidate.toLocaleLowerCase('en-US'))) {
+    const suffix = ` (${sequence})`;
+    const availableLength = EXCEL_WORKSHEET_NAME_MAX_LENGTH - suffix.length;
+    const prefix = baseName.slice(0, availableLength).trimEnd();
+    candidate = `${prefix || normalizeBusinessBackupWorksheetName(fallback, 'Sheet').slice(0, availableLength)}${suffix}`;
+    sequence += 1;
+  }
+
+  usedNames.add(candidate.toLocaleLowerCase('en-US'));
+  return candidate;
 }
 
 export const RESPLADO_NEGOCIO_MODULES: ExportModuleDefinition[] = [
@@ -726,7 +761,14 @@ async function buildXlsx(
   workbook.creator = 'Gym Master';
   workbook.created = new Date();
 
-  const resumen = workbook.addWorksheet(safeBusinessBackupWorksheetName(businessBackupText(locale, 'Resumen', 'Summary')));
+  const usedWorksheetNames = new Set<string>();
+  const worksheetFallback = businessBackupText(locale, 'Hoja', 'Sheet');
+  const summaryWorksheetName = reserveBusinessBackupWorksheetName(
+    businessBackupText(locale, 'Resumen', 'Summary'),
+    usedWorksheetNames,
+    worksheetFallback
+  );
+  const resumen = workbook.addWorksheet(summaryWorksheetName);
   resumen.columns = [
     { header: businessBackupText(locale, 'Módulo', 'Module'), key: 'modulo', width: 34 },
     { header: businessBackupText(locale, 'Tabla origen', 'Source table'), key: 'tabla', width: 28 },
@@ -755,7 +797,11 @@ async function buildXlsx(
   resumen.views = [{ state: 'frozen', ySplit: 1 }];
 
   moduleRows.forEach(({ module, rows }) => {
-    const worksheetName = safeBusinessBackupWorksheetName(businessBackupModuleLabel(module, locale));
+    const worksheetName = reserveBusinessBackupWorksheetName(
+      businessBackupModuleLabel(module, locale),
+      usedWorksheetNames,
+      worksheetFallback
+    );
     const worksheet = workbook.addWorksheet(worksheetName);
     worksheet.columns = module.columns.map((column) => ({
       header: businessBackupColumnLabel(column, locale),

--- a/src/services/browser/cuotasPagosBiApiClient.ts
+++ b/src/services/browser/cuotasPagosBiApiClient.ts
@@ -1,3 +1,4 @@
+import { authHeader } from '@/services/storageService';
 import { CuotasPagosDashboardBiResponse } from "@/interfaces/cuotasPagosBi.interface";
 
 async function parseResponse<T>(res: Response): Promise<T> {
@@ -14,6 +15,7 @@ async function parseResponse<T>(res: Response): Promise<T> {
 export async function getCuotasPagosDashboardBi(): Promise<CuotasPagosDashboardBiResponse> {
   const res = await fetch("/api/admin/cuotas/dashboard-bi", {
     method: "GET",
+    headers: authHeader(),
     cache: "no-store",
   });
 

--- a/src/services/dietaService.ts
+++ b/src/services/dietaService.ts
@@ -1,15 +1,53 @@
 import { CreateDietaDto, Dieta } from '@/interfaces/dieta.interface';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
+import { AuthorizationError } from '@/lib/auth/serverAuthorization';
 import { conexionBD } from '@/middlewares/conexionBd.middleware';
+
+const isManager = (role?: string | null) =>
+  role === 'admin' || role === 'usuario';
+
+async function resolveOwnSocioId(user: JwtUser): Promise<string> {
+  if (user.rol !== 'socio') {
+    throw new AuthorizationError('No autorizado: la identidad no corresponde a un socio', 'AUTH_ROLE_FORBIDDEN');
+  }
+
+  if (user.id_socio) return user.id_socio;
+
+  const supabase = conexionBD();
+  const { data, error } = await supabase
+    .from('socio')
+    .select('id_socio')
+    .eq('usuario_id', user.id)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data?.id_socio) {
+    throw new Error('No se pudo identificar el socio asociado al usuario');
+  }
+
+  return data.id_socio as string;
+}
+
+async function authorizeSocioTarget(user: JwtUser, requestedSocioId: string) {
+  if (isManager(user.rol)) return requestedSocioId;
+
+  const ownSocioId = await resolveOwnSocioId(user);
+  if (requestedSocioId !== ownSocioId) {
+    throw new AuthorizationError('No autorizado para consultar o modificar dietas de otro socio', 'AUTH_SOCIO_SCOPE_FORBIDDEN');
+  }
+
+  return ownSocioId;
+}
 
 export const createDietaSocio = async (
   createDieta: CreateDietaDto,
   user: JwtUser
 ) => {
+  const socioId = await authorizeSocioTarget(user, createDieta.socio_id);
   const supabase = conexionBD();
 
   const { error } = await supabase.rpc('genera_dieta_socio', {
-    p_socio_id: createDieta.socio_id,
+    p_socio_id: socioId,
     p_objetivo_id: createDieta.objetivo,
     p_fecha_inicio: createDieta.fecha_inicio,
     p_fecha_fin: createDieta.fecha_fin,
@@ -21,21 +59,19 @@ export const createDietaSocio = async (
     throw new Error('Error al generar la dieta: ' + error.message);
   }
 
-  // El procedimiento almacenado genera la dieta; luego se consulta la última dieta creada.
-  const ultimaDieta = await getUltimaDietaSocio(createDieta.socio_id, user);
-
-  return ultimaDieta;
+  return getUltimaDietaSocio(socioId, user);
 };
 
 export const getAllDietasSocio = async (
   id: string,
   user: JwtUser
 ): Promise<Dieta[]> => {
+  const socioId = await authorizeSocioTarget(user, id);
   const supabase = conexionBD();
   const { data, error } = await supabase
     .from('dieta')
     .select('*')
-    .eq('socio_id', id)
+    .eq('socio_id', socioId)
     .order('created_at', { ascending: false });
 
   if (error) {
@@ -47,6 +83,10 @@ export const getAllDietasSocio = async (
 };
 
 export const getAllDietas = async (user: JwtUser): Promise<Dieta[]> => {
+  if (!isManager(user.rol)) {
+    throw new AuthorizationError('No autorizado para consultar todas las dietas', 'AUTH_ROLE_FORBIDDEN');
+  }
+
   const supabase = conexionBD();
   const { data, error } = await supabase
     .from('dieta')
@@ -84,25 +124,28 @@ export const getDietaById = async (
     throw new Error('Error al obtener la dieta: ' + error.message);
   }
 
-  return data ?? null;
+  if (!data) return null;
+  await authorizeSocioTarget(user, String(data.socio_id));
+  return data as Dieta;
 };
 
 export const getUltimaDietaSocio = async (
   id: string,
   user: JwtUser
 ): Promise<Dieta> => {
+  const socioId = await authorizeSocioTarget(user, id);
   const supabase = conexionBD();
-  const { data: ultimaDietaData, error: ultimaDietaError } = await supabase
+  const { data, error } = await supabase
     .from('dieta')
     .select('*')
-    .eq('socio_id', id)
+    .eq('socio_id', socioId)
     .order('created_at', { ascending: false })
     .limit(1)
     .single();
 
-  if (ultimaDietaError) {
-    throw new Error('Error al consultar la última dieta: ' + ultimaDietaError.message);
+  if (error) {
+    throw new Error('Error al consultar la última dieta: ' + error.message);
   }
 
-  return ultimaDietaData;
+  return data as Dieta;
 };

--- a/src/services/equipamientoPreventivoClient.ts
+++ b/src/services/equipamientoPreventivoClient.ts
@@ -1,3 +1,4 @@
+import { authHeader } from '@/services/storageService';
 import type {
   CreateEquipamientoOrdenTecnicaDTO,
   CreateEquipamientoPlanPreventivoDTO,
@@ -19,6 +20,7 @@ export async function getEquipamientosPreventivosDashboardClient() {
   return parseJsonResponse<EquipamientoPreventivosDashboard>(
     await fetch('/api/equipamientos/preventivos', {
       method: 'GET',
+      headers: authHeader(),
       cache: 'no-store',
     }),
   );
@@ -27,7 +29,7 @@ export async function getEquipamientosPreventivosDashboardClient() {
 export async function createEquipamientoPlanPreventivoClient(payload: CreateEquipamientoPlanPreventivoDTO) {
   const response = await fetch('/api/equipamientos/preventivos/planes', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: EquipamientoPlanPreventivo }>(response);
@@ -36,7 +38,7 @@ export async function createEquipamientoPlanPreventivoClient(payload: CreateEqui
 export async function createEquipamientoOrdenTecnicaClient(payload: CreateEquipamientoOrdenTecnicaDTO) {
   const response = await fetch('/api/equipamientos/preventivos/ordenes', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: EquipamientoOrdenTecnica }>(response);
@@ -45,7 +47,7 @@ export async function createEquipamientoOrdenTecnicaClient(payload: CreateEquipa
 export async function updateEquipamientoOrdenTecnicaClient(id: string, payload: UpdateEquipamientoOrdenTecnicaDTO) {
   const response = await fetch(`/api/equipamientos/preventivos/ordenes/${id}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: EquipamientoOrdenTecnica }>(response);

--- a/src/services/equipamientoService.ts
+++ b/src/services/equipamientoService.ts
@@ -3,6 +3,7 @@ import { AlertasMantenimientoEquipamientoResponse } from "@/interfaces/equipamie
 import { EquipamientoMantenimientoBiResponse } from "@/interfaces/equipamientoMantenimientoBi.interface";
 import { TipoEquipamiento } from "@/enums/tipoEquipamiento.enum";
 import { getSupabaseClient, supabase } from "./supabaseClient";
+import { authHeader } from "./storageService";
 import dayjs from "dayjs";
 
 export const getAllEquipamientos = async () : Promise<Equipamento[]> => {
@@ -145,6 +146,7 @@ export const getAlertasMantenimientoEquipamientos = async (
     `/api/equipamientos/alertas-mantenimiento?umbralDias=${umbralDias}`,
     {
       method: "GET",
+      headers: authHeader(),
       cache: "no-store",
     }
   );
@@ -162,6 +164,7 @@ export const getAlertasMantenimientoEquipamientos = async (
 export const getEquipamientoMantenimientoBi = async (): Promise<EquipamientoMantenimientoBiResponse> => {
   const response = await fetch("/api/equipamientos/mantenimiento-bi", {
     method: "GET",
+    headers: authHeader(),
     cache: "no-store",
   });
 

--- a/src/services/evolucionSocioService.ts
+++ b/src/services/evolucionSocioService.ts
@@ -3,6 +3,7 @@ import {
   EvolucionSocio,
 } from "@/interfaces/evolucionSocio.interface";
 import { JwtUser } from "@/interfaces/jwtUser.interface";
+import { AuthorizationError } from "@/lib/auth/serverAuthorization";
 import { conexionBD } from "@/middlewares/conexionBd.middleware";
 
 const round2 = (value: number) => Number(value.toFixed(2));
@@ -44,25 +45,48 @@ const normalizarFecha = (fecha?: string | null) => {
 
 const isSocioRole = (rol?: string) => (rol || "").toLowerCase().includes("socio");
 
+async function resolveOwnSocioId(user: JwtUser): Promise<string> {
+  if (!isSocioRole(user.rol)) {
+    throw new AuthorizationError("No autorizado: la identidad no corresponde a un socio", "AUTH_ROLE_FORBIDDEN");
+  }
+
+  if (user.id_socio) return user.id_socio;
+
+  const supabase = conexionBD();
+  const { data, error } = await supabase
+    .from("socio")
+    .select("id_socio")
+    .eq("usuario_id", user.id)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data?.id_socio) {
+    throw new Error("El usuario no tiene un socio asociado");
+  }
+
+  return data.id_socio as string;
+}
+
 export const createEvolucionSocio = async (
   createEvolucionSocio: CreateEvolucionSocioDto,
   user: JwtUser
 ) => {
   const supabase = conexionBD();
 
-  const socioId = createEvolucionSocio.socio_id || user.id_socio;
+  let socioId = createEvolucionSocio.socio_id || user.id_socio;
+
+  if (isSocioRole(user.rol)) {
+    const ownSocioId = await resolveOwnSocioId(user);
+
+    if (createEvolucionSocio.socio_id && createEvolucionSocio.socio_id !== ownSocioId) {
+      throw new AuthorizationError("No autorizado para registrar evolución de otro socio", "AUTH_SOCIO_SCOPE_FORBIDDEN");
+    }
+
+    socioId = ownSocioId;
+  }
 
   if (!socioId) {
     throw new Error("El usuario no tiene un socio asociado");
-  }
-
-  if (
-    createEvolucionSocio.socio_id &&
-    isSocioRole(user.rol) &&
-    user.id_socio &&
-    createEvolucionSocio.socio_id !== user.id_socio
-  ) {
-    throw new Error("No autorizado para registrar evolución de otro socio");
   }
 
   const peso = normalizarNumero(createEvolucionSocio.peso);
@@ -199,12 +223,11 @@ export const findAllEvolucionesSocioByIdSocio = async (
     throw new Error("Debe indicar un socio");
   }
 
-  if (
-    isSocioRole(user.rol) &&
-    user.id_socio &&
-    socio_id !== user.id_socio
-  ) {
-    throw new Error("No autorizado para consultar evolución de otro socio");
+  if (isSocioRole(user.rol)) {
+    const ownSocioId = await resolveOwnSocioId(user);
+    if (socio_id !== ownSocioId) {
+      throw new AuthorizationError("No autorizado para consultar evolución de otro socio", "AUTH_SOCIO_SCOPE_FORBIDDEN");
+    }
   }
 
   const { data, error } = await supabase

--- a/src/services/infraestructuraMantenimientoClient.ts
+++ b/src/services/infraestructuraMantenimientoClient.ts
@@ -1,3 +1,4 @@
+import { authHeader } from '@/services/storageService';
 import type {
   CreateInfraestructuraActivoDTO,
   CreateInfraestructuraChecklistEjecucionDTO,
@@ -27,6 +28,7 @@ export async function getInfraestructuraMantenimientoDashboardClient() {
   return parseJsonResponse<InfraestructuraMantenimientoDashboard>(
     await fetch('/api/infraestructura/mantenimiento-edilicio', {
       method: 'GET',
+      headers: authHeader(),
       cache: 'no-store',
     }),
   );
@@ -35,7 +37,7 @@ export async function getInfraestructuraMantenimientoDashboardClient() {
 export async function createInfraestructuraSectorClient(payload: CreateInfraestructuraSectorDTO) {
   const response = await fetch('/api/infraestructura/sectores', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: InfraestructuraSector }>(response);
@@ -44,7 +46,7 @@ export async function createInfraestructuraSectorClient(payload: CreateInfraestr
 export async function createInfraestructuraActivoClient(payload: CreateInfraestructuraActivoDTO) {
   const response = await fetch('/api/infraestructura/activos', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: InfraestructuraActivo }>(response);
@@ -53,7 +55,7 @@ export async function createInfraestructuraActivoClient(payload: CreateInfraestr
 export async function createMantenimientoEdilicioOrdenClient(payload: CreateMantenimientoEdilicioOrdenDTO) {
   const response = await fetch('/api/infraestructura/ordenes', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: MantenimientoEdilicioOrden }>(response);
@@ -65,7 +67,7 @@ export async function updateMantenimientoEdilicioOrdenClient(
 ) {
   const response = await fetch(`/api/infraestructura/ordenes/${id}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: MantenimientoEdilicioOrden }>(response);
@@ -77,6 +79,7 @@ export async function getInfraestructuraQrLabelsDashboardClient() {
   return parseJsonResponse<InfraestructuraQrLabelsDashboard>(
     await fetch('/api/infraestructura/qr/labels', {
       method: 'GET',
+      headers: authHeader(),
       cache: 'no-store',
     }),
   );
@@ -85,7 +88,7 @@ export async function getInfraestructuraQrLabelsDashboardClient() {
 export async function createInfraestructuraQrCodeClient(payload: CreateInfraestructuraQrDTO) {
   const response = await fetch('/api/infraestructura/qr', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: InfraestructuraQrCodigo }>(response);
@@ -94,6 +97,7 @@ export async function createInfraestructuraQrCodeClient(payload: CreateInfraestr
 export async function resolveInfraestructuraQrCodeClient(codigo: string) {
   const response = await fetch(`/api/infraestructura/qr/resolve?codigo=${encodeURIComponent(codigo)}`, {
     method: 'GET',
+    headers: authHeader(),
     cache: 'no-store',
   });
   return parseJsonResponse<{ message?: string; data: InfraestructuraQrResolveResult }>(response);
@@ -102,7 +106,7 @@ export async function resolveInfraestructuraQrCodeClient(codigo: string) {
 export async function createInfraestructuraChecklistEjecucionClient(payload: CreateInfraestructuraChecklistEjecucionDTO) {
   const response = await fetch('/api/infraestructura/checklists/ejecuciones', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
     body: JSON.stringify(payload),
   });
   return parseJsonResponse<{ message: string; data: InfraestructuraChecklistEjecucion }>(response);

--- a/src/services/rutinaService.ts
+++ b/src/services/rutinaService.ts
@@ -1,6 +1,7 @@
 import { GeneracionRutina, Rutina } from "@/interfaces/rutina.interface";
 import { getSupabaseClient } from "./supabaseClient";
 import { JwtUser } from "@/interfaces/jwtUser.interface";
+import { AuthorizationError } from "@/lib/auth/serverAuthorization";
 import { getSocioByIdUsuario } from "./socioService";
 
 const isValidUUID = (value?: string | null): value is string => {
@@ -11,10 +12,14 @@ const isValidUUID = (value?: string | null): value is string => {
   );
 };
 
-const isAdmin = (rol?: string | null): boolean => {
+const isManager = (rol?: string | null): boolean => {
   const normalizedRol = rol?.trim().toLowerCase();
 
-  return normalizedRol === "admin" || normalizedRol === "administrador";
+  return (
+    normalizedRol === "admin" ||
+    normalizedRol === "administrador" ||
+    normalizedRol === "usuario"
+  );
 };
 
 type RutinaAdminRow = Omit<Rutina, "socio"> & {
@@ -25,32 +30,37 @@ const resolveIdSocioForRutina = async (
   user: JwtUser,
   rutina: GeneracionRutina
 ): Promise<string> => {
-  const idSocioFromBody = rutina.id_socio ?? rutina.idSocio;
+  const requestedSocioId = rutina.id_socio ?? rutina.idSocio;
 
-  // Caso admin o generación explícita: el endpoint puede enviar el socio destino.
-  if (isValidUUID(idSocioFromBody)) {
-    return idSocioFromBody.trim();
-  }
+  if (user.rol === "socio") {
+    let ownSocioId = isValidUUID(user.id_socio) ? user.id_socio.trim() : null;
 
-  // Caso socio logueado: normalmente viene en el JWT.
-  if (isValidUUID(user.id_socio)) {
-    return user.id_socio.trim();
-  }
-
-  // Fallback robusto: si el token quedó viejo/incompleto, buscar el socio por usuario_id.
-  if (!isAdmin(user.rol) && isValidUUID(user.id)) {
-    const socio = await getSocioByIdUsuario(user.id);
-
-    if (isValidUUID(socio?.id_socio)) {
-      return socio.id_socio.trim();
+    if (!ownSocioId && isValidUUID(user.id)) {
+      const socio = await getSocioByIdUsuario(user.id);
+      ownSocioId = isValidUUID(socio?.id_socio) ? socio.id_socio.trim() : null;
     }
+
+    if (!ownSocioId) {
+      throw new Error(
+        "No se pudo determinar el id_socio del socio autenticado para generar la rutina."
+      );
+    }
+
+    if (isValidUUID(requestedSocioId) && requestedSocioId.trim() !== ownSocioId) {
+      throw new AuthorizationError("No autorizado para generar una rutina para otro socio", "AUTH_SOCIO_SCOPE_FORBIDDEN");
+    }
+
+    return ownSocioId;
+  }
+
+  if (isManager(user.rol) && isValidUUID(requestedSocioId)) {
+    return requestedSocioId.trim();
   }
 
   throw new Error(
-    "No se pudo determinar el id_socio para generar rutina. El socio debe tener perfil asociado o el request debe enviar id_socio."
+    "No se pudo determinar el id_socio para generar rutina. Un gestor autorizado debe indicar el socio destino."
   );
 };
-
 
 const resolveIdSocioForAuthenticatedUser = async (
   user: JwtUser
@@ -59,7 +69,7 @@ const resolveIdSocioForAuthenticatedUser = async (
     return user.id_socio.trim();
   }
 
-  if (!isAdmin(user.rol) && isValidUUID(user.id)) {
+  if (!isManager(user.rol) && isValidUUID(user.id)) {
     const socio = await getSocioByIdUsuario(user.id);
 
     if (isValidUUID(socio?.id_socio)) {
@@ -206,7 +216,7 @@ export const historialRutinasAdmin = async (
 export const historialRutinaSocioLogueado = async (
   user: JwtUser
 ): Promise<Rutina[]> => {
-  if (isAdmin(user.rol)) {
+  if (isManager(user.rol)) {
     return historialRutinasAdmin(user);
   }
 
@@ -251,6 +261,14 @@ export const historialRutinaSocio = async (
     return [];
   }
 
+  if (!isManager(user.rol)) {
+    const ownSocioId = await resolveIdSocioForAuthenticatedUser(user);
+
+    if (!ownSocioId || ownSocioId !== id_socio.trim()) {
+      throw new AuthorizationError("No autorizado para consultar rutinas de otro socio", "AUTH_SOCIO_SCOPE_FORBIDDEN");
+    }
+  }
+
   const { data, error } = await supabase
     .from("rutina")
     .select("*")
@@ -287,7 +305,7 @@ export const eliminarRutina = async (
     throw new Error("No se encontró la rutina");
   }
 
-  if (!isAdmin(user.rol)) {
+  if (!isManager(user.rol)) {
     const idSocio = await resolveIdSocioForAuthenticatedUser(user);
 
     if (!idSocio || rutina.id_socio !== idSocio) {

--- a/src/services/server/rutinaServerService.ts
+++ b/src/services/server/rutinaServerService.ts
@@ -1,4 +1,5 @@
 import { JwtUser } from '@/interfaces/jwtUser.interface';
+import { AuthorizationError } from '@/lib/auth/serverAuthorization';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 
 const isValidUUID = (value?: string | null): value is string => {
@@ -9,10 +10,14 @@ const isValidUUID = (value?: string | null): value is string => {
   );
 };
 
-const isAdmin = (rol?: string | null): boolean => {
+const isManager = (rol?: string | null): boolean => {
   const normalizedRol = rol?.trim().toLowerCase();
 
-  return normalizedRol === 'admin' || normalizedRol === 'administrador';
+  return (
+    normalizedRol === 'admin' ||
+    normalizedRol === 'administrador' ||
+    normalizedRol === 'usuario'
+  );
 };
 
 const resolveUserSocioId = async (user: JwtUser): Promise<string | null> => {
@@ -65,11 +70,11 @@ export const deleteRutinaById = async (
     throw new Error('Rutina no encontrada');
   }
 
-  if (!isAdmin(user.rol)) {
+  if (!isManager(user.rol)) {
     const idSocioUsuario = await resolveUserSocioId(user);
 
     if (!idSocioUsuario || idSocioUsuario !== rutina.id_socio) {
-      throw new Error('No autorizado para eliminar esta rutina');
+      throw new AuthorizationError('No autorizado para eliminar esta rutina', 'AUTH_SOCIO_SCOPE_FORBIDDEN');
     }
   }
 

--- a/src/services/server/socioServerService.ts
+++ b/src/services/server/socioServerService.ts
@@ -1,5 +1,6 @@
 import { CreateSocioDto, Socio, UpdateSocioDto } from '@/interfaces/socio.interface';
 import { JwtUser } from '@/interfaces/jwtUser.interface';
+import { AuthorizationError } from '@/lib/auth/serverAuthorization';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 
 const allowedManagerRoles = new Set(['admin', 'usuario']);
@@ -148,11 +149,30 @@ export const getSocioByIdServer = async (
   user: JwtUser,
   id_socio: string
 ): Promise<Socio> => {
-  if (user.rol === 'socio' && user.id_socio !== id_socio) {
-    throw new Error('No autorizado para consultar este socio');
+  const supabase = getSupabaseServerClient();
+
+  if (user.rol === 'socio') {
+    let ownSocioId = user.id_socio ?? null;
+
+    if (!ownSocioId) {
+      const { data: ownSocio, error: ownSocioError } = await supabase
+        .from('socio')
+        .select('id_socio')
+        .eq('usuario_id', user.id)
+        .maybeSingle();
+
+      if (ownSocioError) throw new Error(ownSocioError.message);
+      ownSocioId = ownSocio?.id_socio ?? null;
+    }
+
+    if (!ownSocioId || ownSocioId !== id_socio) {
+      throw new AuthorizationError(
+        'No autorizado para consultar este socio',
+        'AUTH_SOCIO_SCOPE_FORBIDDEN',
+      );
+    }
   }
 
-  const supabase = getSupabaseServerClient();
   const { data, error } = await supabase
     .from('socio')
     .select(


### PR DESCRIPTION
# security: complete final authentication and RBAC audit

## Resumen

Esta Pull Request completa la auditoría final de autenticación, autorización y control de acceso por roles de Gym Master sobre la rama `feature/security-auth-rbac-final-audit-v1`.

La implementación fortalece la frontera de seguridad de Next.js mediante validación estricta de JWT, aislamiento de sesiones de Terminal, RBAC server-side por módulo, control de propiedad de recursos personales, clasificación explícita de todas las API Routes y endurecimiento de endpoints públicos e internos. También incorpora validación real de archivos, protección SSRF del proxy de imágenes y un hotfix detectado durante QA para la exportación XLSX del respaldo del negocio.

## Motivación

Antes de esta auditoría coexistían rutas con distintos niveles de protección: algunas verificaban JWT, otras dependían de guards del cliente y varias APIs heredadas no aplicaban de forma uniforme rol, permiso o propiedad del recurso. La Terminal de asistencia utilizaba un JWT de larga duración que debía quedar restringido a un alcance mínimo.

El objetivo de esta rama es que ninguna API quede pública por omisión y que cada operación privada aplique, según corresponda:

1. JWT válido mediante `Authorization: Bearer <token>`.
2. Rechazo de tokens de Terminal fuera de su alcance.
3. Rol autorizado.
4. Permiso real del módulo.
5. Propiedad del socio o de la cuenta.
6. Exposición mínima de datos.
7. Respuestas `401` y `403` coherentes, sin transformar rechazos en `500`.

## Alcance consolidado

- **197 archivos únicos alcanzados por los parches de la rama.**
- **175 archivos `route.ts` clasificados explícitamente.**
- Helpers server-side reutilizables para autenticación, rol, permiso y propiedad.
- Clientes browser actualizados para enviar Bearer en APIs ahora protegidas.
- Validación de cargas por MIME y firma binaria.
- Protección SSRF en `/api/image-proxy`.
- Aislamiento de Master Admin y licencia Dragon Pyramid.
- Confirmación Stripe vinculada a la cuenta del socio autenticado.
- Redacción de información en la verificación pública de recibos.
- Sanitización segura de nombres de hojas XLSX en Respaldo del negocio.

## Commits de la rama

```text
c03d2ca security: harden terminal session auth scope
1e49406 security: enforce RBAC across legacy API families
2e0c18f security: enforce ownership across sensitive resources
9d366a1 security: complete final authentication and RBAC audit
```

## Cambios por bloque

### Bloque 1 — Fundación Auth/RBAC y aislamiento de Terminal

- Validación estricta de `Authorization: Bearer <token>`.
- Validación del payload JWT y roles reconocidos.
- Error tipado de autorización mediante estado HTTP y código.
- Rechazo predeterminado de `terminal_session: true`.
- Opt-in exclusivo para:
  - `GET /api/asistencias/qr-dia`
  - `GET /api/asistencias/recientes`
  - `GET /api/notificaciones/terminal`
- Verificación server-side del permiso `Asistencias`.
- Incorporación de `src/lib/auth/serverAuthorization.ts`.
- Gate automático `npm run test:auth-rbac`.

### Bloque 2 — APIs heredadas y permisos por familia

Se protegieron 40 rutas de:

- Actividades, turnos, cupos e inscripciones.
- Avisos.
- BI de cuotas y pagos.
- Equipamientos, alertas, mantenimiento BI y preventivos.
- Infraestructura edilicia, activos, sectores, órdenes, checklists y QR.
- Mantenimientos.
- Productos, historial y movimientos de stock.
- Proveedores.
- Servicios.

Se agregaron permisos simples y múltiples por dominio, compatibilidad controlada entre módulos compartidos y Bearer en los clientes browser afectados.

### Bloque 3 — Recursos sensibles y propiedad

- Aislamiento por socio en detalle, ficha médica, pagos, rutinas, dietas y evolución física.
- Resolución del socio desde JWT o relación `usuario_id`; no se confía en IDs manipulables del navegador.
- RBAC en mensajes, notificaciones y analítica sensible.
- Aislamiento exclusivo de Master Admin para licencia y reactivación.
- Respuesta reducida del estado de suspensión para socios.
- Verificación pública de recibos sin correo electrónico del socio.
- Propiedad de fotografía y archivos personales vinculada al usuario autenticado.

### Bloque 4 — Final sweep y fronteras públicas/internas

El verificador clasifica las 175 API Routes actuales:

| Categoría | Cantidad |
|---|---:|
| Terminal con opt-in | 3 |
| APIs heredadas protegidas | 40 |
| APIs sensibles de dashboard | 24 |
| APIs personales por socio | 20 |
| APIs operativas del barrido final | 68 |
| APIs personales/cuenta propia finales | 3 |
| APIs autenticadas transversales | 6 |
| APIs públicas o internas explícitas | 11 |
| **Total** | **175** |

Familias terminadas en este barrido:

- Asistencias, aforo, ranking y métricas.
- Empleados, sueldos, entrenadores y usuarios.
- Parametrización del gimnasio, niveles y objetivos.
- Caja, POS/Kiosco, compras, ventas, stock y finanzas.
- Soporte y tickets.
- Respaldo y exportación.
- Coach IA, corpus RAG, ingesta, búsqueda y vectorización.
- Media de ejercicios.

## Políticas públicas e internas explícitas

| Política | Familia | Control principal |
|---|---|---|
| `PUBLIC_AUTH_PROVIDER` | NextAuth | Proveedor de autenticación |
| `PUBLIC_LOGIN` | Login personalizado | Credenciales y rol solicitado |
| `PUBLIC_RECOVERY` | Solicitud de recuperación | Flujo controlado |
| `PUBLIC_RECOVERY_TOKEN` | Reset de contraseña | Token válido |
| `TERMINAL_BEARER_REFRESH` | Renovación de Terminal | JWT normal + permiso Asistencias |
| `PUBLIC_TOKEN` | Scanner móvil | Token aleatorio, expiración y estado |
| `PUBLIC_VERIFICATION_CODE` | Recibo público | ID + código, exposición mínima |
| `PUBLIC_SIGNED_WEBHOOK` | Stripe webhook | Firma `stripe-signature` |
| `PUBLIC_DOCUMENTATION` | Swagger JSON | Exposición intencional |
| `PUBLIC_CONTROLLED` | Proxy de imágenes | URL, red, redirecciones, tipo y tamaño |
| `INTERNAL_SHARED_SECRET` | Sincronización de licencia | Secreto dedicado y comparación segura |

## Hardening adicional

### Uploads

Se incorpora `src/lib/security/uploadValidation.ts` para validar MIME y firma binaria antes de Cloudinary/Storage.

Aplicado a:

- Foto de perfil.
- Logo del gimnasio.
- Media de ejercicios.
- Comprobantes de gastos.

Formatos permitidos: PNG, JPEG, WEBP, GIF, HEIC/HEIF y PDF solo para comprobantes. SVG se rechaza.

### Proxy de imágenes

`/api/image-proxy` ahora:

- acepta solo HTTP/HTTPS;
- rechaza credenciales y puertos no permitidos;
- bloquea localhost e IP privadas, loopback, link-local, reservadas y multicast;
- valida DNS y cada redirección;
- limita a tres redirecciones;
- exige `Content-Type: image/*`;
- limita la respuesta a 10 MB;
- devuelve `X-Content-Type-Options: nosniff`.

### Confirmación Stripe

`/api/pagar-cuota/confirmar` valida:

```text
metadata.usuario_id === user.id
metadata.socio_id   === user.id_socio
```

Una sesión ajena, incompleta o manipulada responde `403`.

### Endpoint de diagnóstico

`/api/test-alertas` requiere administrador y responde `404` en producción.

## Hotfix incluido — exportación XLSX

Durante el QA final se detectó que los nombres de hojas con caracteres prohibidos por Excel provocaban errores, por ejemplo:

```text
Gastos / egresos
```

La corrección:

- elimina `\ / * ? : [ ]` y caracteres de control;
- limita nombres a 31 caracteres;
- elimina apóstrofes iniciales/finales;
- genera nombres alternativos si quedan vacíos;
- resuelve duplicados con `(2)`, `(3)`, etc.;
- aplica la regla a Resumen y los 18 módulos exportables.

Resultado:

```text
Gastos / egresos → Gastos - egresos
```

La exportación JSON no cambia.

## Validación automática

Ejecutado satisfactoriamente:

```bash
rm -rf .next

npm run build &&
npm run test:pwa-cache &&
npm run test:pwa-install-update &&
npm run test:auth-rbac &&
npm run test:business-backup-export
```

Resultados confirmados:

- Build optimizado de Next.js 14 aprobado.
- TypeScript y lint aprobados.
- Política PWA/cache aprobada.
- Instalación y actualización PWA aprobadas.
- Clasificación de 175 API Routes aprobada.
- Aislamiento de Terminal, socio, cuenta propia y Master Admin aprobado.
- Bearer en clientes críticos aprobado.
- Validación de uploads aprobada.
- Endpoints públicos controlados aprobados.
- Sanitización de hojas XLSX aprobada.

## QA manual aprobado

La matriz manual fue completada con éxito:

- Administrador.
- Usuario interno con permisos.
- Usuario interno sin permisos.
- Socio propietario.
- Socio A intentando recursos de Socio B.
- Master Admin.
- Solicitudes sin token.
- Token de Terminal fuera de alcance.
- URLs directas y menús por rol.
- Logout, botón Atrás y pestañas antiguas.
- Uploads válidos e inválidos por firma.
- Proxy de imágenes y destinos SSRF prohibidos.
- Webhook Stripe sin firma.
- Scanner móvil y recibo público.
- Sincronización interna de licencia.
- Exportación JSON y XLSX de los 18 módulos.

No se observaron filtraciones de datos, errores `500` por autorización ni regresiones funcionales.

## Base de datos

Esta PR **no modifica**:

- tablas;
- migraciones;
- políticas RLS;
- RPC;
- seeds;
- datos persistidos;
- backups;
- configuración sensible.

La seguridad multi-tenant definitiva a nivel de Supabase se revisará en `feature/database-rls-final-audit-v1`.

## Riesgos y consideraciones

- El control implementado fortalece la frontera Next.js; no reemplaza RLS.
- Los endpoints públicos de login, recuperación, scanner e image proxy deben recibir rate limiting en plataforma/edge para producción.
- Se recomienda mantener restricciones de egress/red a nivel de infraestructura como defensa adicional al SSRF.
- Una nueva API Route sin clasificación hará fallar `npm run test:auth-rbac`.

## Rollback

No existen migraciones ni cambios persistentes que revertir. El rollback puede realizarse revirtiendo los cuatro commits de la rama o el merge de la PR.

## Checklist

- [x] Build de producción aprobado.
- [x] `test:pwa-cache` aprobado.
- [x] `test:pwa-install-update` aprobado.
- [x] `test:auth-rbac` aprobado.
- [x] `test:business-backup-export` aprobado.
- [x] Matriz manual por roles aprobada.
- [x] Pruebas de propiedad cruzada aprobadas.
- [x] Pruebas públicas/internas aprobadas.
- [x] Pruebas de uploads y SSRF aprobadas.
- [x] Exportación XLSX/JSON aprobada.
- [x] Sin DB, SQL, RLS, RPC ni secretos en el cambio.
