### PR TITLE
security: complete HTTP runtime hardening audit

### DIFF
--- a/docs/security/security-http-runtime-hardening-final-v1-baseline.md
+++ b/docs/security/security-http-runtime-hardening-final-v1-baseline.md
@@ -1,0 +1,167 @@
+# Security HTTP Runtime Hardening — Final V1
+
+## Rama
+
+`feature/security-http-runtime-hardening-final-v1`
+
+## Objetivo
+
+Endurecer el runtime HTTP de Gym Master sin cambiar el modelo de datos, migraciones, RLS, RPC ni contratos funcionales principales. El alcance cubre cabeceras de navegador, abuso de endpoints públicos, límites de payload, exposición de errores, CORS, recuperación de contraseña, proxy de imágenes, cookies y renderizado HTML generado desde Markdown.
+
+## Hallazgos corregidos
+
+1. `next.config.js` no publicaba una política global de cabeceras de seguridad.
+2. Los endpoints públicos de autenticación, recuperación, scanner, verificación e imagen no tenían un control uniforme de frecuencia.
+3. La mayoría de los cuerpos JSON se parseaban con `request.json()` sin límite explícito y los uploads verificaban tamaño después de ejecutar `formData()`.
+4. El webhook de Stripe leía el cuerpo completo sin límite propio y devolvía mensajes internos del proveedor.
+5. La recuperación de contraseña podía construir el enlace usando `Origin`, `Host` o `X-Forwarded-Host` cuando faltaba una URL pública configurada.
+6. Existían respuestas con CORS wildcard en rutas que operan como same-origin.
+7. El proxy de imágenes no tenía timeout, cargaba el cuerpo completo antes de validar el límite real y admitía SVG remoto.
+8. El preview Markdown usaba `dangerouslySetInnerHTML` sin escapar primero el HTML ni filtrar protocolos de URL.
+9. Las cookies de bearer token eran `SameSite=Strict` y `Secure` sobre HTTPS, pero la ruta de creación/eliminación no estaba expresada de forma determinística.
+10. Algunos errores de autorización y endpoints públicos podían exponer mensajes de configuración, base de datos o proveedor.
+
+## Implementación
+
+### Cabeceras globales
+
+Se agregaron desde `next.config.js`:
+
+- `Content-Security-Policy`.
+- `Strict-Transport-Security` únicamente en producción.
+- `X-Content-Type-Options: nosniff`.
+- `X-Frame-Options: DENY`.
+- `Referrer-Policy: strict-origin-when-cross-origin`.
+- `Permissions-Policy` conservando cámara para el mismo origen.
+- `Cross-Origin-Opener-Policy: same-origin-allow-popups`.
+- `Origin-Agent-Cluster: ?1`.
+- `X-DNS-Prefetch-Control: off`.
+- `X-Permitted-Cross-Domain-Policies: none`.
+
+También se deshabilitó `X-Powered-By` y se fijó el límite de Server Actions en `1mb`.
+
+La CSP admite imágenes HTTPS dinámicas, `blob:` y `data:`; frames de YouTube; workers locales/PWA; conexión al origen Supabase configurado y su WebSocket. `unsafe-eval` queda limitado a desarrollo. Se conserva `unsafe-inline` para compatibilidad con Next.js 14 y ventanas de impresión heredadas; su eliminación requeriría una migración posterior a nonces/hashes.
+
+### Rate limiting
+
+`src/middleware.ts` protege rutas públicas y sensibles:
+
+- login personalizado;
+- recuperación y reset de contraseña;
+- POST de NextAuth;
+- refresh de Terminal;
+- scanner móvil público;
+- verificación pública de recibos;
+- image proxy;
+- sincronización interna de licencia.
+
+Las respuestas por exceso usan `429`, `Retry-After`, `X-RateLimit-*` y `Cache-Control: no-store`.
+
+El almacenamiento es en memoria y está acotado a 5000 buckets con limpieza periódica. Es una defensa por instancia. Para un despliegue horizontal de alto tráfico debe complementarse con WAF, Vercel Firewall o un almacén distribuido como Redis/KV.
+
+### Límites y parsing de solicitudes
+
+Se creó `src/lib/security/httpRuntimeSecurity.ts` con:
+
+- `readJsonBody` con validación de `Content-Type`, `Content-Length`, tamaño UTF-8 real y JSON válido;
+- `readTextBody` para payloads firmados;
+- `requestBodyTooLargeResponse` para cortar multipart antes de `formData()` cuando el cliente declara longitud;
+- `noStoreJson`;
+- `runtimeErrorResponse` para redacción uniforme.
+
+Se aplicaron límites a login, recuperación, cambio de contraseña, scanner, registro QR, confirmación Stripe, webhook, sincronización de licencia y cinco familias de upload.
+
+### Recuperación de contraseña
+
+En producción, los enlaces solo se construyen con `NEXT_PUBLIC_APP_URL` o `APP_URL`. Ya no se confía en `Origin`, `Host` ni `X-Forwarded-Host`. La URL debe ser HTTP/HTTPS, sin credenciales embebidas.
+
+### Image proxy
+
+Se mantuvo el control SSRF existente y se agregó:
+
+- URL máxima de 4096 caracteres;
+- timeout de 8 segundos;
+- máximo de tres redirects manuales;
+- lectura streaming con corte real en 10 MB;
+- rechazo de SVG remoto;
+- respuesta `private` para impedir cache compartida de URLs arbitrarias;
+- eliminación de CORS wildcard;
+- errores de upstream redactados.
+
+### Uploads
+
+Los uploads de perfil, logo, comprobante, media de ejercicios y ficha médica rechazan payloads declarados demasiado grandes antes de parsear multipart. La ficha médica ahora también valida firma binaria real de PDF, JPG y PNG.
+
+### Cookies y sesión
+
+NextAuth habilita explícitamente cookies seguras en producción y mantiene debug desactivado. Las cookies bearer del flujo propio conservan:
+
+- `SameSite=Strict`;
+- `Secure` sobre HTTPS;
+- `Path=/` explícito tanto al crear como al eliminar;
+- expiración alineada al JWT.
+
+Los JWT del flujo propio continúan siendo legibles por JavaScript porque los clientes construyen headers Bearer. Convertirlos a `HttpOnly` exige migrar la arquitectura de autenticación y no se realiza en esta rama.
+
+### Prevención XSS en preview Markdown
+
+El editor ahora:
+
+- escapa HTML crudo antes de convertir Markdown;
+- permite links `http`, `https`, `mailto`, rutas relativas y anchors;
+- permite imágenes solo `http` y `https`;
+- rechaza credenciales embebidas y protocolos como `javascript:`;
+- agrega `noopener`, `noreferrer` y `nofollow` a links externos.
+
+### CORS y errores
+
+Se eliminaron wildcard CORS de `registro-qr` e `image-proxy`. Las rutas endurecidas operan same-origin. Los errores 5xx de autenticación, Stripe, scanner, recibos, licencia, uploads y autorización ya no devuelven mensajes de proveedor, SQL ni nombres de variables internas.
+
+## Gate automático
+
+```bash
+npm run test:http-runtime-security
+```
+
+Valida:
+
+- cabeceras y CSP;
+- rate limiting y `Retry-After`;
+- límites de JSON, raw body y multipart;
+- ausencia de CORS wildcard;
+- origen confiable en recuperación;
+- atributos de cookies;
+- hardening del image proxy;
+- escape de Markdown;
+- firma binaria de adjuntos médicos.
+
+## QA manual recomendada
+
+1. Ejecutar build y todos los gates acumulativos.
+2. Confirmar headers en `/auth/login`, `/dashboard` y `/api/swagger-json`.
+3. Probar login correcto e incorrecto; verificar que no aparezcan mensajes internos.
+4. En local, superar el límite del login y comprobar `429` + `Retry-After`; reiniciar el servidor para limpiar buckets.
+5. Probar recuperación con `APP_URL`/`NEXT_PUBLIC_APP_URL` correctas.
+6. Probar reset válido, inválido, expirado y reutilizado.
+7. Validar Terminal y scanner público.
+8. Generar PDFs de rutina/dieta con imágenes remotas; verificar timeout/formatos y ausencia de regresión.
+9. Subir archivos válidos, falsos y sobredimensionados en las cinco familias de upload.
+10. En el editor Markdown, probar `<img onerror=alert(1)>`, `[x](javascript:alert(1))`, links HTTPS e imágenes HTTPS.
+11. Confirmar cámara QR bajo `Permissions-Policy`.
+12. Revisar consola del navegador por violaciones CSP reales antes de desplegar.
+
+## Riesgos residuales
+
+- El rate limiting es por instancia, no global distribuido.
+- La CSP conserva `unsafe-inline` por compatibilidad.
+- Los JWT propios siguen siendo browser-readable; la defensa depende de evitar XSS.
+- Los límites multipart previos a `formData()` dependen de `Content-Length`; la plataforma de hosting debe mantener límites de request a nivel ingress.
+- El image proxy valida DNS antes de cada fetch/redirect, pero una protección absoluta contra DNS rebinding requeriría pinning de IP/agente de red o allowlist de hosts.
+
+## Fuera de alcance
+
+- Base de datos, migraciones, RLS y RPC.
+- Cambio de contratos funcionales de negocio.
+- Incorporación de Redis/KV/WAF.
+- Migración completa de JWT bearer a cookies `HttpOnly`.
+- Reescritura de ventanas de impresión y scripts inline con nonces.

--- a/docs/security/security-http-runtime-hardening-final-v1-login-error-hotfix.md
+++ b/docs/security/security-http-runtime-hardening-final-v1-login-error-hotfix.md
@@ -1,0 +1,29 @@
+# HTTP Runtime Hardening — Login Error Mapping Hotfix
+
+## Contexto
+
+Durante la validación manual del rate limiting de `POST /api/custom-login`, las primeras veinte solicitudes con un correo inexistente respondieron `500`, aunque la solicitud número veintiuno fue limitada correctamente con `429`.
+
+## Causa raíz
+
+La consulta de usuario utilizaba `.single()`. Supabase devuelve un error cuando la consulta no encuentra filas, por lo que el flujo clasificaba una credencial inexistente como una falla interna de base de datos antes de alcanzar la validación `!data`.
+
+## Corrección
+
+- La consulta utiliza `.maybeSingle()` para representar correctamente la ausencia de usuario con `data = null` y sin error de proveedor.
+- Un correo inexistente continúa usando la respuesta genérica `LOGIN_INVALID_CREDENTIALS` con estado `401`.
+- Los errores reales de consulta siguen respondiendo `500`, pero el log registra únicamente el código estructurado y no el mensaje interno de Supabase.
+- Se retiraron logs específicos de correo, contraseña y rol inválidos para reducir información sensible en registros operativos.
+- El gate `test:http-runtime-security` verifica que esta regresión no vuelva a introducirse.
+
+## Resultado esperado
+
+Con el servidor reiniciado para limpiar el bucket local de rate limiting:
+
+- Solicitudes 1 a 20 con credenciales inválidas: `401 Unauthorized`.
+- Solicitud 21 dentro de la misma ventana: `429 Too Many Requests`.
+- Una falla real del proveedor o de conectividad: `500` con respuesta pública redactada.
+
+## Alcance
+
+No modifica base de datos, migraciones, RLS, RPC, contratos de sesión, permisos ni el límite configurado para login.

--- a/docs/security/security-http-runtime-hardening-final-v1-terminal-photo-hotfix.md
+++ b/docs/security/security-http-runtime-hardening-final-v1-terminal-photo-hotfix.md
@@ -1,0 +1,37 @@
+# HTTP Runtime Hardening — Terminal member photo hotfix
+
+## Context
+
+During production-mode QA on `http://localhost:3000`, the attendance terminal continued loading recent movements but member avatars rendered as broken images after the HTTP security header baseline was enabled.
+
+## Root cause
+
+`next build` + `next start` sets `NODE_ENV=production` even when the application is being exercised locally over plain HTTP. The initial policy therefore enabled HTTPS-only image sources, HSTS and `upgrade-insecure-requests` solely from `NODE_ENV`. Legacy or local HTTP image URLs could consequently be blocked or rewritten to an unavailable HTTPS endpoint.
+
+## Resolution
+
+- HTTPS enforcement is now based on a configured HTTPS application origin (`NEXT_PUBLIC_APP_URL`, `APP_URL` or `NEXTAUTH_URL`) rather than `NODE_ENV` alone.
+- HSTS and `upgrade-insecure-requests` remain active for real configured HTTPS deployments.
+- Local production-mode QA may load HTTP image/media endpoints without weakening the real HTTPS deployment policy.
+- Legacy `http://res.cloudinary.com/...` profile photos are normalized to HTTPS.
+- The terminal replaces an image that still fails with the local Gym Master logo instead of leaving a broken avatar.
+- The HTTP runtime verification gate covers both the environment-aware policy and the terminal fallback.
+
+## Scope
+
+Modified files:
+
+- `next.config.js`
+- `src/components/asistencia/AsistenciaTerminalDisplay.tsx`
+- `scripts/verify-http-runtime-security.mjs`
+
+No database, migration, RLS, RPC, API contract or authorization changes are included.
+
+## QA
+
+1. Build and start with the configured local origin over HTTP.
+2. Open `/dashboard/asistencias/terminal`.
+3. Confirm recent members display their photos.
+4. Confirm an intentionally invalid image URL falls back to `/gm_logo.svg`.
+5. Confirm the response headers omit HSTS and `upgrade-insecure-requests` for a configured local HTTP origin.
+6. Confirm a configured production HTTPS origin retains HSTS and `upgrade-insecure-requests`.

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,130 @@
 /** @type {import('next').NextConfig} */
 
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+function getOrigin(value) {
+  if (!value) return null;
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isLoopbackOrigin(origin) {
+  if (!origin) return false;
+
+  try {
+    const { hostname } = new URL(origin);
+    return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}
+
+const configuredAppOrigin = getOrigin(
+  process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.APP_URL ||
+    process.env.NEXTAUTH_URL,
+);
+const shouldEnforceHttps =
+  isProduction &&
+  Boolean(configuredAppOrigin?.startsWith('https://')) &&
+  !isLoopbackOrigin(configuredAppOrigin);
+
+function buildContentSecurityPolicy() {
+  const supabaseOrigin = getOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
+  const supabaseWebSocketOrigin = supabaseOrigin
+    ?.replace(/^https:/, 'wss:')
+    .replace(/^http:/, 'ws:');
+  const connectSources = [
+    "'self'",
+    supabaseOrigin,
+    supabaseWebSocketOrigin,
+    ...(shouldEnforceHttps ? [] : ['http:', 'https:', 'ws:', 'wss:']),
+  ].filter(Boolean);
+  const imageSources = [
+    "'self'",
+    'data:',
+    'blob:',
+    'https:',
+    ...(shouldEnforceHttps ? [] : ['http:']),
+  ];
+  const mediaSources = [
+    "'self'",
+    'blob:',
+    'https:',
+    ...(shouldEnforceHttps ? [] : ['http:']),
+  ];
+
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${isProduction ? '' : " 'unsafe-eval'"}`,
+    "style-src 'self' 'unsafe-inline'",
+    `img-src ${imageSources.join(' ')}`,
+    "font-src 'self' data:",
+    `connect-src ${connectSources.join(' ')}`,
+    `media-src ${mediaSources.join(' ')}`,
+    "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    ...(shouldEnforceHttps ? ['upgrade-insecure-requests'] : []),
+  ].join('; ');
+}
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: buildContentSecurityPolicy(),
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(self), microphone=(), geolocation=(), payment=(self), usb=(), browsing-topics=()',
+  },
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'off',
+  },
+  {
+    key: 'X-Permitted-Cross-Domain-Policies',
+    value: 'none',
+  },
+  {
+    key: 'Cross-Origin-Opener-Policy',
+    value: 'same-origin-allow-popups',
+  },
+  {
+    key: 'Origin-Agent-Cluster',
+    value: '?1',
+  },
+  ...(shouldEnforceHttps
+    ? [
+        {
+          key: 'Strict-Transport-Security',
+          value: 'max-age=31536000',
+        },
+      ]
+    : []),
+];
+
 const runtimeCaching = [
   {
     urlPattern: ({ url, request }) =>
@@ -95,8 +220,19 @@ const withPWA = require('next-pwa')({
 
 const nextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
   experimental: {
-    serverActions: {},
+    serverActions: {
+      bodySizeLimit: '1mb',
+    },
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
   },
   images: {
     remotePatterns: [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:pwa-cache": "node scripts/verify-pwa-cache-policy.mjs",
     "test:pwa-install-update": "node scripts/verify-pwa-install-update.mjs",
     "test:auth-rbac": "node scripts/verify-auth-rbac-security.mjs",
+    "test:http-runtime-security": "node scripts/verify-http-runtime-security.mjs",
     "test:business-backup-export": "node scripts/verify-business-backup-export.mjs",
     "security:cleanup-local-artifacts": "node scripts/cleanup-local-repo-artifacts.mjs",
     "test:repo-security": "node scripts/verify-repo-security.mjs"

--- a/scripts/verify-http-runtime-security.mjs
+++ b/scripts/verify-http-runtime-security.mjs
@@ -1,0 +1,252 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function assert(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+function includesAll(source, snippets) {
+  return snippets.every((snippet) => source.includes(snippet));
+}
+
+const nextConfig = read('next.config.js');
+assert(
+  includesAll(nextConfig, [
+    "key: 'Content-Security-Policy'",
+    "default-src 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "key: 'Strict-Transport-Security'",
+    "key: 'Referrer-Policy'",
+    "key: 'X-Content-Type-Options'",
+    "key: 'X-Frame-Options'",
+    "key: 'Permissions-Policy'",
+    'poweredByHeader: false',
+    "bodySizeLimit: '1mb'",
+  ]),
+  'Next.js must publish the complete HTTP security header baseline and disable X-Powered-By.',
+);
+assert(
+  includesAll(nextConfig, [
+    'const shouldEnforceHttps =',
+    "configuredAppOrigin?.startsWith('https://')",
+    '!isLoopbackOrigin(configuredAppOrigin)',
+    "shouldEnforceHttps ? ['upgrade-insecure-requests'] : []",
+    "...(shouldEnforceHttps ? [] : ['http:'])",
+  ]) &&
+    !nextConfig.includes("script-src 'self' 'unsafe-inline' 'unsafe-eval'"),
+  'HTTPS-only CSP and HSTS must remain enabled for configured secure deployments while local production QA may load HTTP media without mixed-content breakage.',
+);
+
+const middleware = read('src/middleware.ts');
+assert(
+  includesAll(middleware, [
+    '/api/custom-login',
+    '/api/auth/:path*',
+    '/api/comercial/mobile-scanner/public/:path*',
+    '/api/pagos/:id/verificar',
+    '/api/image-proxy',
+    '/api/internal/dragon-pyramid/license-sync',
+    'status: 429',
+    "'Retry-After'",
+    'MAX_BUCKETS',
+    'sweepExpiredBuckets',
+  ]),
+  'Sensitive public and internal routes must be covered by bounded per-instance rate limiting.',
+);
+
+const runtimeSecurity = read('src/lib/security/httpRuntimeSecurity.ts');
+assert(
+  includesAll(runtimeSecurity, [
+    'export async function readJsonBody',
+    'export async function readTextBody',
+    'export function requestBodyTooLargeResponse',
+    'REQUEST_BODY_TOO_LARGE',
+    'UNSUPPORTED_MEDIA_TYPE',
+    'INVALID_JSON_BODY',
+    "'Cache-Control': 'no-store'",
+  ]),
+  'Runtime security helpers must enforce body limits, JSON media types and no-store responses.',
+);
+
+const requiredJsonBodyRoutes = [
+  'src/app/api/custom-login/route.ts',
+  'src/app/api/auth/forgot-password/route.ts',
+  'src/app/api/auth/reset-password/route.ts',
+  'src/app/api/auth/change-password/route.ts',
+  'src/app/api/comercial/mobile-scanner/public/[token]/route.ts',
+  'src/app/api/internal/dragon-pyramid/license-sync/route.ts',
+  'src/app/api/pagar-cuota/confirmar/route.ts',
+  'src/app/api/asistencias/registro-qr/route.ts',
+];
+
+for (const route of requiredJsonBodyRoutes) {
+  assert(
+    read(route).includes('readJsonBody'),
+    `${route} must parse JSON through the bounded runtime helper.`,
+  );
+}
+
+const stripeWebhook = read('src/app/api/stripe-webhook/route.ts');
+assert(
+  includesAll(stripeWebhook, [
+    'readTextBody',
+    'STRIPE_WEBHOOK_BODY_MAX_BYTES',
+    'constructEvent',
+    'stripe-signature',
+    "{ error: 'Firma de Stripe inválida' }",
+  ]),
+  'Stripe webhook must bound its raw body and redact signature/provider errors.',
+);
+
+const imageProxy = read('src/app/api/image-proxy/route.ts');
+assert(
+  includesAll(imageProxy, [
+    "redirect: 'manual'",
+    'AbortSignal.timeout',
+    'readImageBodyWithinLimit',
+    "contentType === 'image/svg+xml'",
+    'MAX_IMAGE_URL_LENGTH',
+    'MAX_IMAGE_BYTES',
+  ]),
+  'Image proxy must retain SSRF controls and add timeout, streaming size enforcement and SVG rejection.',
+);
+assert(
+  !imageProxy.includes('Access-Control-Allow-Origin'),
+  'Image proxy must remain same-origin and must not emit wildcard CORS.',
+);
+
+const apiRoot = path.join(root, 'src/app/api');
+const routeFiles = [];
+function walk(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) walk(fullPath);
+    if (entry.isFile() && entry.name === 'route.ts') routeFiles.push(fullPath);
+  }
+}
+walk(apiRoot);
+
+for (const routeFile of routeFiles) {
+  const source = fs.readFileSync(routeFile, 'utf8');
+  assert(
+    !source.includes("'Access-Control-Allow-Origin': '*'") &&
+      !source.includes('"Access-Control-Allow-Origin": "*"'),
+    `${path.relative(root, routeFile)} must not allow wildcard CORS.`,
+  );
+}
+
+const uploadRoutes = [
+  'src/app/api/file-upload/route.ts',
+  'src/app/api/gimnasio-parametrizacion/logo-upload/route.ts',
+  'src/app/api/otros_gastos/comprobante-upload/route.ts',
+  'src/app/api/rutinas/ejercicios-media/upload/route.ts',
+  'src/app/api/socios/[id]/ficha-medica/route.ts',
+];
+
+for (const route of uploadRoutes) {
+  assert(
+    read(route).includes('requestBodyTooLargeResponse'),
+    `${route} must reject oversized multipart requests before formData parsing when Content-Length is available.`,
+  );
+}
+assert(
+  read('src/app/api/socios/[id]/ficha-medica/route.ts').includes('hasSafeUploadSignature'),
+  'Medical attachments must validate binary signatures in addition to MIME type.',
+);
+
+const loginService = read('src/services/loginService.ts');
+assert(
+  loginService.includes('.maybeSingle()') &&
+    !loginService.includes(".eq('email', email)\n    .single()") &&
+    !loginService.includes("error.message") &&
+    loginService.includes("code: error.code || 'LOGIN_USER_QUERY_ERROR'"),
+  'Login lookup must treat an absent user as invalid credentials and must not expose provider error messages in logs.',
+);
+
+const authRecovery = read('src/services/authRecoveryService.ts');
+assert(
+  includesAll(authRecovery, [
+    'function normalizeAppBaseUrl',
+    "process.env.NODE_ENV === 'production'",
+    'NEXT_PUBLIC_APP_URL o APP_URL debe estar configurada',
+  ]) &&
+    !authRecovery.includes("headers.get('origin')") &&
+    !authRecovery.includes("headers.get('x-forwarded-host')") &&
+    !authRecovery.includes("headers.get('host')"),
+  'Password recovery links must use a configured public origin in production and must not trust request Host/Origin headers.',
+);
+
+
+const serverAuthorization = read('src/lib/auth/serverAuthorization.ts');
+assert(
+  includesAll(serverAuthorization, [
+    'noStoreJson',
+    'No se pudo validar la autorización de la solicitud',
+    'error.status >= 500',
+  ]),
+  'Authorization failures must be no-store and redact server-side configuration details.',
+);
+
+const nextAuth = read('src/app/api/auth/[...nextauth]/route.ts');
+assert(
+  nextAuth.includes("useSecureCookies: process.env.NODE_ENV === 'production'") &&
+    nextAuth.includes('debug: false'),
+  'NextAuth must explicitly enable secure production cookies and keep debug output disabled.',
+);
+
+const storageService = read('src/services/storageService.ts');
+assert(
+  includesAll(storageService, [
+    'sameSite: "strict"',
+    'secure: shouldUseSecureCookie()',
+    'path: "/"',
+    'Cookies.remove(TOKEN_KEY, { path: "/" })',
+    'Cookies.remove(TERMINAL_TOKEN_KEY, { path: "/" })',
+  ]),
+  'Browser-readable bearer cookies must keep Strict SameSite, HTTPS-only production transport and deterministic Path cleanup.',
+);
+
+const attendanceTerminal = read('src/components/asistencia/AsistenciaTerminalDisplay.tsx');
+assert(
+  includesAll(attendanceTerminal, [
+    'function normalizeTerminalPhotoUrl',
+    "normalized.startsWith('http://res.cloudinary.com/')",
+    'function replaceBrokenTerminalPhoto',
+    "image.src = '/gm_logo.svg'",
+    'onError={replaceBrokenTerminalPhoto}',
+  ]),
+  'Attendance terminal must normalize legacy Cloudinary URLs and replace failed member photos with a deterministic local fallback.',
+);
+
+const textEditor = read('src/components/ui/TextEditor.tsx');
+assert(
+  includesAll(textEditor, [
+    'function escapeHtml',
+    'function sanitizeMarkdownUrl',
+    'return escapeHtml(text)',
+    "new Set(['http:', 'https:', 'mailto:'])",
+    'rel="noopener noreferrer nofollow"',
+    'dangerouslySetInnerHTML',
+  ]),
+  'Markdown preview must escape raw HTML and allow only explicit URL protocols before HTML rendering.',
+);
+
+if (failures.length > 0) {
+  console.error('HTTP runtime security verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('HTTP security headers OK: CSP, HSTS, clickjacking, MIME, referrer and permissions policies are configured.');
+console.log('Runtime abuse controls OK: sensitive public routes have bounded rate limits and Retry-After responses.');
+console.log('Request limits OK: JSON, Stripe raw bodies and multipart uploads reject oversized payloads.');
+console.log('Public endpoint exposure OK: wildcard CORS and raw provider/database errors are removed from hardened routes.');
+console.log('Browser security OK: secure cookie attributes, trusted recovery origins and escaped Markdown preview are enforced.');

--- a/src/app/api/asistencias/registro-qr/route.ts
+++ b/src/app/api/asistencias/registro-qr/route.ts
@@ -3,8 +3,13 @@ import {
   authorizationErrorResponse,
   authorizePersonalOrDashboardRequest,
 } from '@/lib/auth/serverAuthorization';
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 import { registrarAsistenciaDesdeQR } from '@/services/asistenciaService';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +17,11 @@ const REGISTRO_QR_PATHS = [
   '/dashboard/asistencias',
   '/dashboard/control-asistencia',
 ];
+const REGISTRO_QR_BODY_MAX_BYTES = 8 * 1024;
+
+type RegistroQrBody = {
+  qr?: unknown;
+};
 
 function getInvalidRegistroStatus(registro: any) {
   if (registro?.access_status === 'desactivado') return 403;
@@ -32,22 +42,20 @@ async function handleRegistroQR(
   user: JwtUser,
   tokenAsistencia: string | null,
 ) {
-  if (!tokenAsistencia) {
-    return NextResponse.json(
+  if (!tokenAsistencia || tokenAsistencia.length > 512) {
+    return noStoreJson(
       { valido: false, error: 'Falta el tokenAsistencia' },
-      { status: 400 },
+      400,
     );
   }
 
   const registro = await registrarAsistenciaDesdeQR(tokenAsistencia, user);
 
   if (!registro.valido) {
-    return NextResponse.json(registro, {
-      status: getInvalidRegistroStatus(registro),
-    });
+    return noStoreJson(registro, getInvalidRegistroStatus(registro));
   }
 
-  return NextResponse.json(registro, { status: 200 });
+  return noStoreJson(registro, 200);
 }
 
 export async function GET(req: NextRequest) {
@@ -59,12 +67,13 @@ export async function GET(req: NextRequest) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
 
-    const message =
-      error instanceof Error ? error.message : 'Error al registrar asistencia';
-    console.error(error);
-    return NextResponse.json(
-      { valido: false, error: message },
-      { status: 400 },
+    console.error('Error al registrar asistencia QR:', {
+      method: 'GET',
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return noStoreJson(
+      { valido: false, error: 'No se pudo registrar la asistencia' },
+      400,
     );
   }
 }
@@ -72,29 +81,29 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const user = await authorizeRegistroQR(req);
-    const body = await req.json();
-    return handleRegistroQR(user, body.qr ?? null);
+    const body = await readJsonBody<RegistroQrBody>(
+      req,
+      REGISTRO_QR_BODY_MAX_BYTES,
+    );
+    const qr = typeof body.qr === 'string' ? body.qr.trim() : '';
+    return handleRegistroQR(user, qr || null);
   } catch (error) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
 
-    const message =
-      error instanceof Error ? error.message : 'Error al registrar asistencia';
-    console.error(error);
-    return NextResponse.json(
-      { valido: false, error: message },
-      { status: 400 },
+    const runtimeResponse = runtimeErrorResponse(
+      error,
+      'No se pudo registrar la asistencia',
+      400,
     );
-  }
-}
 
-export async function OPTIONS() {
-  return new Response(null, {
-    status: 200,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    },
-  });
+    if (runtimeResponse.status >= 500) {
+      console.error('Error al registrar asistencia QR:', {
+        method: 'POST',
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
+    }
+
+    return runtimeResponse;
+  }
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -13,6 +13,8 @@ const supabase = createClient(
 );
 
 const handler = NextAuth({
+  useSecureCookies: process.env.NODE_ENV === 'production',
+  debug: false,
   providers: [
     CredentialsProvider({
       name: "credentials",

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -1,44 +1,63 @@
 import bcrypt from 'bcryptjs';
 import * as jwt from 'jsonwebtoken';
-import { NextResponse } from 'next/server';
 
-import { authMiddleware } from '@/middlewares/auth.middleware';
-import { authorizationErrorResponse } from '@/lib/auth/serverAuthorization';
+import type { JwtUser } from '@/interfaces/jwtUser.interface';
+import {
+  authorizationErrorResponse,
+} from '@/lib/auth/serverAuthorization';
 import { sanitizeMenuPermissionsForRole } from '@/lib/permissions/menuPermissions';
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
+import { authMiddleware } from '@/middlewares/auth.middleware';
 import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 import { getPasswordPolicyMessage, isStrongPassword } from '@/utils/passwordPolicy';
-import type { JwtUser } from '@/interfaces/jwtUser.interface';
 
 export const dynamic = 'force-dynamic';
+
+const CHANGE_PASSWORD_BODY_MAX_BYTES = 8 * 1024;
+
+type ChangePasswordBody = {
+  new_password?: unknown;
+};
 
 export async function POST(req: Request) {
   try {
     const { user } = await authMiddleware(req);
-    const { new_password } = await req.json();
+    const body = await readJsonBody<ChangePasswordBody>(
+      req,
+      CHANGE_PASSWORD_BODY_MAX_BYTES,
+    );
+    const newPassword = typeof body.new_password === 'string'
+      ? body.new_password
+      : '';
 
-    if (!new_password || typeof new_password !== 'string') {
-      return NextResponse.json(
+    if (!newPassword) {
+      return noStoreJson(
         { error: 'La nueva contraseña es obligatoria' },
-        { status: 400 }
+        400,
       );
     }
 
-    if (!isStrongPassword(new_password)) {
-      return NextResponse.json(
+    if (!isStrongPassword(newPassword)) {
+      return noStoreJson(
         { error: getPasswordPolicyMessage() },
-        { status: 400 }
+        400,
       );
     }
 
     if (!process.env.JWT_SECRET) {
-      return NextResponse.json(
-        { error: 'JWT_SECRET no está definido en las variables de entorno' },
-        { status: 500 }
+      console.error('JWT_SECRET no está configurado para cambio de contraseña.');
+      return noStoreJson(
+        { error: 'No se pudo actualizar la contraseña' },
+        500,
       );
     }
 
     const supabase = getSupabaseServerClient();
-    const password_hash = await bcrypt.hash(new_password.trim(), 10);
+    const password_hash = await bcrypt.hash(newPassword.trim(), 10);
 
     const { data: updatedUser, error } = await supabase
       .from('usuario')
@@ -53,10 +72,13 @@ export async function POST(req: Request) {
       .select('id,nombre,email,rol,activo,foto,permisos_menu,must_change_password')
       .single();
 
-    if (error) {
-      return NextResponse.json(
-        { error: error.message || 'No se pudo actualizar la contraseña' },
-        { status: 500 }
+    if (error || !updatedUser) {
+      console.error('No se pudo actualizar la contraseña:', {
+        code: error?.code ?? 'UPDATE_USER_FAILED',
+      });
+      return noStoreJson(
+        { error: 'No se pudo actualizar la contraseña' },
+        500,
       );
     }
 
@@ -82,7 +104,7 @@ export async function POST(req: Request) {
       foto: updatedUser.foto ? updatedUser.foto : null,
       permisos_menu: sanitizeMenuPermissionsForRole(
         updatedUser.rol,
-        updatedUser.permisos_menu
+        updatedUser.permisos_menu,
       ),
       must_change_password: false,
     };
@@ -90,20 +112,23 @@ export async function POST(req: Request) {
     const jwtExpiresIn = (process.env.JWT_EXPIRES_IN || '12h') as jwt.SignOptions['expiresIn'];
     const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: jwtExpiresIn });
 
-    return NextResponse.json(
+    return noStoreJson(
       {
         message: 'Contraseña actualizada correctamente',
         token,
       },
-      { status: 200 }
+      200,
     );
-  } catch (error: any) {
+  } catch (error) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
 
-    return NextResponse.json(
-      { error: error.message || 'Error al cambiar contraseña' },
-      { status: error.message?.includes('Token') ? 401 : 500 }
+    console.error('Error inesperado al cambiar contraseña:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return runtimeErrorResponse(
+      error,
+      'No se pudo actualizar la contraseña',
     );
   }
 }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,5 +1,8 @@
-import { NextResponse } from 'next/server';
-
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 import {
   getPasswordRecoveryErrorStatus,
   requestPasswordReset,
@@ -9,21 +12,44 @@ export const dynamic = 'force-dynamic';
 
 // AUTH POLICY: PUBLIC_RECOVERY
 
+const PASSWORD_RECOVERY_BODY_MAX_BYTES = 8 * 1024;
+
+type PasswordRecoveryBody = {
+  email?: unknown;
+  rol?: unknown;
+};
+
 export async function POST(req: Request) {
   try {
-    const body = await req.json().catch(() => ({}));
+    const body = await readJsonBody<PasswordRecoveryBody>(
+      req,
+      PASSWORD_RECOVERY_BODY_MAX_BYTES,
+    );
     const result = await requestPasswordReset({
-      email: body.email,
-      rol: body.rol,
+      email: body.email as string,
+      rol: body.rol as string,
       requestUrl: req.url,
       headers: req.headers,
     });
 
-    return NextResponse.json(result, { status: 200 });
+    return noStoreJson(result, 200);
   } catch (error) {
     const status = getPasswordRecoveryErrorStatus(error);
-    const message = error instanceof Error ? error.message : 'No se pudo procesar la solicitud';
 
-    return NextResponse.json({ error: message }, { status });
+    if (status >= 500) {
+      console.error('Error al solicitar recuperación de contraseña:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
+      return runtimeErrorResponse(
+        error,
+        'No se pudo procesar la solicitud',
+      );
+    }
+
+    const message = error instanceof Error
+      ? error.message
+      : 'No se pudo procesar la solicitud';
+
+    return noStoreJson({ error: message }, status);
   }
 }

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,5 +1,8 @@
-import { NextResponse } from 'next/server';
-
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 import {
   getPasswordRecoveryErrorStatus,
   resetPasswordWithToken,
@@ -10,27 +13,68 @@ export const dynamic = 'force-dynamic';
 
 // AUTH POLICY: PUBLIC_RECOVERY_TOKEN
 
+const PASSWORD_RESET_BODY_MAX_BYTES = 16 * 1024;
+const PASSWORD_RESET_TOKEN_MAX_LENGTH = 256;
+
+type PasswordResetBody = {
+  token?: unknown;
+  new_password?: unknown;
+};
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const token = searchParams.get('token') ?? '';
+  const token = searchParams.get('token')?.trim() ?? '';
+
+  if (!token || token.length > PASSWORD_RESET_TOKEN_MAX_LENGTH) {
+    return noStoreJson(
+      { valid: false, message: 'El enlace no es válido o expiró' },
+      400,
+    );
+  }
+
   const result = await validatePasswordResetToken(token);
-  return NextResponse.json(result, { status: result.valid ? 200 : 400 });
+  return noStoreJson(result, result.valid ? 200 : 400);
 }
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json().catch(() => ({}));
+    const body = await readJsonBody<PasswordResetBody>(
+      req,
+      PASSWORD_RESET_BODY_MAX_BYTES,
+    );
+    const token = typeof body.token === 'string' ? body.token.trim() : '';
+
+    if (token.length > PASSWORD_RESET_TOKEN_MAX_LENGTH) {
+      return noStoreJson(
+        { error: 'El enlace no es válido o expiró' },
+        400,
+      );
+    }
+
     const result = await resetPasswordWithToken({
-      token: body.token,
-      newPassword: body.new_password,
+      token,
+      newPassword: body.new_password as string,
       headers: req.headers,
     });
 
-    return NextResponse.json(result, { status: 200 });
+    return noStoreJson(result, 200);
   } catch (error) {
     const status = getPasswordRecoveryErrorStatus(error);
-    const message = error instanceof Error ? error.message : 'No se pudo restablecer la contraseña';
 
-    return NextResponse.json({ error: message }, { status });
+    if (status >= 500) {
+      console.error('Error al restablecer contraseña:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
+      return runtimeErrorResponse(
+        error,
+        'No se pudo restablecer la contraseña',
+      );
+    }
+
+    const message = error instanceof Error
+      ? error.message
+      : 'No se pudo restablecer la contraseña';
+
+    return noStoreJson({ error: message }, status);
   }
 }

--- a/src/app/api/auth/terminal-session/refresh/route.ts
+++ b/src/app/api/auth/terminal-session/refresh/route.ts
@@ -1,7 +1,8 @@
 import * as jwt from 'jsonwebtoken';
-import { NextResponse } from 'next/server';
+
 import type { JwtUser } from '@/interfaces/jwtUser.interface';
 import { canAccessDashboardPath } from '@/lib/permissions/menuPermissions';
+import { noStoreJson } from '@/lib/security/httpRuntimeSecurity';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,7 +14,14 @@ type TerminalSessionPayload = JwtUser & {
 };
 
 function getBearerToken(req: Request) {
-  return req.headers.get('authorization')?.split(' ')[1]?.trim() ?? '';
+  const authorization = req.headers.get('authorization')?.trim() ?? '';
+  const [scheme, token, ...rest] = authorization.split(/\s+/);
+
+  if (scheme?.toLowerCase() !== 'bearer' || !token || rest.length > 0) {
+    return '';
+  }
+
+  return token;
 }
 
 function getTerminalJwtExpiresIn() {
@@ -25,62 +33,63 @@ export async function POST(req: Request) {
     const token = getBearerToken(req);
 
     if (!token) {
-      return NextResponse.json(
+      return noStoreJson(
         {
           error: 'Token no proporcionado',
           error_code: 'TERMINAL_SESSION_TOKEN_MISSING',
         },
-        { status: 401 }
+        401,
       );
     }
 
     if (!process.env.JWT_SECRET) {
-      return NextResponse.json(
+      console.error('JWT_SECRET no está configurado para renovar Terminal.');
+      return noStoreJson(
         {
-          error: 'JWT_SECRET no está definido en las variables de entorno',
-          error_code: 'JWT_SECRET_MISSING',
+          error: 'No se pudo renovar la sesión de Terminal.',
+          error_code: 'TERMINAL_SESSION_CONFIGURATION_ERROR',
         },
-        { status: 500 }
+        500,
       );
     }
 
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
     if (!decoded || typeof decoded === 'string') {
-      return NextResponse.json(
+      return noStoreJson(
         {
           error: 'Token inválido',
           error_code: 'TERMINAL_SESSION_TOKEN_INVALID',
         },
-        { status: 401 }
+        401,
       );
     }
 
     const user = decoded as TerminalSessionPayload;
 
     if (user.must_change_password) {
-      return NextResponse.json(
+      return noStoreJson(
         {
           error: 'El usuario debe cambiar su contraseña antes de abrir la Terminal.',
           error_code: 'TERMINAL_SESSION_PASSWORD_CHANGE_REQUIRED',
         },
-        { status: 403 }
+        403,
       );
     }
 
     const canAccessTerminal = canAccessDashboardPath(
       user.rol,
       user.permisos_menu ?? null,
-      '/dashboard/asistencias/terminal'
+      '/dashboard/asistencias/terminal',
     );
 
     if (!canAccessTerminal) {
-      return NextResponse.json(
+      return noStoreJson(
         {
           error: 'El usuario no tiene permisos para renovar la sesión de Terminal.',
           error_code: 'TERMINAL_SESSION_FORBIDDEN',
         },
-        { status: 403 }
+        403,
       );
     }
 
@@ -104,20 +113,19 @@ export async function POST(req: Request) {
 
     const refreshedDecoded = jwt.decode(refreshedToken) as TerminalSessionPayload | null;
 
-    return NextResponse.json(
+    return noStoreJson(
       {
         token: refreshedToken,
         expires_at: refreshedDecoded?.exp
           ? new Date(refreshedDecoded.exp * 1000).toISOString()
           : null,
       },
-      { status: 200 }
+      200,
     );
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Token inválido';
-    const isExpired = message.toLowerCase().includes('expired');
+    const isExpired = error instanceof jwt.TokenExpiredError;
 
-    return NextResponse.json(
+    return noStoreJson(
       {
         error: isExpired
           ? 'La sesión de Terminal expiró. Iniciá sesión nuevamente para reactivar la pantalla.'
@@ -126,7 +134,7 @@ export async function POST(req: Request) {
           ? 'TERMINAL_SESSION_EXPIRED'
           : 'TERMINAL_SESSION_REFRESH_ERROR',
       },
-      { status: 401 }
+      401,
     );
   }
 }

--- a/src/app/api/comercial/mobile-scanner/public/[token]/route.ts
+++ b/src/app/api/comercial/mobile-scanner/public/[token]/route.ts
@@ -1,8 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 import {
   createPublicComercialScannerEvent,
   getPublicComercialScannerSession,
 } from '@/services/server/comercialMobileScannerServerService';
-import { NextRequest, NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,11 +16,16 @@ export const dynamic = 'force-dynamic';
 // limited by a 144-bit random token, strict token format, expiry and session
 // state checks in the server service.
 const PUBLIC_SCANNER_TOKEN_RE = /^gm-pos-[a-f0-9]{36}$/;
+const PUBLIC_SCANNER_BODY_MAX_BYTES = 8 * 1024;
 
 type Params = {
   params: {
     token: string;
   };
+};
+
+type ScannerBody = {
+  codigo?: unknown;
 };
 
 function getValidatedToken(token: string) {
@@ -36,6 +46,38 @@ function publicScannerResponse<T>(payload: T, status: number) {
   });
 }
 
+function getPublicScannerError(error: unknown, operation: 'read' | 'write') {
+  const message = error instanceof Error ? error.message : '';
+
+  if (/Token de scanner inválido/i.test(message)) {
+    return { message: 'Token de scanner inválido', status: 400 };
+  }
+
+  if (/Sesión de scanner no encontrada/i.test(message)) {
+    return { message: 'Sesión de scanner no encontrada', status: 404 };
+  }
+
+  if (/no está activa|expiró/i.test(message)) {
+    return { message, status: 409 };
+  }
+
+  if (/código válido/i.test(message)) {
+    return { message: 'El código escaneado es inválido', status: 400 };
+  }
+
+  console.error('Error en scanner público:', {
+    operation,
+    name: error instanceof Error ? error.name : 'UnknownError',
+  });
+
+  return {
+    message: operation === 'read'
+      ? 'No se pudo obtener la sesión pública de scanner'
+      : 'No se pudo procesar el código escaneado',
+    status: 500,
+  };
+}
+
 export async function GET(_req: NextRequest, { params }: Params) {
   try {
     const session = await getPublicComercialScannerSession(
@@ -43,19 +85,22 @@ export async function GET(_req: NextRequest, { params }: Params) {
     );
     return publicScannerResponse({ data: session }, 200);
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : 'Error al obtener sesión pública de scanner';
-    return publicScannerResponse({ error: message }, 404);
+    const publicError = getPublicScannerError(error, 'read');
+    return publicScannerResponse(
+      { error: publicError.message },
+      publicError.status,
+    );
   }
 }
 
 export async function POST(req: NextRequest, { params }: Params) {
   try {
     const token = getValidatedToken(params.token);
-    const body = await req.json().catch(() => ({}));
-    const codigo = String(body?.codigo ?? '').trim();
+    const body = await readJsonBody<ScannerBody>(
+      req,
+      PUBLIC_SCANNER_BODY_MAX_BYTES,
+    );
+    const codigo = String(body.codigo ?? '').trim();
 
     if (!codigo || codigo.length > 160) {
       return publicScannerResponse(
@@ -70,10 +115,17 @@ export async function POST(req: NextRequest, { params }: Params) {
       201,
     );
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : 'Error al enviar código escaneado';
-    return publicScannerResponse({ error: message }, 400);
+    const runtimeResponse = runtimeErrorResponse(
+      error,
+      'No se pudo procesar el código escaneado',
+    );
+
+    if (runtimeResponse.status !== 500) return runtimeResponse;
+
+    const publicError = getPublicScannerError(error, 'write');
+    return publicScannerResponse(
+      { error: publicError.message },
+      publicError.status,
+    );
   }
 }

--- a/src/app/api/custom-login/route.ts
+++ b/src/app/api/custom-login/route.ts
@@ -1,9 +1,24 @@
-import { signIn } from "@/services/loginService";
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
+
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
+import { signIn } from '@/services/loginService';
 
 export const dynamic = 'force-dynamic';
 
 // AUTH POLICY: PUBLIC_LOGIN
+
+const LOGIN_BODY_MAX_BYTES = 8 * 1024;
+const LOGIN_ROLES = new Set(['admin', 'usuario', 'socio']);
+
+type LoginBody = {
+  email?: unknown;
+  password?: unknown;
+  rol?: unknown;
+};
 
 type LoginError = Error & {
   code?: string;
@@ -21,45 +36,63 @@ function getLoginStatus(error: LoginError) {
 
 export async function POST(req: Request) {
   try {
-    const body = await req.json();
-    const { email, password, rol } = body;
+    const body = await readJsonBody<LoginBody>(req, LOGIN_BODY_MAX_BYTES);
+    const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+    const rol = typeof body.rol === 'string' ? body.rol.trim().toLowerCase() : '';
 
     if (!email || !password || !rol) {
-      return NextResponse.json(
+      return noStoreJson(
         {
-          message: "Faltan datos",
-          error_code: "LOGIN_MISSING_FIELDS",
+          message: 'Faltan datos',
+          error_code: 'LOGIN_MISSING_FIELDS',
         },
-        { status: 400 }
+        400,
+      );
+    }
+
+    if (email.length > 254 || password.length > 256 || !LOGIN_ROLES.has(rol)) {
+      return noStoreJson(
+        {
+          message: 'Credenciales inválidas',
+          error_code: 'LOGIN_INVALID_INPUT',
+        },
+        400,
       );
     }
 
     const loginSignin = await signIn({ email, password, rol });
 
-    return NextResponse.json(
+    return noStoreJson(
       {
-        message: "Logueado con exito",
+        message: 'Logueado con exito',
         token: loginSignin,
       },
-      { status: 200 }
+      200,
     );
   } catch (error) {
     const loginError = error as LoginError;
     const status = getLoginStatus(loginError);
 
-    console.error("Error en el inicio de sesión:", {
-      message: loginError.message,
-      code: loginError.code,
-      status,
-    });
+    if (status >= 500) {
+      console.error('Error en el inicio de sesión:', {
+        code: loginError.code || 'LOGIN_ERROR',
+        status,
+      });
 
-    return NextResponse.json(
+      return runtimeErrorResponse(
+        error,
+        'No se pudo iniciar sesión',
+      );
+    }
+
+    return noStoreJson(
       {
-        message: loginError.message || "Error al iniciar sesión",
-        error_code: loginError.code || "LOGIN_ERROR",
+        message: loginError.message || 'No se pudo iniciar sesión',
+        error_code: loginError.code || 'LOGIN_ERROR',
         details: loginError.details ?? null,
       },
-      { status }
+      status,
     );
   }
 }

--- a/src/app/api/file-upload/route.ts
+++ b/src/app/api/file-upload/route.ts
@@ -7,11 +7,13 @@ import {
   hasSafeUploadSignature,
   isSafeUploadMimeType,
 } from '@/lib/security/uploadValidation';
+import { requestBodyTooLargeResponse } from '@/lib/security/httpRuntimeSecurity';
 import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = MAX_FILE_SIZE_BYTES + 512 * 1024;
 
 export async function POST(request: Request) {
   try {
@@ -20,6 +22,9 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
+
+    const oversizedRequest = requestBodyTooLargeResponse(request, MAX_REQUEST_BODY_BYTES);
+    if (oversizedRequest) return oversizedRequest;
 
     const formData = await request.formData();
     const file = formData.get('file') as File;
@@ -90,8 +95,12 @@ export async function POST(request: Request) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
 
-    console.error('error file:', error);
-    const message = error?.message || 'Error al subir la imagen.';
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('Error al subir foto de perfil:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return NextResponse.json(
+      { error: 'No se pudo subir la imagen.' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/gimnasio-parametrizacion/logo-upload/route.ts
+++ b/src/app/api/gimnasio-parametrizacion/logo-upload/route.ts
@@ -4,6 +4,7 @@ import {
   hasSafeUploadSignature,
   isSafeUploadMimeType,
 } from '@/lib/security/uploadValidation';
+import { requestBodyTooLargeResponse } from '@/lib/security/httpRuntimeSecurity';
 
 import {
   authorizeDashboardRequest,
@@ -13,6 +14,7 @@ import {
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = MAX_FILE_SIZE_BYTES + 512 * 1024;
 
 function normalizeRole(role?: string | null) {
   return role?.trim().toLowerCase() ?? '';
@@ -36,6 +38,9 @@ export async function POST(request: Request) {
         { status: 403 }
       );
     }
+
+    const oversizedRequest = requestBodyTooLargeResponse(request, MAX_REQUEST_BODY_BYTES);
+    if (oversizedRequest) return oversizedRequest;
 
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
@@ -91,11 +96,13 @@ export async function POST(request: Request) {
     const status = getStatusFromError(error);
 
     if (status === 500) {
-      console.error('Error al subir logo del gimnasio a Cloudinary:', error);
+      console.error('Error al subir logo del gimnasio a Cloudinary:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
     }
 
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Error al subir logo del gimnasio.' },
+      { error: status >= 500 ? 'No se pudo subir el logo del gimnasio.' : 'Solicitud no autorizada.' },
       { status }
     );
   }

--- a/src/app/api/image-proxy/route.ts
+++ b/src/app/api/image-proxy/route.ts
@@ -2,7 +2,10 @@ import { lookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 import { NextResponse } from 'next/server';
 
+import { noStoreJson } from '@/lib/security/httpRuntimeSecurity';
+
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
 
 // AUTH POLICY: PUBLIC_CONTROLLED
 // The proxy is intentionally public because browser-generated PDFs load images
@@ -10,6 +13,8 @@ export const dynamic = 'force-dynamic';
 // to loopback, private, link-local and reserved network ranges.
 const MAX_REDIRECTS = 3;
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGE_URL_LENGTH = 4096;
+const IMAGE_FETCH_TIMEOUT_MS = 8000;
 
 function isBlockedIpv4(address: string) {
   const parts = address.split('.').map(Number);
@@ -55,6 +60,10 @@ function isBlockedIp(address: string) {
 }
 
 async function assertSafeImageUrl(value: string) {
+  if (!value || value.length > MAX_IMAGE_URL_LENGTH) {
+    throw new Error('URL de imagen inválida');
+  }
+
   let parsed: URL;
 
   try {
@@ -94,7 +103,10 @@ async function assertSafeImageUrl(value: string) {
   }
 
   const addresses = await lookup(hostname, { all: true, verbatim: true });
-  if (addresses.length === 0 || addresses.some(({ address }: { address: string }) => isBlockedIp(address))) {
+  if (
+    addresses.length === 0 ||
+    addresses.some(({ address }: { address: string }) => isBlockedIp(address))
+  ) {
     throw new Error('El host de imagen resuelve a una red no permitida');
   }
 
@@ -108,8 +120,9 @@ async function fetchSafeImage(initialUrl: string) {
     const response = await fetch(currentUrl, {
       cache: 'force-cache',
       redirect: 'manual',
+      signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
       headers: {
-        Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+        Accept: 'image/avif,image/webp,image/apng,image/png,image/jpeg,image/gif,image/*;q=0.8',
         'User-Agent': 'GymMaster-PDF-Image-Proxy/1.0',
       },
     });
@@ -132,13 +145,54 @@ async function fetchSafeImage(initialUrl: string) {
   throw new Error('Demasiadas redirecciones de imagen');
 }
 
-export async function GET(request: Request) {
-  const imageUrl = new URL(request.url).searchParams.get('url');
+async function readImageBodyWithinLimit(response: Response) {
+  if (!response.body) {
+    const body = new Uint8Array(await response.arrayBuffer());
+    if (body.byteLength > MAX_IMAGE_BYTES) {
+      throw new Error('La imagen supera el tamaño permitido');
+    }
+    return body;
+  }
 
-  if (!imageUrl) {
-    return NextResponse.json(
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_IMAGE_BYTES) {
+      try {
+        await reader.cancel('Image body exceeds configured limit');
+      } catch {
+        // La respuesta ya excedió el límite; ignorar errores del cierre del stream.
+      }
+      throw new Error('La imagen supera el tamaño permitido');
+    }
+
+    chunks.push(value);
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return body;
+}
+
+export async function GET(request: Request) {
+  const imageUrl = new URL(request.url).searchParams.get('url')?.trim() ?? '';
+
+  if (!imageUrl || imageUrl.length > MAX_IMAGE_URL_LENGTH) {
+    return noStoreJson(
       { message: 'URL de imagen inválida' },
-      { status: 400 },
+      400,
     );
   }
 
@@ -146,56 +200,61 @@ export async function GET(request: Request) {
     const response = await fetchSafeImage(imageUrl);
 
     if (!response.ok) {
-      return NextResponse.json(
+      return noStoreJson(
         { message: 'No se pudo obtener la imagen' },
-        { status: response.status },
+        502,
       );
     }
 
-    const contentType = response.headers.get('content-type') || '';
-    if (!contentType.toLowerCase().startsWith('image/')) {
-      return NextResponse.json(
-        { message: 'El recurso no es una imagen' },
-        { status: 415 },
+    const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ?? '';
+    if (!contentType.startsWith('image/') || contentType === 'image/svg+xml') {
+      return noStoreJson(
+        { message: 'El recurso no es una imagen permitida' },
+        415,
       );
     }
 
     const declaredLength = Number(response.headers.get('content-length') || 0);
     if (declaredLength > MAX_IMAGE_BYTES) {
-      return NextResponse.json(
+      return noStoreJson(
         { message: 'La imagen supera el tamaño permitido' },
-        { status: 413 },
+        413,
       );
     }
 
-    const imageBuffer = await response.arrayBuffer();
-    if (imageBuffer.byteLength > MAX_IMAGE_BYTES) {
-      return NextResponse.json(
-        { message: 'La imagen supera el tamaño permitido' },
-        { status: 413 },
-      );
-    }
+    const imageBuffer = await readImageBodyWithinLimit(response);
 
     return new NextResponse(imageBuffer, {
       status: 200,
       headers: {
         'Content-Type': contentType,
-        'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
-        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'private, max-age=3600, no-transform',
         'X-Content-Type-Options': 'nosniff',
       },
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Error al obtener la imagen';
-    const isPolicyError = /no permitid|inválid|credenciales|redirecci/i.test(
-      message,
-    );
+    const message = error instanceof Error ? error.message : '';
+    const isPolicyError = /no permitid|inválid|credenciales|redirecci|red de imagen/i.test(message);
+    const isTooLarge = /tamaño permitido/i.test(message);
+    const isTimeout = error instanceof Error && ['TimeoutError', 'AbortError'].includes(error.name);
 
-    console.error('Error en image-proxy:', message);
-    return NextResponse.json(
-      { message: isPolicyError ? message : 'Error al obtener la imagen' },
-      { status: isPolicyError ? 400 : 502 },
+    if (!isPolicyError && !isTooLarge && !isTimeout) {
+      console.error('Error en image-proxy:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
+    }
+
+    return noStoreJson(
+      {
+        message: isPolicyError
+          ? message
+          : isTooLarge
+            ? 'La imagen supera el tamaño permitido'
+            : isTimeout
+              ? 'La descarga de la imagen excedió el tiempo permitido'
+              : 'Error al obtener la imagen',
+      },
+      isPolicyError ? 400 : isTooLarge ? 413 : isTimeout ? 504 : 502,
     );
   }
 }

--- a/src/app/api/internal/dragon-pyramid/license-sync/route.ts
+++ b/src/app/api/internal/dragon-pyramid/license-sync/route.ts
@@ -1,5 +1,10 @@
 import { timingSafeEqual } from 'node:crypto';
-import { NextResponse } from 'next/server';
+
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 import {
   reactivateDragonPyramidLicenseAfterPayment,
   upsertDragonPyramidLicense,
@@ -10,6 +15,8 @@ export const dynamic = 'force-dynamic';
 // AUTH POLICY: INTERNAL_SHARED_SECRET
 // This endpoint is used only by Dragon Pyramid's billing platform and requires
 // a dedicated server-to-server secret. It never accepts a browser JWT.
+
+const LICENSE_SYNC_BODY_MAX_BYTES = 128 * 1024;
 
 function getSyncSecret() {
   return process.env.DRAGON_PYRAMID_LICENSE_SYNC_SECRET?.trim() || '';
@@ -25,51 +32,54 @@ function secretsMatch(provided: string, expected: string) {
   );
 }
 
-function resolveStatus(message: string) {
-  if (message.includes('no configurado')) return 503;
-  if (message.includes('no autorizada')) return 401;
-  if (message.includes('válid')) return 400;
-  return 500;
-}
-
 export async function POST(req: Request) {
+  const expectedSecret = getSyncSecret();
+  if (!expectedSecret) {
+    console.error('DRAGON_PYRAMID_LICENSE_SYNC_SECRET no está configurado.');
+    return noStoreJson(
+      { error: 'Endpoint de sincronización no disponible' },
+      503,
+    );
+  }
+
+  const providedSecret = req.headers.get('x-dragon-pyramid-sync-key')?.trim() || '';
+  if (!providedSecret || !secretsMatch(providedSecret, expectedSecret)) {
+    return noStoreJson(
+      { error: 'Sincronización no autorizada' },
+      401,
+    );
+  }
+
   try {
-    const expectedSecret = getSyncSecret();
-    if (!expectedSecret) {
-      throw new Error('Endpoint de sincronización no configurado');
-    }
-
-    const providedSecret = req.headers.get('x-dragon-pyramid-sync-key')?.trim() || '';
-    if (!providedSecret || !secretsMatch(providedSecret, expectedSecret)) {
-      throw new Error('Sincronización no autorizada');
-    }
-
-    const body = await req.json();
-    const wantsReactivation = Boolean(body?.reactivate) ||
-      ((body?.status ?? body?.license_status) === 'active' &&
-        (body?.paymentStatus ?? body?.payment_status) === 'paid');
+    const body = await readJsonBody<Record<string, any>>(
+      req,
+      LICENSE_SYNC_BODY_MAX_BYTES,
+    );
+    const wantsReactivation = Boolean(body.reactivate) ||
+      ((body.status ?? body.license_status) === 'active' &&
+        (body.paymentStatus ?? body.payment_status) === 'paid');
 
     const commonPayload = {
-      client_code: body?.clientCode ?? body?.client_code,
-      client_name: body?.clientName ?? body?.client_name,
-      license_status: body?.status ?? body?.license_status,
-      payment_status: body?.paymentStatus ?? body?.payment_status,
-      last_payment_at: body?.lastPaymentAt ?? body?.last_payment_at,
-      next_due_at: body?.nextDueAt ?? body?.next_due_at,
-      expected_amount: body?.expectedAmount ?? body?.expected_amount,
-      currency: body?.currency,
-      billing_plan: body?.billingPlan ?? body?.billing_plan,
-      payment_notes: body?.paymentNotes ?? body?.payment_notes,
-      activated_at: body?.activatedAt ?? body?.activated_at,
-      expires_at: body?.expiresAt ?? body?.expires_at,
-      grace_until: body?.graceUntil ?? body?.grace_until,
-      suspended_at: body?.suspendedAt ?? body?.suspended_at,
-      reactivated_at: body?.reactivatedAt ?? body?.reactivated_at,
-      suspension_reason: body?.reason ?? body?.suspension_reason,
+      client_code: body.clientCode ?? body.client_code,
+      client_name: body.clientName ?? body.client_name,
+      license_status: body.status ?? body.license_status,
+      payment_status: body.paymentStatus ?? body.payment_status,
+      last_payment_at: body.lastPaymentAt ?? body.last_payment_at,
+      next_due_at: body.nextDueAt ?? body.next_due_at,
+      expected_amount: body.expectedAmount ?? body.expected_amount,
+      currency: body.currency,
+      billing_plan: body.billingPlan ?? body.billing_plan,
+      payment_notes: body.paymentNotes ?? body.payment_notes,
+      activated_at: body.activatedAt ?? body.activated_at,
+      expires_at: body.expiresAt ?? body.expires_at,
+      grace_until: body.graceUntil ?? body.grace_until,
+      suspended_at: body.suspendedAt ?? body.suspended_at,
+      reactivated_at: body.reactivatedAt ?? body.reactivated_at,
+      suspension_reason: body.reason ?? body.suspension_reason,
       sync_source: 'dragon_pyramid_platform',
-      reason: body?.reason ?? body?.suspension_reason,
+      reason: body.reason ?? body.suspension_reason,
       metadata: {
-        ...(body?.metadata && typeof body.metadata === 'object' ? body.metadata : {}),
+        ...(body.metadata && typeof body.metadata === 'object' ? body.metadata : {}),
         synced_from: 'dragon_pyramid_platform',
         received_at: new Date().toISOString(),
       },
@@ -82,16 +92,25 @@ export async function POST(req: Request) {
         })
       : await upsertDragonPyramidLicense({
           ...commonPayload,
-          license_status: body?.status ?? body?.license_status,
-          suspended_at: body?.suspendedAt ?? body?.suspended_at,
-          reactivated_at: body?.reactivatedAt ?? body?.reactivated_at,
-          suspension_reason: body?.reason ?? body?.suspension_reason,
+          license_status: body.status ?? body.license_status,
+          suspended_at: body.suspendedAt ?? body.suspended_at,
+          reactivated_at: body.reactivatedAt ?? body.reactivated_at,
+          suspension_reason: body.reason ?? body.suspension_reason,
           sync_source: 'dragon_pyramid_platform',
         });
 
-    return NextResponse.json({ data }, { status: 200 });
+    return noStoreJson({ data }, 200);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Error interno del servidor';
-    return NextResponse.json({ error: message }, { status: resolveStatus(message) });
+    const runtimeResponse = runtimeErrorResponse(
+      error,
+      'No se pudo sincronizar la licencia',
+    );
+
+    if (runtimeResponse.status !== 500) return runtimeResponse;
+
+    console.error('Error en sincronización interna de licencia:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return runtimeResponse;
   }
 }

--- a/src/app/api/otros_gastos/comprobante-upload/route.ts
+++ b/src/app/api/otros_gastos/comprobante-upload/route.ts
@@ -4,6 +4,7 @@ import {
   hasSafeUploadSignature,
   isSafeUploadMimeType,
 } from '@/lib/security/uploadValidation';
+import { requestBodyTooLargeResponse } from '@/lib/security/httpRuntimeSecurity';
 
 import {
   authorizeDashboardRequest,
@@ -13,10 +14,14 @@ import {
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = MAX_FILE_SIZE_BYTES + 512 * 1024;
 
 export async function POST(request: Request) {
   try {
     const user = await authorizeDashboardRequest(request, '/dashboard/otros-gastos', ['admin', 'usuario']);
+    const oversizedRequest = requestBodyTooLargeResponse(request, MAX_REQUEST_BODY_BYTES);
+    if (oversizedRequest) return oversizedRequest;
+
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
 
@@ -75,12 +80,12 @@ export async function POST(request: Request) {
   } catch (error: any) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
-    const message = error?.message || 'Error al subir comprobante.';
-    const status =
-      message.includes('Token no proporcionado') || message.includes('Token inválido')
-        ? 401
-        : 500;
-
-    return NextResponse.json({ error: message }, { status });
+    console.error('Error al subir comprobante de gasto:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return NextResponse.json(
+      { error: 'No se pudo subir el comprobante.' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/pagar-cuota/confirmar/route.ts
+++ b/src/app/api/pagar-cuota/confirmar/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { stripe } from '@/lib/stripe';
 import { registerStripeCheckoutPago } from '@/services/server/stripePagoRegistrationService';
+import {
+  noStoreJson,
+  readJsonBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 
 import {
   authorizeDashboardRequest,
@@ -8,6 +13,8 @@ import {
 } from '@/lib/auth/serverAuthorization';
 
 export const dynamic = 'force-dynamic';
+
+const PAYMENT_CONFIRMATION_BODY_MAX_BYTES = 8 * 1024;
 
 export async function POST(req: NextRequest) {
   try {
@@ -21,20 +28,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    let body: { session_id?: string } = {};
-
-    try {
-      body = await req.json();
-    } catch {
-      body = {};
-    }
-
-    const sessionId = body.session_id?.trim();
+    const body = await readJsonBody<{ session_id?: unknown }>(
+      req,
+      PAYMENT_CONFIRMATION_BODY_MAX_BYTES,
+    );
+    const sessionId = typeof body.session_id === 'string'
+      ? body.session_id.trim()
+      : '';
 
     if (!sessionId) {
-      return NextResponse.json(
+      return noStoreJson(
         { error: 'session_id es obligatorio' },
-        { status: 400 }
+        400,
       );
     }
 
@@ -53,9 +58,9 @@ export async function POST(req: NextRequest) {
       metadataUsuarioId !== user.id ||
       metadataSocioId !== user.id_socio
     ) {
-      return NextResponse.json(
+      return noStoreJson(
         { error: 'La sesión de Stripe no corresponde al socio autenticado' },
-        { status: 403 }
+        403,
       );
     }
 
@@ -63,7 +68,7 @@ export async function POST(req: NextRequest) {
       origen: 'stripe_success_sync',
     });
 
-    return NextResponse.json(
+    return noStoreJson(
       {
         message:
           result.status === 'already_registered'
@@ -72,15 +77,20 @@ export async function POST(req: NextRequest) {
         status: result.status,
         data: result.pago,
       },
-      { status: 200 }
+      200,
     );
   } catch (error: any) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
-    console.error('Error al confirmar pago Stripe:', error);
-    return NextResponse.json(
-      { error: error.message || 'Error al confirmar pago Stripe' },
-      { status: 500 }
+    const runtimeResponse = runtimeErrorResponse(
+      error,
+      'No se pudo confirmar el pago Stripe',
     );
+    if (runtimeResponse.status >= 500) {
+      console.error('Error al confirmar pago Stripe:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
+    }
+    return runtimeResponse;
   }
 }

--- a/src/app/api/pagos/[id]/verificar/route.ts
+++ b/src/app/api/pagos/[id]/verificar/route.ts
@@ -1,59 +1,62 @@
-import { NextResponse } from "next/server";
-import { getSupabaseServerClient } from "@/services/supabaseServerClient";
+import { noStoreJson } from '@/lib/security/httpRuntimeSecurity';
+import { getSupabaseServerClient } from '@/services/supabaseServerClient';
 import {
   buildPagoVerificationCode,
   isPagoVerificationCodeValid,
   normalizePagoVerificationCode,
-} from "@/utils/pagoReciboCodigo";
+} from '@/utils/pagoReciboCodigo';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 // AUTH POLICY: PUBLIC_VERIFICATION_CODE
 
+const MAX_PAYMENT_ID_LENGTH = 128;
+const MAX_VERIFICATION_CODE_LENGTH = 128;
+
 export async function GET(
   req: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { id } = await params;
+    const { id: rawId } = await params;
+    const id = String(rawId ?? '').trim();
     const url = new URL(req.url);
-    const codigo = normalizePagoVerificationCode(url.searchParams.get("codigo"));
+    const codigo = normalizePagoVerificationCode(url.searchParams.get('codigo'));
 
-    if (!id) {
-      return NextResponse.json(
+    if (!id || id.length > MAX_PAYMENT_ID_LENGTH) {
+      return noStoreJson(
         {
           valid: false,
-          error: "ID de pago requerido",
+          error: 'ID de pago requerido',
         },
-        { status: 400 }
+        400,
       );
     }
 
-    if (!codigo) {
-      return NextResponse.json(
+    if (!codigo || codigo.length > MAX_VERIFICATION_CODE_LENGTH) {
+      return noStoreJson(
         {
           valid: false,
-          error: "Código de verificación requerido",
+          error: 'Código de verificación requerido',
         },
-        { status: 400 }
+        400,
       );
     }
 
     if (!isPagoVerificationCodeValid(id, codigo)) {
-      return NextResponse.json(
+      return noStoreJson(
         {
           valid: false,
-          codigo,
-          error: "Código de verificación inválido para este pago",
+          error: 'Código de verificación inválido para este pago',
         },
-        { status: 400 }
+        400,
       );
     }
 
     const supabase = getSupabaseServerClient();
 
     const { data, error } = await supabase
-      .from("pago")
+      .from('pago')
       .select(
         `
         id,
@@ -72,29 +75,37 @@ export async function GET(
         activo,
         socio:socio_id(id_socio,nombre_completo),
         cuota:cuota_id(id,descripcion,monto,periodo)
-      `
+      `,
       )
-      .eq("id", id)
+      .eq('id', id)
       .maybeSingle();
 
     if (error) {
-      throw new Error(error.message);
+      console.error('Error al consultar comprobante de pago:', {
+        code: error.code ?? 'PAYMENT_VERIFICATION_QUERY_ERROR',
+      });
+      return noStoreJson(
+        {
+          valid: false,
+          error: 'No se pudo verificar el comprobante',
+        },
+        500,
+      );
     }
 
     if (!data) {
-      return NextResponse.json(
+      return noStoreJson(
         {
           valid: false,
-          codigo,
-          error: "No se encontró el pago asociado al comprobante",
+          error: 'No se encontró el pago asociado al comprobante',
         },
-        { status: 404 }
+        404,
       );
     }
 
     const expectedCode = buildPagoVerificationCode(id);
 
-    return NextResponse.json({
+    return noStoreJson({
       valid: true,
       codigo: expectedCode,
       verificado_en: new Date().toISOString(),
@@ -122,19 +133,18 @@ export async function GET(
         socio: data.socio,
         cuota: data.cuota,
       },
-    });
+    }, 200);
   } catch (error) {
-    console.error("Error al verificar recibo de pago:", error);
+    console.error('Error al verificar recibo de pago:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
 
-    return NextResponse.json(
+    return noStoreJson(
       {
         valid: false,
-        error:
-          error instanceof Error
-            ? error.message
-            : "Error al verificar recibo de pago",
+        error: 'No se pudo verificar el comprobante',
       },
-      { status: 500 }
+      500,
     );
   }
 }

--- a/src/app/api/rutinas/ejercicios-media/upload/route.ts
+++ b/src/app/api/rutinas/ejercicios-media/upload/route.ts
@@ -5,6 +5,7 @@ import {
   hasSafeUploadSignature,
   isSafeUploadMimeType,
 } from '@/lib/security/uploadValidation';
+import { requestBodyTooLargeResponse } from '@/lib/security/httpRuntimeSecurity';
 
 import {
   authorizeDashboardRequest,
@@ -14,6 +15,7 @@ import {
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = MAX_FILE_SIZE_BYTES + 512 * 1024;
 
 function getStatusFromError(error: any) {
   const message = error?.message ?? '';
@@ -40,6 +42,9 @@ export async function POST(request: Request) {
         { status: 403 }
       );
     }
+
+    const oversizedRequest = requestBodyTooLargeResponse(request, MAX_REQUEST_BODY_BYTES);
+    if (oversizedRequest) return oversizedRequest;
 
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
@@ -114,11 +119,13 @@ export async function POST(request: Request) {
     const status = getStatusFromError(error);
 
     if (status === 500) {
-      console.error('Error al subir media de ejercicio:', error);
+      console.error('Error al subir media de ejercicio:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
     }
 
     return NextResponse.json(
-      { error: error?.message ?? 'Error al subir media de ejercicio.' },
+      { error: status >= 500 ? 'No se pudo subir la media del ejercicio.' : 'Solicitud no autorizada.' },
       { status }
     );
   }

--- a/src/app/api/socios/[id]/ficha-medica/route.ts
+++ b/src/app/api/socios/[id]/ficha-medica/route.ts
@@ -5,6 +5,10 @@ import {
 } from '@/lib/auth/serverAuthorization';
 import { createFichaMedicaSocio, resolveFichaMedicaSocioId } from '@/services/fichaMedicaService';
 import { FileUploadDTO } from '@/interfaces/fileUpload.interface';
+import {
+  hasSafeUploadSignature,
+} from '@/lib/security/uploadValidation';
+import { requestBodyTooLargeResponse } from '@/lib/security/httpRuntimeSecurity';
 
 
 function getFichaMedicaErrorStatus(message?: string) {
@@ -17,6 +21,7 @@ function getFichaMedicaErrorStatus(message?: string) {
 export const dynamic = 'force-dynamic';
 
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_REQUEST_BODY_BYTES = 30 * 1024 * 1024;
 const VALID_MEDICAL_FILE_TYPES = new Set([
   'application/pdf',
   'image/jpeg',
@@ -34,6 +39,10 @@ async function toFileDto(file: File, fieldName: string): Promise<FileUploadDTO> 
 
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
+
+  if (!hasSafeUploadSignature(buffer, file.type)) {
+    throw new Error(`El contenido de ${file.name} no coincide con el formato declarado.`);
+  }
 
   return {
     fieldName,
@@ -73,6 +82,9 @@ export async function POST(
       );
     }
 
+    const oversizedRequest = requestBodyTooLargeResponse(req, MAX_REQUEST_BODY_BYTES);
+    if (oversizedRequest) return oversizedRequest;
+
     const formdata = await req.formData();
     const fichaRaw = formdata.get('ficha');
 
@@ -98,7 +110,6 @@ export async function POST(
         {
           error: 'Ficha inválida: JSON malformado',
           code: 'invalid_ficha_json',
-          details: err?.message,
         },
         { status: 400 }
       );
@@ -142,10 +153,19 @@ export async function POST(
   } catch (error: any) {
     const authResponse = authorizationErrorResponse(error);
     if (authResponse) return authResponse;
-    console.error('Error al crear ficha médica:', error);
     const status = getFichaMedicaErrorStatus(error?.message);
+    if (status >= 500) {
+      console.error('Error al crear ficha médica:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+      });
+    }
     return NextResponse.json(
-      { error: error.message || 'Error interno', code: 'server_error' },
+      {
+        error: status >= 500
+          ? 'No se pudo crear la ficha médica'
+          : error?.message || 'Solicitud inválida',
+        code: status >= 500 ? 'server_error' : 'request_error',
+      },
       { status }
     );
   }

--- a/src/app/api/stripe-webhook/route.ts
+++ b/src/app/api/stripe-webhook/route.ts
@@ -1,11 +1,19 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import Stripe from 'stripe';
+
 import { stripe } from '@/lib/stripe';
+import {
+  noStoreJson,
+  readTextBody,
+  runtimeErrorResponse,
+} from '@/lib/security/httpRuntimeSecurity';
 import { registerStripeCheckoutPago } from '@/services/server/stripePagoRegistrationService';
 
 export const dynamic = 'force-dynamic';
 
 // AUTH POLICY: PUBLIC_SIGNED_WEBHOOK
+
+const STRIPE_WEBHOOK_BODY_MAX_BYTES = 1024 * 1024;
 
 if (!process.env.STRIPE_WEBHOOK_SECRET) {
   throw new Error('STRIPE_WEBHOOK_SECRET no está definido');
@@ -14,13 +22,23 @@ if (!process.env.STRIPE_WEBHOOK_SECRET) {
 const endpointSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
 export async function POST(request: NextRequest) {
-  const body = await request.text();
+  let body: string;
+
+  try {
+    body = await readTextBody(request, STRIPE_WEBHOOK_BODY_MAX_BYTES);
+  } catch (error) {
+    return runtimeErrorResponse(
+      error,
+      'No se pudo procesar el webhook de Stripe',
+    );
+  }
+
   const sig = request.headers.get('stripe-signature');
 
-  if (!sig) {
-    return NextResponse.json(
-      { error: 'No se envió la firma de Stripe' },
-      { status: 400 }
+  if (!sig || sig.length > 2048) {
+    return noStoreJson(
+      { error: 'No se recibió una firma válida de Stripe' },
+      400,
     );
   }
 
@@ -28,16 +46,20 @@ export async function POST(request: NextRequest) {
 
   try {
     event = stripe.webhooks.constructEvent(body, sig, endpointSecret);
-  } catch (error: any) {
-    console.error('Firma de Stripe inválida:', error);
-    return NextResponse.json({ error: error.message }, { status: 400 });
+  } catch (error) {
+    console.error('Firma de Stripe inválida:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return noStoreJson(
+      { error: 'Firma de Stripe inválida' },
+      400,
+    );
   }
 
   if (event.type !== 'checkout.session.completed') {
-    console.log(`Evento no manejado: ${event.type}`);
-    return NextResponse.json(
+    return noStoreJson(
       { message: 'Evento recibido sin acción requerida' },
-      { status: 200 }
+      200,
     );
   }
 
@@ -47,7 +69,7 @@ export async function POST(request: NextRequest) {
       origen: 'stripe_webhook',
     });
 
-    return NextResponse.json(
+    return noStoreJson(
       {
         message:
           result.status === 'already_registered'
@@ -56,13 +78,15 @@ export async function POST(request: NextRequest) {
         status: result.status,
         data: result.pago,
       },
-      { status: 200 }
+      200,
     );
-  } catch (error: any) {
-    console.error('Error al registrar pago desde webhook Stripe:', error);
-    return NextResponse.json(
-      { error: error.message || 'Error al registrar pago desde Stripe' },
-      { status: 500 }
+  } catch (error) {
+    console.error('Error al registrar pago desde webhook Stripe:', {
+      name: error instanceof Error ? error.name : 'UnknownError',
+    });
+    return noStoreJson(
+      { error: 'No se pudo registrar el pago desde Stripe' },
+      500,
     );
   }
 }

--- a/src/components/asistencia/AsistenciaTerminalDisplay.tsx
+++ b/src/components/asistencia/AsistenciaTerminalDisplay.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import Image from "next/image";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type SyntheticEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -147,6 +154,25 @@ function getTerminalNeonClass(color?: string | null) {
   );
 }
 
+function normalizeTerminalPhotoUrl(value?: string | null) {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+
+  if (normalized.startsWith('http://res.cloudinary.com/')) {
+    return `https://${normalized.slice('http://'.length)}`;
+  }
+
+  return normalized;
+}
+
+function replaceBrokenTerminalPhoto(event: SyntheticEvent<HTMLImageElement>) {
+  const image = event.currentTarget;
+  image.onerror = null;
+  image.src = '/gm_logo.svg';
+  image.classList.remove('object-cover');
+  image.classList.add('object-contain');
+}
+
 function decodeTokenExpiration(token?: string | null): Date | null {
   if (!token) return null;
 
@@ -218,7 +244,7 @@ function buildTerminalEventFromAsistencia(
     id: `asistencia-${row.id}`,
     variant,
     nombre,
-    foto: row.socio?.foto ?? null,
+    foto: normalizeTerminalPhotoUrl(row.socio?.foto),
     idSocio: row.socio?.id_socio ?? row.socio_id,
     title:
       row.tipo_movimiento === "salida"
@@ -257,7 +283,7 @@ function buildTerminalEventFromBroadcast(
       `${variant}-${payload.socio?.id_socio ?? "socio"}-${Date.now()}`,
     variant,
     nombre,
-    foto: payload.socio?.foto ?? null,
+    foto: normalizeTerminalPhotoUrl(payload.socio?.foto),
     idSocio: payload.socio?.id_socio,
     title:
       payload.tipo_movimiento === "salida"
@@ -733,7 +759,7 @@ export default function AsistenciaTerminalDisplay() {
         status: getVariantFromAccess(row.alert_type, row.access_status),
         hora: (row.hora_egreso || row.hora_ingreso)?.slice(0, 5) || "--:--",
         tipoMovimiento: row.tipo_movimiento,
-        foto: row.socio?.foto ?? null,
+        foto: normalizeTerminalPhotoUrl(row.socio?.foto),
       })),
     [recent],
   );
@@ -1065,6 +1091,7 @@ export default function AsistenciaTerminalDisplay() {
                             src={item.foto}
                             alt={item.nombre}
                             className="h-full w-full rounded-full object-cover"
+                            onError={replaceBrokenTerminalPhoto}
                           />
                         ) : (
                           <Image

--- a/src/components/ui/TextEditor.tsx
+++ b/src/components/ui/TextEditor.tsx
@@ -21,6 +21,50 @@ interface TextEditorProps {
   onChange: (value: string) => void;
 }
 
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (character) => {
+    const entities: Record<string, string> = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    };
+    return entities[character] ?? character;
+  });
+}
+
+function decodeEscapedMarkdownUrl(value: string) {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+function sanitizeMarkdownUrl(value: string, kind: 'link' | 'image') {
+  const decoded = decodeEscapedMarkdownUrl(value);
+
+  if (kind === 'link' && (decoded.startsWith('/') || decoded.startsWith('#'))) {
+    return decoded;
+  }
+
+  try {
+    const parsed = new URL(decoded);
+    const allowedProtocols = kind === 'image'
+      ? new Set(['http:', 'https:'])
+      : new Set(['http:', 'https:', 'mailto:']);
+
+    if (!allowedProtocols.has(parsed.protocol) || parsed.username || parsed.password) {
+      return null;
+    }
+
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
 const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
   //! Esto se añade debido a que React 18 y TypeScript requieren que los componentes de función sean forwardRef para poder usarlos con refs.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -61,7 +105,7 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
     );
 
     const formatMarkdown = (text: string) => {
-      return text
+      return escapeHtml(text)
         .replace(
           /^### (.*$)/gm,
           '<h3 class="text-lg font-semibold mb-2">$1</h3>'
@@ -79,26 +123,36 @@ const TextEditor = forwardRef<HTMLDivElement, TextEditorProps>(
         )
         .replace(
           /!\[([^\]]*)\]\(([^)]+)\)/g,
-          '<img src="$2" alt="$1" class="max-w-full h-auto rounded-lg my-2" />'
+          (_match: string, alt: string, rawUrl: string) => {
+            const safeUrl = sanitizeMarkdownUrl(rawUrl, 'image');
+            if (!safeUrl) return `<span class="text-red-600">${alt}</span>`;
+
+            return `<img src="${escapeHtml(safeUrl)}" alt="${alt}" class="max-w-full h-auto rounded-lg my-2" loading="lazy" referrerpolicy="no-referrer" />`;
+          }
         )
         .replace(
           /\[([^\]]+)\]\(([^)]+)\)/g,
-          '<a href="$2" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 underline">$1</a>'
+          (_match: string, label: string, rawUrl: string) => {
+            const safeUrl = sanitizeMarkdownUrl(rawUrl, 'link');
+            if (!safeUrl) return label;
+
+            return `<a href="${escapeHtml(safeUrl)}" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 underline" target="_blank" rel="noopener noreferrer nofollow">${label}</a>`;
+          }
         )
         .replace(
-          /^> (.*)$/gm,
+          /^&gt; (.*)$/gm,
           '<blockquote class="border-l-4 border-gray-300 dark:border-gray-700 pl-4 italic text-gray-700 dark:text-gray-300 my-2">$1</blockquote>'
         )
         .replace(/^\* (.*)$/gm, '<li class="ml-4">$1</li>')
         .replace(/^(\d+)\. (.*)$/gm, '<li class="ml-4">$2</li>')
         .replace(/(<li.*>.*<\/li>)/g, (match: string) => {
-          if (match.includes("ml-4")) {
+          if (match.includes('ml-4')) {
             return match.replace(/<li class="ml-4">/g, '<li class="ml-4">• ');
           }
           return match;
         })
         .replace(/\n\n/g, '</p><p class="mb-4">')
-        .replace(/\n/g, "<br />");
+        .replace(/\n/g, '<br />');
     };
 
     const getPreviewHTML = () => {

--- a/src/lib/auth/serverAuthorization.ts
+++ b/src/lib/auth/serverAuthorization.ts
@@ -7,7 +7,7 @@ import {
   AuthMiddlewareError,
   authMiddleware,
 } from '@/middlewares/auth.middleware';
-import { NextResponse } from 'next/server';
+import { noStoreJson } from '@/lib/security/httpRuntimeSecurity';
 
 export class AuthorizationError extends Error {
   code: string;
@@ -168,9 +168,23 @@ export function requireOwnSocioOrRoles(
 
 export function authorizationErrorResponse(error: unknown) {
   if (error instanceof AuthMiddlewareError || error instanceof AuthorizationError) {
-    return NextResponse.json(
-      { error: error.message, error_code: error.code },
-      { status: error.status },
+    const isServerFailure = error.status >= 500;
+
+    if (isServerFailure) {
+      console.error('Authorization runtime failure:', {
+        code: error.code,
+        status: error.status,
+      });
+    }
+
+    return noStoreJson(
+      {
+        error: isServerFailure
+          ? 'No se pudo validar la autorización de la solicitud'
+          : error.message,
+        error_code: error.code,
+      },
+      error.status,
     );
   }
 

--- a/src/lib/security/httpRuntimeSecurity.ts
+++ b/src/lib/security/httpRuntimeSecurity.ts
@@ -1,0 +1,158 @@
+import { NextResponse } from 'next/server';
+
+const JSON_CONTENT_TYPES = new Set([
+  'application/json',
+  'application/ld+json',
+  'application/problem+json',
+]);
+
+export class HttpRuntimeError extends Error {
+  code: string;
+  status: number;
+
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = 'HttpRuntimeError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function getContentType(request: Request) {
+  return request.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ?? '';
+}
+
+function getDeclaredContentLength(request: Request) {
+  const raw = request.headers.get('content-length');
+  if (!raw) return null;
+
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function getUtf8ByteLength(value: string) {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+export function noStoreJson<T>(
+  payload: T,
+  status = 200,
+  headers?: HeadersInit,
+) {
+  return NextResponse.json(payload, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+      ...headers,
+    },
+  });
+}
+
+export function requestBodyTooLargeResponse(
+  request: Request,
+  maxBytes: number,
+) {
+  const declaredLength = getDeclaredContentLength(request);
+
+  if (declaredLength !== null && declaredLength > maxBytes) {
+    return noStoreJson(
+      {
+        error: 'El cuerpo de la solicitud supera el tamaño permitido',
+        error_code: 'REQUEST_BODY_TOO_LARGE',
+      },
+      413,
+    );
+  }
+
+  return null;
+}
+
+export async function readJsonBody<T = Record<string, unknown>>(
+  request: Request,
+  maxBytes = 32 * 1024,
+): Promise<T> {
+  const oversized = requestBodyTooLargeResponse(request, maxBytes);
+  if (oversized) {
+    throw new HttpRuntimeError(
+      'El cuerpo de la solicitud supera el tamaño permitido',
+      'REQUEST_BODY_TOO_LARGE',
+      413,
+    );
+  }
+
+  const contentType = getContentType(request);
+  if (contentType && !JSON_CONTENT_TYPES.has(contentType) && !contentType.endsWith('+json')) {
+    throw new HttpRuntimeError(
+      'Content-Type no permitido; se esperaba application/json',
+      'UNSUPPORTED_MEDIA_TYPE',
+      415,
+    );
+  }
+
+  const rawBody = await request.text();
+  if (getUtf8ByteLength(rawBody) > maxBytes) {
+    throw new HttpRuntimeError(
+      'El cuerpo de la solicitud supera el tamaño permitido',
+      'REQUEST_BODY_TOO_LARGE',
+      413,
+    );
+  }
+
+  if (!rawBody.trim()) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(rawBody) as T;
+  } catch {
+    throw new HttpRuntimeError(
+      'El cuerpo JSON de la solicitud es inválido',
+      'INVALID_JSON_BODY',
+      400,
+    );
+  }
+}
+
+export async function readTextBody(
+  request: Request,
+  maxBytes: number,
+) {
+  const oversized = requestBodyTooLargeResponse(request, maxBytes);
+  if (oversized) {
+    throw new HttpRuntimeError(
+      'El cuerpo de la solicitud supera el tamaño permitido',
+      'REQUEST_BODY_TOO_LARGE',
+      413,
+    );
+  }
+
+  const rawBody = await request.text();
+  if (getUtf8ByteLength(rawBody) > maxBytes) {
+    throw new HttpRuntimeError(
+      'El cuerpo de la solicitud supera el tamaño permitido',
+      'REQUEST_BODY_TOO_LARGE',
+      413,
+    );
+  }
+
+  return rawBody;
+}
+
+export function runtimeErrorResponse(
+  error: unknown,
+  fallbackMessage: string,
+  fallbackStatus = 500,
+) {
+  if (error instanceof HttpRuntimeError) {
+    return noStoreJson(
+      { error: error.message, error_code: error.code },
+      error.status,
+    );
+  }
+
+  return noStoreJson(
+    { error: fallbackMessage, error_code: 'INTERNAL_SERVER_ERROR' },
+    fallbackStatus,
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+type RateLimitPolicy = {
+  id: string;
+  limit: number;
+  windowMs: number;
+};
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type RuntimeRateLimitGlobal = typeof globalThis & {
+  __gymMasterRuntimeRateLimitBuckets?: Map<string, RateLimitBucket>;
+  __gymMasterRuntimeRateLimitLastSweep?: number;
+};
+
+const runtimeGlobal = globalThis as RuntimeRateLimitGlobal;
+const buckets = runtimeGlobal.__gymMasterRuntimeRateLimitBuckets ?? new Map<string, RateLimitBucket>();
+runtimeGlobal.__gymMasterRuntimeRateLimitBuckets = buckets;
+
+const MINUTE = 60 * 1000;
+const MAX_BUCKETS = 5000;
+
+function getClientAddress(request: NextRequest) {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  const firstForwardedAddress = forwardedFor?.split(',')[0]?.trim();
+
+  return (
+    request.headers.get('x-vercel-forwarded-for')?.split(',')[0]?.trim() ||
+    firstForwardedAddress ||
+    request.headers.get('cf-connecting-ip')?.trim() ||
+    request.headers.get('x-real-ip')?.trim() ||
+    'unknown-client'
+  );
+}
+
+function getPolicy(request: NextRequest): RateLimitPolicy | null {
+  const pathname = request.nextUrl.pathname;
+  const method = request.method.toUpperCase();
+
+  if (pathname === '/api/custom-login' && method === 'POST') {
+    return { id: 'custom-login', limit: 20, windowMs: 10 * MINUTE };
+  }
+
+  if (pathname === '/api/auth/forgot-password' && method === 'POST') {
+    return { id: 'forgot-password', limit: 6, windowMs: 15 * MINUTE };
+  }
+
+  if (pathname === '/api/auth/reset-password') {
+    return method === 'POST'
+      ? { id: 'reset-password-post', limit: 8, windowMs: 15 * MINUTE }
+      : { id: 'reset-password-get', limit: 60, windowMs: 5 * MINUTE };
+  }
+
+  if (pathname === '/api/auth/terminal-session/refresh' && method === 'POST') {
+    return { id: 'terminal-refresh', limit: 120, windowMs: 10 * MINUTE };
+  }
+
+  if (pathname.startsWith('/api/auth/') && method === 'POST') {
+    return { id: 'next-auth', limit: 60, windowMs: 10 * MINUTE };
+  }
+
+  if (pathname.startsWith('/api/comercial/mobile-scanner/public/')) {
+    return method === 'POST'
+      ? { id: 'public-scanner-post', limit: 120, windowMs: MINUTE }
+      : { id: 'public-scanner-get', limit: 180, windowMs: MINUTE };
+  }
+
+  if (/^\/api\/pagos\/[^/]+\/verificar$/.test(pathname) && method === 'GET') {
+    return { id: 'payment-verification', limit: 120, windowMs: 5 * MINUTE };
+  }
+
+  if (pathname === '/api/image-proxy' && method === 'GET') {
+    return { id: 'image-proxy', limit: 240, windowMs: MINUTE };
+  }
+
+  if (pathname === '/api/internal/dragon-pyramid/license-sync' && method === 'POST') {
+    return { id: 'license-sync', limit: 120, windowMs: 5 * MINUTE };
+  }
+
+  return null;
+}
+
+function sweepExpiredBuckets(now: number) {
+  const lastSweep = runtimeGlobal.__gymMasterRuntimeRateLimitLastSweep ?? 0;
+  if (now - lastSweep < MINUTE && buckets.size < MAX_BUCKETS) return;
+
+  for (const [key, bucket] of buckets.entries()) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+
+  if (buckets.size > MAX_BUCKETS) {
+    const oldestKeys = [...buckets.entries()]
+      .sort((a, b) => a[1].resetAt - b[1].resetAt)
+      .slice(0, buckets.size - MAX_BUCKETS)
+      .map(([key]) => key);
+
+    for (const key of oldestKeys) buckets.delete(key);
+  }
+
+  runtimeGlobal.__gymMasterRuntimeRateLimitLastSweep = now;
+}
+
+export function middleware(request: NextRequest) {
+  const policy = getPolicy(request);
+  if (!policy) return NextResponse.next();
+
+  const now = Date.now();
+  sweepExpiredBuckets(now);
+
+  const key = `${policy.id}:${getClientAddress(request)}`;
+  const current = buckets.get(key);
+  const bucket = !current || current.resetAt <= now
+    ? { count: 0, resetAt: now + policy.windowMs }
+    : current;
+
+  if (bucket.count >= policy.limit) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+
+    return NextResponse.json(
+      {
+        error: 'Demasiadas solicitudes. Intentá nuevamente más tarde.',
+        error_code: 'RATE_LIMIT_EXCEEDED',
+      },
+      {
+        status: 429,
+        headers: {
+          'Cache-Control': 'no-store',
+          'Retry-After': String(retryAfterSeconds),
+          'X-RateLimit-Limit': String(policy.limit),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(Math.ceil(bucket.resetAt / 1000)),
+        },
+      },
+    );
+  }
+
+  bucket.count += 1;
+  buckets.set(key, bucket);
+
+  const response = NextResponse.next();
+  response.headers.set('X-RateLimit-Limit', String(policy.limit));
+  response.headers.set('X-RateLimit-Remaining', String(Math.max(0, policy.limit - bucket.count)));
+  response.headers.set('X-RateLimit-Reset', String(Math.ceil(bucket.resetAt / 1000)));
+  return response;
+}
+
+export const config = {
+  matcher: [
+    '/api/custom-login',
+    '/api/auth/:path*',
+    '/api/comercial/mobile-scanner/public/:path*',
+    '/api/pagos/:id/verificar',
+    '/api/image-proxy',
+    '/api/internal/dragon-pyramid/license-sync',
+  ],
+};

--- a/src/services/authRecoveryService.ts
+++ b/src/services/authRecoveryService.ts
@@ -86,18 +86,35 @@ function getTtlMinutes(): number {
   return Number.isFinite(raw) && raw >= 10 && raw <= 1440 ? Math.round(raw) : 60;
 }
 
-function buildAppBaseUrl(requestUrl: string, headers: Headers): string {
-  const envUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL;
-  if (envUrl) return envUrl.replace(/\/+$/, '');
+function normalizeAppBaseUrl(value: string): string {
+  let parsed: URL;
 
-  const origin = headers.get('origin');
-  if (origin) return origin.replace(/\/+$/, '');
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new PasswordRecoveryError('La URL pública de la aplicación no es válida', 500);
+  }
 
-  const host = headers.get('x-forwarded-host') || headers.get('host');
-  const proto = headers.get('x-forwarded-proto') || 'http';
-  if (host) return `${proto}://${host}`.replace(/\/+$/, '');
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+    throw new PasswordRecoveryError('La URL pública de la aplicación no es válida', 500);
+  }
 
-  return new URL(requestUrl).origin.replace(/\/+$/, '');
+  const path = parsed.pathname === '/' ? '' : parsed.pathname.replace(/\/+$/, '');
+  return `${parsed.origin}${path}`;
+}
+
+function buildAppBaseUrl(requestUrl: string): string {
+  const configuredUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.APP_URL;
+  if (configuredUrl) return normalizeAppBaseUrl(configuredUrl);
+
+  if (process.env.NODE_ENV === 'production') {
+    throw new PasswordRecoveryError(
+      'NEXT_PUBLIC_APP_URL o APP_URL debe estar configurada para recuperación de contraseña',
+      500,
+    );
+  }
+
+  return normalizeAppBaseUrl(new URL(requestUrl).origin);
 }
 
 function maskEmail(email: string): string {
@@ -245,7 +262,7 @@ export async function requestPasswordReset({
     throw new PasswordRecoveryError(insertError.message, 500);
   }
 
-  const appBaseUrl = buildAppBaseUrl(requestUrl, headers);
+  const appBaseUrl = buildAppBaseUrl(requestUrl);
   const resetUrl = `${appBaseUrl}/auth/reset-password?token=${encodeURIComponent(token)}`;
 
   try {

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -44,10 +44,12 @@ export const signIn = async (login: SignInDto) => {
     .from('usuario')
     .select('id,nombre,email,password_hash,rol,activo,foto,permisos_menu,must_change_password')
     .eq('email', email)
-    .single();
+    .maybeSingle();
 
   if (error) {
-    console.log('Error al obtener el usuario:', error.message);
+    console.error('Error al consultar el usuario durante el inicio de sesión:', {
+      code: error.code || 'LOGIN_USER_QUERY_ERROR',
+    });
     throw new LoginBusinessError('Error al obtener el usuario', {
       code: 'LOGIN_USER_QUERY_ERROR',
       status: 500,
@@ -55,7 +57,6 @@ export const signIn = async (login: SignInDto) => {
   }
 
   if (!data) {
-    console.log('Email no encontrado');
     throw new LoginBusinessError(
       'Usuario no encontrado o contraseña incorrecta',
       {
@@ -68,7 +69,6 @@ export const signIn = async (login: SignInDto) => {
   const validatePassword = bcrypt.compareSync(password, data.password_hash);
 
   if (!validatePassword) {
-    console.log('Contraseña incorrecta');
     throw new LoginBusinessError(
       'Usuario no encontrado o contraseña incorrecta',
       {
@@ -79,7 +79,6 @@ export const signIn = async (login: SignInDto) => {
   }
 
   if (data.rol !== rol) {
-    console.log('Rol no autorizado');
     throw new LoginBusinessError(
       'Usuario no encontrado o contraseña incorrecta',
       {

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -117,13 +117,14 @@ export function loginSession(token: string) {
   Cookies.set(TOKEN_KEY, token, {
     sameSite: "strict",
     secure: shouldUseSecureCookie(),
+    path: "/",
     ...(expiresAt ? { expires: new Date(expiresAt) } : {}),
   });
 }
 
 export function logoutSession() {
-  Cookies.remove(TOKEN_KEY);
-  Cookies.remove(TERMINAL_TOKEN_KEY);
+  Cookies.remove(TOKEN_KEY, { path: "/" });
+  Cookies.remove(TERMINAL_TOKEN_KEY, { path: "/" });
 
   if (typeof window !== "undefined") {
     try {
@@ -143,6 +144,7 @@ export function loginTerminalSession(token: string) {
   Cookies.set(TERMINAL_TOKEN_KEY, token, {
     sameSite: "strict",
     secure: shouldUseSecureCookie(),
+    path: "/",
     ...(expiresAt ? { expires: new Date(expiresAt) } : {}),
   });
 
@@ -156,7 +158,7 @@ export function loginTerminalSession(token: string) {
 }
 
 export function logoutTerminalSession() {
-  Cookies.remove(TERMINAL_TOKEN_KEY);
+  Cookies.remove(TERMINAL_TOKEN_KEY, { path: "/" });
 
   if (typeof window !== "undefined") {
     try {
@@ -180,7 +182,7 @@ export function getToken() {
 
   if (validCandidates.length === 0) {
     if (cookieToken && isTokenExpired(cookieToken)) {
-      Cookies.remove(TOKEN_KEY);
+      Cookies.remove(TOKEN_KEY, { path: "/" });
     }
 
     return null;
@@ -202,7 +204,7 @@ export function getTerminalToken() {
 
   if (validCandidates.length === 0) {
     if (cookieToken && isTokenExpired(cookieToken)) {
-      Cookies.remove(TERMINAL_TOKEN_KEY);
+      Cookies.remove(TERMINAL_TOKEN_KEY, { path: "/" });
     }
 
     return null;


### PR DESCRIPTION
# security: complete HTTP runtime hardening audit

## Resumen

Esta Pull Request completa la auditoría final de seguridad del runtime HTTP de Gym Master sobre la rama `feature/security-http-runtime-hardening-final-v1`.

El cambio incorpora una defensa en profundidad para el tráfico web: cabeceras globales de navegador, CSP, rate limiting, límites de payload, redacción de errores, origen confiable para recuperación de contraseña, endurecimiento del proxy de imágenes, validación temprana de uploads y mitigación de XSS en el preview Markdown. También incluye dos correcciones descubiertas durante la QA manual: el mapeo correcto de usuarios inexistentes en el login y la compatibilidad segura de las fotos de la Terminal durante pruebas locales en modo producción.

## Motivación

Antes de esta auditoría existían riesgos de runtime que no estaban cubiertos de forma uniforme:

- ausencia de una política global de cabeceras HTTP;
- endpoints públicos y sensibles sin rate limiting homogéneo;
- cuerpos JSON, webhooks y multipart sin límites tempranos consistentes;
- recuperación de contraseña potencialmente dependiente de encabezados controlados por el cliente;
- respuestas 5xx con riesgo de revelar detalles internos;
- CORS wildcard innecesario en rutas same-origin;
- proxy de imágenes sin timeout, límite streaming ni rechazo de SVG;
- preview Markdown con HTML crudo y protocolos de URL peligrosos;
- atributos de cookies sin ruta explícita;
- una consulta de login que trataba la ausencia de usuario como error interno;
- una política HTTPS basada solo en `NODE_ENV` que afectó imágenes HTTP durante QA local con `next start`.

## Alcance consolidado

- **32 archivos únicos** modificados o agregados.
- **1757 inserciones** y **336 eliminaciones** sobre el snapshot limpio.
- **5 archivos nuevos**: middleware, helper de seguridad, verificador y tres documentos técnicos.
- Cabeceras HTTP globales y CSP.
- Rate limiting por instancia en rutas públicas y sensibles.
- Límites de JSON, raw webhook y multipart.
- Recuperación de contraseña con origen configurado.
- Image proxy con timeout, redirects acotados, SSRF y tamaño streaming.
- Validación binaria de adjuntos médicos.
- Redacción de errores y eliminación de CORS wildcard.
- Escape de Markdown y allowlist de protocolos.
- Hotfix de login `401/429`.
- Hotfix de fotos de socios en la Terminal.
- Nuevo gate `npm run test:http-runtime-security`.
- Sin cambios de base de datos, migraciones, RLS, RPC ni contratos funcionales de negocio.

## Cambios principales

### 1. Cabeceras HTTP y CSP

`next.config.js` publica para todas las rutas:

- `Content-Security-Policy`;
- `X-Content-Type-Options: nosniff`;
- `X-Frame-Options: DENY`;
- `Referrer-Policy: strict-origin-when-cross-origin`;
- `Permissions-Policy`;
- `Cross-Origin-Opener-Policy`;
- `Origin-Agent-Cluster`;
- `X-DNS-Prefetch-Control`;
- `X-Permitted-Cross-Domain-Policies`.

También se deshabilita `X-Powered-By` y se limita Server Actions a `1mb`.

`Strict-Transport-Security` y `upgrade-insecure-requests` se aplican cuando el origen configurado de la aplicación es HTTPS y no es loopback. Esto mantiene el endurecimiento real en producción y permite QA local con `next start` sobre HTTP sin romper imágenes o media legítima.

La CSP admite los recursos necesarios para Gym Master:

- imágenes `self`, `data:`, `blob:` y HTTPS;
- media y workers PWA;
- frames de YouTube;
- conexión al origen Supabase configurado y WebSocket;
- cámara para el mismo origen.

Se conserva `unsafe-inline` por compatibilidad con Next.js 14 y ventanas de impresión existentes. La migración a nonces/hashes queda como mejora posterior.

### 2. Rate limiting

Se incorpora `src/middleware.ts` con buckets por IP y política:

| Ruta | Límite |
|---|---:|
| `POST /api/custom-login` | 20 / 10 min |
| `POST /api/auth/forgot-password` | 6 / 15 min |
| `POST /api/auth/reset-password` | 8 / 15 min |
| `GET /api/auth/reset-password` | 60 / 5 min |
| `POST /api/auth/terminal-session/refresh` | 120 / 10 min |
| NextAuth `POST` | 60 / 10 min |
| Scanner público `POST` | 120 / min |
| Scanner público `GET` | 180 / min |
| Verificación pública de pago | 120 / 5 min |
| Image proxy | 240 / min |
| License sync interno | 120 / 5 min |

El almacenamiento está acotado a 5000 buckets con limpieza periódica. Al superar el límite se responde `429` con `Retry-After`, `X-RateLimit-*` y `Cache-Control: no-store`.

### 3. Límites de payload y respuestas seguras

Se agrega `src/lib/security/httpRuntimeSecurity.ts` con:

- `readJsonBody`;
- `readTextBody`;
- `requestBodyTooLargeResponse`;
- `noStoreJson`;
- `runtimeErrorResponse`.

Los helpers validan `Content-Type`, `Content-Length`, tamaño UTF-8 real, JSON válido y respuestas `no-store`.

Se aplican límites explícitos a login, recuperación, reset, cambio de contraseña, scanner, registro QR, confirmación de pago, webhook de Stripe, sincronización de licencia y uploads.

### 4. Recuperación de contraseña

En producción, los enlaces de recuperación solo se construyen desde:

```text
NEXT_PUBLIC_APP_URL
APP_URL
```

No se confía en `Origin`, `Host` ni `X-Forwarded-Host`. La URL configurada debe ser HTTP/HTTPS y no puede contener credenciales embebidas.

### 5. Image proxy

El proxy conserva la validación SSRF y agrega:

- URL máxima de 4096 caracteres;
- timeout de 8 segundos;
- máximo de tres redirects;
- lectura streaming con corte real en 10 MB;
- rechazo de SVG remoto;
- no-store/private cache;
- eliminación de CORS wildcard;
- errores upstream redactados.

### 6. Uploads

Los uploads de perfil, logo, comprobante, media de ejercicios y ficha médica rechazan cuerpos declarados demasiado grandes antes de ejecutar `formData()`.

La ficha médica también valida firma binaria real para PDF, JPG y PNG, además del MIME declarado.

### 7. Cookies, sesión y errores

- NextAuth habilita cookies seguras en producción y mantiene `debug: false`.
- Las cookies bearer propias conservan `SameSite=Strict`, `Secure` sobre HTTPS y `Path=/` al crear y eliminar.
- Los errores 5xx de autenticación, Stripe, scanner, recibos, licencia, uploads y autorización no exponen mensajes de proveedor, SQL ni nombres de variables internas.
- Se retiraron CORS wildcard de las rutas endurecidas.

Los JWT bearer siguen siendo legibles por JavaScript porque los clientes actuales construyen headers `Authorization`. Su migración a cookies `HttpOnly` requiere un cambio arquitectónico y queda fuera de esta PR.

### 8. Prevención de XSS en Markdown

El preview del editor:

- escapa HTML crudo;
- permite enlaces `http`, `https`, `mailto`, rutas relativas y anchors;
- permite imágenes únicamente `http` y `https`;
- rechaza credenciales embebidas y protocolos como `javascript:`;
- agrega `noopener noreferrer nofollow` a enlaces externos.

### 9. Hotfix de mapeo del login

Durante la prueba de rate limiting, un correo inexistente respondía `500` porque la consulta utilizaba `.single()`.

La corrección:

- utiliza `.maybeSingle()`;
- devuelve `401` para correo, contraseña o rol inválidos;
- conserva `403` para usuario inactivo;
- reserva `500` para fallas reales del proveedor;
- evita registrar mensajes internos de Supabase.

QA confirmada:

```text
Solicitudes 1-20 -> 401
Solicitud 21    -> 429
```

### 10. Hotfix de fotos de la Terminal

Durante QA local con `next build` + `next start`, las fotos de socios quedaron bloqueadas porque `NODE_ENV=production` activaba HSTS y `upgrade-insecure-requests` aun cuando la aplicación se probaba sobre HTTP local.

La corrección:

- decide la exigencia HTTPS mediante el origen configurado;
- mantiene HSTS y upgrade para producción HTTPS;
- permite imágenes/media HTTP en QA local;
- normaliza `http://res.cloudinary.com/...` a HTTPS;
- reemplaza imágenes fallidas por `/gm_logo.svg`.

La Terminal fue validada nuevamente con fotos de socios visibles.

## Archivos del cambio

```text
docs/security/security-http-runtime-hardening-final-v1-baseline.md
docs/security/security-http-runtime-hardening-final-v1-login-error-hotfix.md
docs/security/security-http-runtime-hardening-final-v1-terminal-photo-hotfix.md
next.config.js
package.json
scripts/verify-http-runtime-security.mjs
src/middleware.ts
src/lib/security/httpRuntimeSecurity.ts
src/lib/auth/serverAuthorization.ts
src/services/authRecoveryService.ts
src/services/loginService.ts
src/services/storageService.ts
src/components/ui/TextEditor.tsx
src/components/asistencia/AsistenciaTerminalDisplay.tsx
src/app/api/asistencias/registro-qr/route.ts
src/app/api/auth/[...nextauth]/route.ts
src/app/api/auth/change-password/route.ts
src/app/api/auth/forgot-password/route.ts
src/app/api/auth/reset-password/route.ts
src/app/api/auth/terminal-session/refresh/route.ts
src/app/api/comercial/mobile-scanner/public/[token]/route.ts
src/app/api/custom-login/route.ts
src/app/api/file-upload/route.ts
src/app/api/gimnasio-parametrizacion/logo-upload/route.ts
src/app/api/image-proxy/route.ts
src/app/api/internal/dragon-pyramid/license-sync/route.ts
src/app/api/otros_gastos/comprobante-upload/route.ts
src/app/api/pagar-cuota/confirmar/route.ts
src/app/api/pagos/[id]/verificar/route.ts
src/app/api/rutinas/ejercicios-media/upload/route.ts
src/app/api/socios/[id]/ficha-medica/route.ts
src/app/api/stripe-webhook/route.ts
```

## Validación ejecutada

Gate agregado:

```bash
npm run test:http-runtime-security
```

Gate consolidado:

```bash
rm -rf .next

npm run build &&
npm run test:pwa-cache &&
npm run test:pwa-install-update &&
npm run test:auth-rbac &&
npm run test:http-runtime-security &&
npm run test:business-backup-export &&
npm run test:repo-security
```

Resultados confirmados:

- build de producción aprobado;
- gates PWA aprobados;
- Auth/RBAC aprobado;
- exportación de respaldo aprobada;
- seguridad del repositorio aprobada;
- gate HTTP Runtime aprobado;
- cabeceras verificadas en login, dashboard y Swagger;
- login inválido: `401`;
- solicitud 21 del rate limit: `429`;
- recuperación y reset aprobados;
- Terminal, scanner, uploads, proxy, Markdown y cámara QR aprobados;
- fotos de socios restauradas en la Terminal;
- `git diff --check` sin errores.

## Base de datos y contratos funcionales

Esta PR **no modifica**:

- tablas;
- migraciones;
- políticas RLS;
- funciones RPC;
- seeds;
- datos persistidos;
- contratos funcionales principales;
- reglas de negocio.

## Riesgos residuales

| Riesgo | Situación / mitigación |
|---|---|
| Rate limiting por instancia | Complementar con WAF, Vercel Firewall o Redis/KV para despliegues horizontales. |
| CSP con `unsafe-inline` | Migrar scripts/estilos inline a nonces o hashes en una rama futura. |
| JWT bearer legible por JavaScript | Mantener prevención XSS; una migración a `HttpOnly` exige rediseñar clientes. |
| Multipart sin `Content-Length` | Complementar con límites de ingress del proveedor de hosting. |
| DNS rebinding avanzado | Considerar allowlist o pinning de IP/agente si el proxy amplía su exposición. |
| Headers en HTTP local | HSTS se aplica solo cuando el origen configurado es HTTPS no-loopback. |

## Rollback

No existen cambios persistentes ni migraciones. El rollback consiste en revertir el commit o merge de esta PR.

En caso de rollback parcial, deben revertirse conjuntamente:

- `src/middleware.ts`;
- `src/lib/security/httpRuntimeSecurity.ts`;
- modificaciones de `next.config.js`;
- rutas adaptadas a los helpers;
- cambios de cookies y recuperación;
- hotfixes de login y Terminal;
- gate `test:http-runtime-security`.

## Checklist

- [x] Cabeceras HTTP globales configuradas.
- [x] CSP aplicada y adaptada a Gym Master.
- [x] HSTS condicionado a origen HTTPS real.
- [x] `X-Powered-By` deshabilitado.
- [x] Rate limiting con `429` y `Retry-After`.
- [x] Límites de JSON, raw webhook y multipart.
- [x] Recuperación usa origen confiable.
- [x] Image proxy con timeout, redirects y límite streaming.
- [x] SVG remoto rechazado.
- [x] CORS wildcard eliminado.
- [x] Errores 5xx redactados.
- [x] Cookies con `Path=/` determinístico.
- [x] Markdown protegido contra HTML y protocolos peligrosos.
- [x] Login inexistente responde `401`, no `500`.
- [x] Solicitud 21 del login responde `429`.
- [x] Fotos de socios restauradas en la Terminal.
- [x] Build y gates acumulativos aprobados.
- [x] QA manual completa aprobada.
- [x] Sin cambios de DB, migraciones, RLS ni RPC.
