### PR TITLE
feat: add professional PDF output to RAG Coach

### DIFF
--- a/docs/rag/rag-coach-pdf-output-v1.md
+++ b/docs/rag/rag-coach-pdf-output-v1.md
@@ -1,0 +1,106 @@
+# RAG Coach PDF output v1
+
+## Objetivo
+
+Agregar una exportación PDF profesional y directa para cada respuesta útil generada por el Coach IA unificado de Gym Master.
+
+La salida se genera en el navegador desde `/dashboard/coach` y no captura el layout del dashboard, sidebar, modo oscuro ni componentes visuales de la pantalla.
+
+## Alcance funcional
+
+Cada respuesta exitosa emitida después de una consulta muestra la acción:
+
+```text
+Descargar informe PDF / Download PDF report
+```
+
+El documento incluye, cuando existe:
+
+- identidad visual y textos institucionales configurados para el gimnasio;
+- socio asociado a la respuesta, con snapshot de nombre, DNI y email;
+- fecha de emisión y usuario que generó el informe;
+- consulta original y respuesta del Coach IA;
+- intención y confianza contextual;
+- resumen y snapshot operativo del socio;
+- rutina generada y ejercicios organizados por día;
+- dieta generada y comidas interpretadas desde observaciones;
+- análisis de evolución con métricas, recomendaciones, alertas y disclaimers;
+- acciones, fuentes RAG, similitud, QA y notas de seguridad;
+- memoria, pistas, próximos pasos y sugerencias de continuidad;
+- aviso responsable, texto legal y pie institucional;
+- numeración `Página X de Y` / `Page X of Y`.
+
+## Gobernanza ES/EN
+
+El PDF utiliza el `locale` activo de la interfaz:
+
+- `es`: títulos, etiquetas, fechas, días, comidas y aviso responsable en español;
+- `en`: títulos, etiquetas, fechas, días, comidas y aviso responsable en inglés.
+
+Los datos reales cargados por el gimnasio o el socio se mantienen sin traducción automática. Solo se traducen etiquetas y contenido propio del sistema, siguiendo la gobernanza previa de contenido generado por IA.
+
+## Seguridad y propiedad
+
+- El botón se encuentra dentro de `/dashboard/coach`, que ya exige una sesión autenticada.
+- No se agrega un endpoint público de exportación.
+- El PDF usa el snapshot del socio asociado al momento de generar la respuesta. Cambiar posteriormente el selector administrativo no altera el destinatario del informe anterior.
+- No se vuelcan objetos internos completos ni JSON técnico crudo.
+- Las imágenes del branding pasan por el proxy interno cuando son externas.
+- El documento no contiene tokens, permisos, IDs internos ni trazas de autenticación.
+
+## Archivos principales
+
+```text
+src/app/dashboard/coach/page.tsx
+src/utils/ragCoachPdf.ts
+scripts/verify-rag-coach-pdf-output.mjs
+package.json
+docs/rag/rag-coach-pdf-output-v1.md
+```
+
+## Alcance técnico excluido
+
+No se modifican:
+
+```text
+src/app/api/rag/coach/chat/route.ts
+src/services/server/ragCoachUnifiedChatService.ts
+database/
+supabase/migrations/
+```
+
+Tampoco se modifican contratos de API, tablas, migraciones, RLS, RPC ni persistencia del historial conversacional.
+
+## Validación automática
+
+```bash
+npm run test:rag-coach-pdf
+```
+
+Gate acumulativo recomendado:
+
+```bash
+rm -rf .next
+
+npm run build &&
+npm run test:pwa-cache &&
+npm run test:pwa-install-update &&
+npm run test:auth-rbac &&
+npm run test:http-runtime-security &&
+npm run test:rag-coach-pdf &&
+npm run test:business-backup-export &&
+npm run test:repo-security
+```
+
+## QA manual
+
+1. Ingresar como socio y solicitar orientación general; descargar el PDF.
+2. Solicitar una rutina; verificar días, ejercicios, series, repeticiones, fuentes y QA.
+3. Solicitar una dieta; verificar fechas, comidas, warnings y disclaimer.
+4. Solicitar análisis de evolución; verificar métricas, recomendaciones y alertas.
+5. Cambiar ES/EN y repetir una exportación.
+6. Ingresar como administrador, seleccionar un socio y generar un informe.
+7. Cambiar el selector de socio antes de descargar un informe anterior y comprobar que el PDF conserva el snapshot correcto.
+8. Probar textos largos y verificar saltos de página, footer y ausencia de cortes.
+9. Validar logo configurado y fallback `/gm_logo.svg`.
+10. Confirmar que el botón no aparece en el saludo inicial ni en respuestas de error.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:pwa-install-update": "node scripts/verify-pwa-install-update.mjs",
     "test:auth-rbac": "node scripts/verify-auth-rbac-security.mjs",
     "test:http-runtime-security": "node scripts/verify-http-runtime-security.mjs",
+    "test:rag-coach-pdf": "node scripts/verify-rag-coach-pdf-output.mjs",
     "test:business-backup-export": "node scripts/verify-business-backup-export.mjs",
     "security:cleanup-local-artifacts": "node scripts/cleanup-local-repo-artifacts.mjs",
     "test:repo-security": "node scripts/verify-repo-security.mjs"

--- a/scripts/verify-rag-coach-pdf-output.mjs
+++ b/scripts/verify-rag-coach-pdf-output.mjs
@@ -1,0 +1,110 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const failures = [];
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function assert(condition, message) {
+  if (!condition) failures.push(message);
+}
+
+function includesAll(source, snippets) {
+  return snippets.every((snippet) => source.includes(snippet));
+}
+
+const packageJson = JSON.parse(read('package.json'));
+assert(
+  packageJson.scripts?.['test:rag-coach-pdf'] === 'node scripts/verify-rag-coach-pdf-output.mjs',
+  'package.json must expose the RAG Coach PDF verification gate.',
+);
+
+const pdf = read('src/utils/ragCoachPdf.ts');
+assert(
+  includesAll(pdf, [
+    'import jsPDF from "jspdf";',
+    'getResolvedGimnasioBranding',
+    'buildTimestampedDownloadFileName',
+    'export async function descargarRagCoachPdf',
+    'addContextSnapshot',
+    'addRoutinePayload',
+    'addDietPayload',
+    'addEvolutionPayload',
+    'addSources',
+    'addFooter',
+    'textoLegalReportes',
+    'piePagina',
+  ]),
+  'The PDF utility must cover branding, context, routines, diets, evolution, sources and paginated footer output.',
+);
+assert(
+  includesAll(pdf, [
+    'ensureSpace(state',
+    'addPage(state)',
+    'CONTENT_BOTTOM',
+    'splitTextToSize',
+    'getNumberOfPages()',
+  ]),
+  'The PDF utility must wrap long text and add pages before content reaches the footer.',
+);
+assert(
+  includesAll(pdf, [
+    'locale = "es"',
+    'translateCoreDayLabel',
+    'translateCoreFoodItem',
+    'translateCoreLevel',
+    'translateCoreObjective',
+    'Responsible notice',
+  ]),
+  'The PDF utility must preserve ES/EN governance and translate system-owned labels.',
+);
+assert(
+  !pdf.includes('JSON.stringify(action.payload)') && !pdf.includes('doc.html('),
+  'The export must not dump raw payload JSON or capture the dashboard DOM.',
+);
+
+const coachPage = read('src/app/dashboard/coach/page.tsx');
+assert(
+  includesAll(coachPage, [
+    "import { descargarRagCoachPdf } from '@/utils/ragCoachPdf';",
+    "import { toast } from 'sonner';",
+    'FileDown,',
+    'createdAt: string;',
+    'requestMessage?: string;',
+    'socioSnapshot?: {',
+    'const handleDownloadPdf = async (message: ChatMessage)',
+    'message.socioSnapshot ??',
+    "locale: locale === 'en' ? 'en' : 'es'",
+    "c('Descargar informe PDF', 'Download PDF report')",
+  ]),
+  'Coach UI must capture the member/message snapshot and offer an ES/EN PDF download for successful assistant responses.',
+);
+assert(
+  coachPage.includes("message.role === 'assistant' && message.requestMessage") &&
+    coachPage.includes('disabled={Boolean(exportingPdfMessageId)}'),
+  'Only generated assistant responses must expose a guarded download action.',
+);
+
+const forbiddenApiOrDatabaseChanges = [
+  'src/app/api/rag/coach/chat/route.ts',
+  'src/services/server/ragCoachUnifiedChatService.ts',
+  'database/',
+  'supabase/migrations/',
+];
+const documentation = read('docs/rag/rag-coach-pdf-output-v1.md');
+for (const marker of forbiddenApiOrDatabaseChanges) {
+  assert(documentation.includes(marker), `Documentation must state the status of ${marker}.`);
+}
+
+if (failures.length > 0) {
+  console.error('RAG Coach PDF output verification failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('RAG Coach PDF output OK: authenticated Coach responses expose a professional browser-generated PDF download.');
+console.log('RAG Coach PDF layout OK: branding, member snapshot, ES/EN content, actions, context, sources, QA, safety and page footers are covered.');
+console.log('RAG Coach PDF scope OK: no API contract, database, migration, RLS or RPC changes are required.');

--- a/src/app/dashboard/coach/page.tsx
+++ b/src/app/dashboard/coach/page.tsx
@@ -13,6 +13,7 @@ import {
   Brain,
   CheckCircle2,
   Dumbbell,
+  FileDown,
   History,
   Info,
   Loader2,
@@ -46,6 +47,8 @@ import { fetchSociosApi } from '@/services/browser/socioApiClient';
 import { useAuthStore } from '@/stores/authStore';
 import { useI18n } from '@/i18n/I18nProvider';
 import { translateCoreLevel, translateCoreObjective } from '@/utils/coreSeedI18n';
+import { descargarRagCoachPdf } from '@/utils/ragCoachPdf';
+import { toast } from 'sonner';
 
 type ChatMessage = {
   id: string;
@@ -65,6 +68,13 @@ type ChatMessage = {
   memoryHighlights?: string[];
   memoryTrace?: string[];
   contextConfidence?: 'alta' | 'media' | 'baja';
+  createdAt: string;
+  requestMessage?: string;
+  socioSnapshot?: {
+    name: string;
+    dni?: string | null;
+    email?: string | null;
+  };
 };
 
 const coachCapabilities = [
@@ -356,6 +366,7 @@ export default function CoachIaPage() {
   const [sociosError, setSociosError] = useState<string | null>(null);
   const [selectedSocioId, setSelectedSocioId] = useState('');
   const [socioSearch, setSocioSearch] = useState('');
+  const [exportingPdfMessageId, setExportingPdfMessageId] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const totalAssistantMessages = messages.filter((message) => message.role === 'assistant').length;
   const totalActionMessages = messages.reduce((total, message) => total + (message.actions?.filter((action) => action.ok).length ?? 0), 0);
@@ -449,6 +460,7 @@ export default function CoachIaPage() {
         ),
         suggestedReplies: localizedQuickPrompts,
         nextBestStep: c('Contame tu objetivo, disponibilidad semanal, nivel y restricciones.', 'Tell me your goal, weekly availability, level, and restrictions.'),
+        createdAt: new Date().toISOString(),
       },
     ]);
   }, [c, displayName, isAuthenticated, isInitialized, localizedQuickPrompts, messages.length]);
@@ -481,6 +493,7 @@ export default function CoachIaPage() {
       id: createId(),
       role: 'user',
       content: message,
+      createdAt: new Date().toISOString(),
     };
 
     setMessages((current) => [...current, userMessage]);
@@ -489,6 +502,23 @@ export default function CoachIaPage() {
       const effectiveSocioId = isAdminSession
         ? selectedSocioId || undefined
         : user?.id_socio || undefined;
+      const socioSnapshot = selectedSocio
+        ? {
+            name: selectedSocio.nombre_completo?.trim() || selectedSocio.email?.trim() || c('Socio', 'Member'),
+            dni: selectedSocio.dni,
+            email: selectedSocio.email,
+          }
+        : isAdminSession
+          ? {
+              name: c('Sin socio seleccionado', 'No member selected'),
+              dni: null,
+              email: null,
+            }
+          : {
+              name: displayName,
+              dni: typeof (user as { dni?: unknown } | null)?.dni === 'string' ? String((user as { dni?: string }).dni) : null,
+              email: user?.email ?? null,
+            };
 
       const res = await enviarMensajeCoachIa({
         message,
@@ -519,6 +549,9 @@ export default function CoachIaPage() {
         memoryHighlights: res.data.memoryHighlights,
         memoryTrace: res.data.memoryTrace,
         contextConfidence: res.data.contextConfidence,
+        createdAt: new Date().toISOString(),
+        requestMessage: message,
+        socioSnapshot,
       };
 
       setMessages((current) => [...current, assistantMessage]);
@@ -532,10 +565,35 @@ export default function CoachIaPage() {
             ? error.message
             : c('Ocurrió un error al consultar el Coach IA.', 'An error occurred while consulting the AI Coach.'),
           nextBestStep: c('Reintentá en unos segundos o revisá los módulos de rutinas, dietas y evolución desde el menú.', 'Try again in a few seconds or review the routines, diets, and physical evolution modules from the menu.'),
+          createdAt: new Date().toISOString(),
         },
       ]);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleDownloadPdf = async (message: ChatMessage) => {
+    if (!message.requestMessage || exportingPdfMessageId) return;
+
+    setExportingPdfMessageId(message.id);
+
+    try {
+      await descargarRagCoachPdf({
+        message,
+        subject: message.socioSnapshot ?? {
+          name: message.contextSnapshot?.socioName?.trim() || displayName,
+          email: user?.email ?? null,
+        },
+        generatedBy: displayName,
+        locale: locale === 'en' ? 'en' : 'es',
+      });
+      toast.success(c('Informe del RAG Coach descargado correctamente.', 'RAG Coach report downloaded successfully.'));
+    } catch (error) {
+      console.error('Error al descargar informe RAG Coach:', error);
+      toast.error(c('No se pudo descargar el informe del RAG Coach.', 'The RAG Coach report could not be downloaded.'));
+    } finally {
+      setExportingPdfMessageId(null);
     }
   };
 
@@ -556,6 +614,7 @@ export default function CoachIaPage() {
         ),
         suggestedReplies: localizedQuickPrompts,
         nextBestStep: c('Elegí una sugerencia o escribí tu consulta completa.', 'Choose a suggestion or write your full question.'),
+        createdAt: new Date().toISOString(),
       },
     ]);
   };
@@ -838,6 +897,29 @@ export default function CoachIaPage() {
                                       {suggestion}
                                     </button>
                                   ))}
+                                </div>
+                              )}
+
+
+                              {message.role === 'assistant' && message.requestMessage && (
+                                <div className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-700">
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    className="h-9 rounded-xl bg-white text-xs dark:bg-slate-950/60"
+                                    onClick={() => handleDownloadPdf(message)}
+                                    disabled={Boolean(exportingPdfMessageId)}
+                                  >
+                                    {exportingPdfMessageId === message.id ? (
+                                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                                    ) : (
+                                      <FileDown className="mr-1.5 h-3.5 w-3.5" />
+                                    )}
+                                    {exportingPdfMessageId === message.id
+                                      ? c('Generando PDF...', 'Generating PDF...')
+                                      : c('Descargar informe PDF', 'Download PDF report')}
+                                  </Button>
                                 </div>
                               )}
                             </div>

--- a/src/utils/ragCoachPdf.ts
+++ b/src/utils/ragCoachPdf.ts
@@ -1,0 +1,803 @@
+"use client";
+
+import jsPDF from "jspdf";
+
+import type {
+  RagCoachChatActionResult,
+  RagCoachChatIntent,
+  RagCoachChatSource,
+  RagCoachContextSnapshot,
+} from "@/interfaces/ragCoachChat.interface";
+import { buildTimestampedDownloadFileName } from "@/utils/downloadFileName";
+import {
+  translateCoreDayLabel,
+  translateCoreFoodItem,
+  translateCoreLevel,
+  translateCoreMealTitle,
+  translateCoreMuscleGroup,
+  translateCoreObjective,
+} from "@/utils/coreSeedI18n";
+import { getResolvedGimnasioBranding } from "@/utils/gimnasioBrandingClient";
+
+export type RagCoachPdfLocale = "es" | "en";
+
+export interface RagCoachPdfSubject {
+  name: string;
+  dni?: string | null;
+  email?: string | null;
+}
+
+export interface RagCoachPdfMessage {
+  content: string;
+  createdAt?: string;
+  requestMessage?: string;
+  actions?: RagCoachChatActionResult[];
+  suggestedReplies?: string[];
+  contextSummary?: string;
+  contextHints?: string[];
+  coachNotes?: string[];
+  nextBestStep?: string;
+  safetySummary?: string;
+  qaSummary?: string;
+  intent?: RagCoachChatIntent;
+  missingParams?: string[];
+  contextSnapshot?: RagCoachContextSnapshot;
+  memoryHighlights?: string[];
+  memoryTrace?: string[];
+  contextConfidence?: "alta" | "media" | "baja";
+}
+
+interface DescargarRagCoachPdfParams {
+  message: RagCoachPdfMessage;
+  subject: RagCoachPdfSubject;
+  generatedBy?: string | null;
+  locale?: RagCoachPdfLocale;
+}
+
+type UnknownRecord = Record<string, unknown>;
+type PdfState = {
+  doc: jsPDF;
+  y: number;
+  locale: RagCoachPdfLocale;
+  brandName: string;
+  brandSubtitle: string;
+  logoData: string | null;
+};
+
+const PAGE_WIDTH = 210;
+const PAGE_HEIGHT = 297;
+const PAGE_MARGIN = 14;
+const CONTENT_WIDTH = PAGE_WIDTH - PAGE_MARGIN * 2;
+const CONTENT_BOTTOM = 278;
+const LINE_HEIGHT = 5.2;
+
+const COLORS = {
+  navy: [15, 23, 42] as const,
+  cyan: [2, 168, 225] as const,
+  slate: [71, 85, 105] as const,
+  lightSlate: [241, 245, 249] as const,
+  border: [203, 213, 225] as const,
+  green: [5, 150, 105] as const,
+  amber: [180, 83, 9] as const,
+  violet: [109, 40, 217] as const,
+};
+
+const tx = (locale: RagCoachPdfLocale, es: string, en: string) =>
+  locale === "en" ? en : es;
+
+function safeText(value: unknown, fallback = "-"): string {
+  if (value === null || value === undefined || value === "") return fallback;
+
+  return String(value)
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")
+    .replace(/[\u{1F300}-\u{1FAFF}]/gu, "")
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[–—]/g, "-")
+    .replace(/\u00a0/g, " ")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim() || fallback;
+}
+
+function asRecord(value: unknown): UnknownRecord | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as UnknownRecord;
+}
+
+function parseMaybeJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) return value;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function numericValue(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatDateTime(value: string | undefined, locale: RagCoachPdfLocale): string {
+  const parsed = value ? new Date(value) : new Date();
+  const date = Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+
+  return new Intl.DateTimeFormat(locale === "en" ? "en-US" : "es-AR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function formatDate(value: unknown, locale: RagCoachPdfLocale): string {
+  if (!value) return "-";
+  const parsed = new Date(String(value));
+  if (Number.isNaN(parsed.getTime())) return safeText(value);
+
+  return new Intl.DateTimeFormat(locale === "en" ? "en-US" : "es-AR", {
+    dateStyle: "medium",
+  }).format(parsed);
+}
+
+function formatMetric(value: unknown, suffix: string, locale: RagCoachPdfLocale): string {
+  const number = numericValue(value);
+  if (number === null) return "-";
+  const prefix = number > 0 ? "+" : "";
+  return `${prefix}${number.toLocaleString(locale === "en" ? "en-US" : "es-AR", { maximumFractionDigits: 2 })}${suffix}`;
+}
+
+function formatSimilarity(value?: number): string | null {
+  if (typeof value !== "number" || Number.isNaN(value)) return null;
+  return `${Math.max(0, Math.min(100, Math.round(value * 100)))}%`;
+}
+
+function normalizeImageUrl(url: string): string {
+  const value = url.trim();
+  if (!value || value.startsWith("data:")) return value;
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return `/api/image-proxy?url=${encodeURIComponent(value)}`;
+  }
+  return value;
+}
+
+async function loadImageAsDataUrl(
+  url: string,
+  maxWidth = 600,
+  maxHeight = 600,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    if (!url) {
+      resolve(null);
+      return;
+    }
+
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+
+    image.onload = () => {
+      try {
+        const ratio = Math.min(maxWidth / image.width, maxHeight / image.height, 1);
+        const canvas = document.createElement("canvas");
+        canvas.width = Math.max(1, Math.round(image.width * ratio));
+        canvas.height = Math.max(1, Math.round(image.height * ratio));
+        const context = canvas.getContext("2d");
+
+        if (!context) {
+          resolve(null);
+          return;
+        }
+
+        context.fillStyle = "#ffffff";
+        context.fillRect(0, 0, canvas.width, canvas.height);
+        context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        resolve(canvas.toDataURL("image/png"));
+      } catch {
+        resolve(null);
+      }
+    };
+
+    image.onerror = () => resolve(null);
+    image.src = normalizeImageUrl(url);
+  });
+}
+
+function addContinuationHeader(state: PdfState): void {
+  const { doc, brandName, locale } = state;
+  doc.setFillColor(...COLORS.navy);
+  doc.rect(0, 0, PAGE_WIDTH, 15, "F");
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8.5);
+  doc.setTextColor(255, 255, 255);
+  doc.text(safeText(brandName), PAGE_MARGIN, 9.5);
+  doc.setFont("helvetica", "normal");
+  doc.text(tx(locale, "Informe RAG Coach", "RAG Coach report"), PAGE_WIDTH - PAGE_MARGIN, 9.5, {
+    align: "right",
+  });
+  state.y = 23;
+}
+
+function addPage(state: PdfState): void {
+  state.doc.addPage();
+  addContinuationHeader(state);
+}
+
+function ensureSpace(state: PdfState, requiredHeight: number): void {
+  if (state.y + requiredHeight <= CONTENT_BOTTOM) return;
+  addPage(state);
+}
+
+function addWrappedText(
+  state: PdfState,
+  text: unknown,
+  options: {
+    x?: number;
+    width?: number;
+    fontSize?: number;
+    lineHeight?: number;
+    color?: readonly [number, number, number];
+    fontStyle?: "normal" | "bold" | "italic";
+    gapAfter?: number;
+  } = {},
+): void {
+  const value = safeText(text, "");
+  if (!value) return;
+
+  const x = options.x ?? PAGE_MARGIN;
+  const width = options.width ?? CONTENT_WIDTH;
+  const fontSize = options.fontSize ?? 9.4;
+  const lineHeight = options.lineHeight ?? LINE_HEIGHT;
+  const lines = state.doc.splitTextToSize(value, width) as string[];
+  const requiredHeight = Math.max(lineHeight, lines.length * lineHeight) + (options.gapAfter ?? 2);
+
+  ensureSpace(state, requiredHeight);
+  state.doc.setFont("helvetica", options.fontStyle ?? "normal");
+  state.doc.setFontSize(fontSize);
+  state.doc.setTextColor(...(options.color ?? COLORS.slate));
+  state.doc.text(lines, x, state.y);
+  state.y += requiredHeight;
+}
+
+function addSectionTitle(
+  state: PdfState,
+  title: string,
+  color: readonly [number, number, number] = COLORS.cyan,
+): void {
+  ensureSpace(state, 13);
+  state.doc.setFillColor(248, 250, 252);
+  state.doc.setDrawColor(...COLORS.border);
+  state.doc.roundedRect(PAGE_MARGIN, state.y - 4.2, CONTENT_WIDTH, 9, 2, 2, "FD");
+  state.doc.setFillColor(...color);
+  state.doc.roundedRect(PAGE_MARGIN, state.y - 4.2, 3, 9, 1, 1, "F");
+  state.doc.setFont("helvetica", "bold");
+  state.doc.setFontSize(10.5);
+  state.doc.setTextColor(...COLORS.navy);
+  state.doc.text(safeText(title), PAGE_MARGIN + 6, state.y + 1.5);
+  state.y += 12;
+}
+
+function addLabelValue(state: PdfState, label: string, value: unknown): void {
+  const safeValue = safeText(value);
+  const labelWidth = 42;
+  const lines = state.doc.splitTextToSize(safeValue, CONTENT_WIDTH - labelWidth - 4) as string[];
+  const height = Math.max(7, lines.length * 4.7 + 2);
+  ensureSpace(state, height);
+
+  state.doc.setFont("helvetica", "bold");
+  state.doc.setFontSize(8.3);
+  state.doc.setTextColor(...COLORS.navy);
+  state.doc.text(safeText(label), PAGE_MARGIN, state.y);
+
+  state.doc.setFont("helvetica", "normal");
+  state.doc.setTextColor(...COLORS.slate);
+  state.doc.text(lines, PAGE_MARGIN + labelWidth, state.y);
+  state.y += height;
+}
+
+function addBulletList(
+  state: PdfState,
+  values: unknown[] | undefined,
+  emptyLabel?: string,
+): void {
+  const items = (values ?? []).map((value) => safeText(value, "")).filter(Boolean);
+  if (items.length === 0) {
+    if (emptyLabel) addWrappedText(state, emptyLabel, { fontStyle: "italic" });
+    return;
+  }
+
+  for (const item of items) {
+    const lines = state.doc.splitTextToSize(item, CONTENT_WIDTH - 7) as string[];
+    const height = Math.max(5.2, lines.length * 5.2) + 1.5;
+    ensureSpace(state, height);
+    state.doc.setFont("helvetica", "bold");
+    state.doc.setFontSize(9.2);
+    state.doc.setTextColor(...COLORS.cyan);
+    state.doc.text("•", PAGE_MARGIN + 1, state.y);
+    state.doc.setFont("helvetica", "normal");
+    state.doc.setTextColor(...COLORS.slate);
+    state.doc.text(lines, PAGE_MARGIN + 7, state.y);
+    state.y += height;
+  }
+}
+
+function actionLabel(type: RagCoachChatActionResult["type"], locale: RagCoachPdfLocale): string {
+  if (type === "routine_generated") return tx(locale, "Rutina generada", "Generated routine");
+  if (type === "diet_generated") return tx(locale, "Dieta generada", "Generated diet");
+  if (type === "evolution_analyzed") return tx(locale, "Evolución analizada", "Analyzed evolution");
+  return tx(locale, "Orientación", "Guidance");
+}
+
+function intentLabel(intent: RagCoachChatIntent | undefined, locale: RagCoachPdfLocale): string {
+  if (intent === "routine_request") return tx(locale, "Solicitud de rutina", "Routine request");
+  if (intent === "diet_request") return tx(locale, "Solicitud de dieta", "Diet request");
+  if (intent === "routine_and_diet_request") return tx(locale, "Solicitud de rutina y dieta", "Routine and diet request");
+  if (intent === "evolution_analysis_request") return tx(locale, "Análisis de evolución", "Evolution analysis");
+  if (intent === "general_guidance") return tx(locale, "Orientación general", "General guidance");
+  if (intent === "unknown") return tx(locale, "Intención pendiente", "Pending intent");
+  return "-";
+}
+
+function confidenceLabel(value: RagCoachPdfMessage["contextConfidence"], locale: RagCoachPdfLocale): string {
+  if (value === "alta") return tx(locale, "Alta", "High");
+  if (value === "media") return tx(locale, "Media", "Medium");
+  if (value === "baja") return tx(locale, "Baja", "Low");
+  return tx(locale, "No informada", "Not reported");
+}
+
+function addContextSnapshot(state: PdfState, snapshot: RagCoachContextSnapshot): void {
+  addSectionTitle(state, tx(state.locale, "Contexto operativo aplicado", "Applied operational context"), COLORS.green);
+  addLabelValue(state, tx(state.locale, "Socio", "Member"), snapshot.socioName || "-");
+  addLabelValue(state, tx(state.locale, "Objetivo", "Goal"), translateCoreObjective(snapshot.objetivoLabel, state.locale));
+  addLabelValue(state, tx(state.locale, "Nivel", "Level"), translateCoreLevel(snapshot.nivelLabel, state.locale));
+  addLabelValue(state, tx(state.locale, "Días por semana", "Days per week"), snapshot.diasPorSemana ?? "-");
+  addLabelValue(state, tx(state.locale, "Rutinas / Dietas / Evolución", "Routines / Diets / Evolution"), `${snapshot.rutinasTotal} / ${snapshot.dietasTotal} / ${snapshot.evolucionTotal}`);
+  addLabelValue(state, tx(state.locale, "Asistencia 7 / 30 días", "7 / 30 day attendance"), `${snapshot.asistencia7Dias} / ${snapshot.asistencia30Dias}`);
+  addLabelValue(state, tx(state.locale, "Ficha médica", "Medical record"), snapshot.fichaMedicaExiste ? tx(state.locale, "Disponible", "Available") : tx(state.locale, "No disponible", "Not available"));
+  addLabelValue(state, tx(state.locale, "Restricciones médicas", "Medical restrictions"), snapshot.restriccionesMedicas);
+  addLabelValue(state, tx(state.locale, "Preparación contextual", "Context readiness"), `${snapshot.readinessScore}% · ${safeText(snapshot.readinessLabel)}`);
+}
+
+function sourceLine(source: RagCoachChatSource, locale: RagCoachPdfLocale): string {
+  const metadata = [source.domain, source.sourceTable].filter(Boolean).join(" · ");
+  const similarity = formatSimilarity(source.similarity);
+  return [
+    safeText(source.title),
+    metadata || null,
+    similarity ? `${tx(locale, "similitud", "similarity")} ${similarity}` : null,
+  ].filter(Boolean).join(" · ");
+}
+
+function addSources(state: PdfState, sources: RagCoachChatSource[] | undefined): void {
+  if (!sources?.length) return;
+
+  addSectionTitle(state, tx(state.locale, "Fuentes RAG recuperadas", "Retrieved RAG sources"), COLORS.violet);
+  for (const source of sources) {
+    addWrappedText(state, sourceLine(source, state.locale), {
+      fontStyle: "bold",
+      color: COLORS.navy,
+      gapAfter: 1,
+    });
+    if (source.contentPreview) {
+      addWrappedText(state, source.contentPreview, {
+        x: PAGE_MARGIN + 4,
+        width: CONTENT_WIDTH - 4,
+        fontSize: 8.4,
+        lineHeight: 4.6,
+        gapAfter: 3,
+      });
+    }
+  }
+}
+
+function getRoutineDays(payload: UnknownRecord): Array<{ day: string; exercises: unknown[] }> {
+  const generated = asRecord(payload.rutinaGenerada) ?? payload;
+  const structured = parseMaybeJson(generated.rutina_desc ?? generated.contenido ?? generated);
+  const record = asRecord(structured);
+  if (!record) return [];
+
+  if (Array.isArray(record.dias)) {
+    return record.dias.map((dayData, index) => {
+      const dayRecord = asRecord(dayData);
+      const exercises = Array.isArray(dayRecord?.ejercicios)
+        ? dayRecord.ejercicios
+        : Array.isArray(dayRecord?.items)
+          ? dayRecord.items
+          : Array.isArray(dayData)
+            ? dayData
+            : [];
+      return {
+        day: safeText(dayRecord?.dia ?? dayRecord?.nombre_dia ?? dayRecord?.dia_semana ?? `${index + 1}`),
+        exercises,
+      };
+    });
+  }
+
+  const week = asRecord(record.semana);
+  if (week) {
+    return Object.entries(week).map(([day, value]) => {
+      const dayRecord = asRecord(value);
+      const exercises = Array.isArray(value)
+        ? value
+        : Array.isArray(dayRecord?.ejercicios)
+          ? dayRecord.ejercicios
+          : Array.isArray(dayRecord?.items)
+            ? dayRecord.items
+            : [];
+      return { day, exercises };
+    });
+  }
+
+  const knownDays = ["lunes", "martes", "miercoles", "miércoles", "jueves", "viernes", "sabado", "sábado", "domingo"];
+  return knownDays
+    .filter((day) => Array.isArray(record[day]))
+    .map((day) => ({ day, exercises: record[day] as unknown[] }));
+}
+
+function routineExerciseLine(value: unknown, locale: RagCoachPdfLocale): string {
+  const exercise = asRecord(value);
+  if (!exercise) return safeText(value);
+
+  const name = safeText(exercise.nombre ?? exercise.ejercicio ?? exercise.nombre_ejercicio, tx(locale, "Ejercicio", "Exercise"));
+  const group = safeText(exercise.grupo_muscular ?? exercise.grupo_nombre ?? exercise.grupo, "");
+  const series = safeText(exercise.series ?? exercise.sets, "");
+  const reps = safeText(exercise.reps ?? exercise.repeticiones, "");
+  const restValue = exercise.descanso_seg ?? exercise.descanso;
+  const rest = restValue === undefined || restValue === null || restValue === ""
+    ? ""
+    : `${safeText(restValue)}${exercise.descanso_seg !== undefined ? "s" : ""}`;
+
+  return [
+    name,
+    group ? translateCoreMuscleGroup(group, locale) : null,
+    series ? `${tx(locale, "series", "sets")}: ${series}` : null,
+    reps ? `${tx(locale, "repeticiones", "repetitions")}: ${reps}` : null,
+    rest ? `${tx(locale, "descanso", "rest")}: ${rest}` : null,
+  ].filter(Boolean).join(" · ");
+}
+
+function addRoutinePayload(state: PdfState, payload: UnknownRecord): void {
+  addLabelValue(state, tx(state.locale, "Objetivo", "Goal"), safeText(payload.objetivo));
+  addLabelValue(state, tx(state.locale, "Nivel", "Level"), safeText(payload.nivel));
+  addLabelValue(state, tx(state.locale, "Días", "Days"), safeText(payload.dias));
+  if (payload.restricciones) {
+    addLabelValue(state, tx(state.locale, "Restricciones", "Restrictions"), payload.restricciones);
+  }
+
+  const days = getRoutineDays(payload);
+  if (!days.length) return;
+
+  for (const day of days) {
+    addWrappedText(state, translateCoreDayLabel(day.day, state.locale), {
+      fontStyle: "bold",
+      color: COLORS.navy,
+      gapAfter: 2,
+    });
+    addBulletList(state, day.exercises.map((exercise) => routineExerciseLine(exercise, state.locale)));
+    state.y += 2;
+  }
+}
+
+function getDietBlocks(value: unknown): Array<{ title: string; items: string[] }> {
+  const parsed = parseMaybeJson(value);
+
+  if (Array.isArray(parsed)) {
+    return parsed.map((entry, index) => {
+      const record = asRecord(entry);
+      const items = Array.isArray(record?.items)
+        ? record.items.map((item) => safeText(item))
+        : [safeText(record?.descripcion ?? record?.detalle ?? entry)];
+      return {
+        title: safeText(record?.title ?? record?.comida ?? `${index + 1}`),
+        items,
+      };
+    });
+  }
+
+  const record = asRecord(parsed);
+  if (!record) return typeof parsed === "string" ? [{ title: "", items: [safeText(parsed)] }] : [];
+
+  return Object.entries(record).map(([title, rawItems]) => {
+    const nested = asRecord(rawItems);
+    const items = Array.isArray(rawItems)
+      ? rawItems.map((item) => safeText(item))
+      : Array.isArray(nested?.items)
+        ? (nested.items as unknown[]).map((item) => safeText(item))
+        : [safeText(nested?.descripcion ?? nested?.detalle ?? rawItems)];
+    return { title, items };
+  });
+}
+
+function addDietPayload(state: PdfState, payload: UnknownRecord): void {
+  const generated = asRecord(payload.dietaGenerada);
+  addLabelValue(state, tx(state.locale, "Objetivo", "Goal"), generated?.objetivo ?? payload.objetivo);
+  addLabelValue(state, tx(state.locale, "Inicio", "Start"), formatDate(generated?.fecha_inicio ?? payload.fecha_inicio, state.locale));
+  addLabelValue(state, tx(state.locale, "Fin", "End"), formatDate(generated?.fecha_fin ?? payload.fecha_fin, state.locale));
+  if (generated?.nombre_plan) {
+    addLabelValue(state, tx(state.locale, "Plan", "Plan"), generated.nombre_plan);
+  }
+
+  const blocks = getDietBlocks(generated?.observaciones);
+  for (const block of blocks) {
+    if (block.title) {
+      addWrappedText(state, translateCoreMealTitle(block.title, state.locale), {
+        fontStyle: "bold",
+        color: COLORS.navy,
+        gapAfter: 2,
+      });
+    }
+    addBulletList(state, block.items.map((item) => translateCoreFoodItem(item, state.locale)));
+    state.y += 2;
+  }
+}
+
+function addEvolutionPayload(state: PdfState, payload: UnknownRecord): void {
+  const progress = asRecord(payload.progreso);
+  if (payload.resumen) addWrappedText(state, payload.resumen, { gapAfter: 4 });
+
+  if (progress) {
+    addLabelValue(state, tx(state.locale, "Registros analizados", "Records analyzed"), progress.totalRegistros ?? "-");
+    addLabelValue(state, tx(state.locale, "Período", "Period"), `${formatDate(progress.fechaInicial, state.locale)} - ${formatDate(progress.fechaActual, state.locale)}`);
+    addLabelValue(state, tx(state.locale, "Tendencia principal", "Main trend"), progress.tendenciaPrincipal ?? "-");
+
+    const metrics: Array<[string, unknown, string]> = [
+      [tx(state.locale, "Peso", "Weight"), asRecord(progress.peso)?.diferencia, " kg"],
+      [tx(state.locale, "Cintura", "Waist"), asRecord(progress.cintura)?.diferencia, " cm"],
+      ["IMC", asRecord(progress.imc)?.diferencia, ""],
+      [tx(state.locale, "% grasa", "Fat %"), asRecord(progress.porcentajeGrasa)?.diferencia, "%"],
+      [tx(state.locale, "Masa muscular", "Muscle mass"), asRecord(progress.masaMuscular)?.diferencia, " kg"],
+    ];
+
+    for (const [label, value, suffix] of metrics) {
+      addLabelValue(state, label, formatMetric(value, suffix, state.locale));
+    }
+  }
+
+  const recommendations = Array.isArray(payload.recomendaciones) ? payload.recomendaciones : [];
+  if (recommendations.length) {
+    addWrappedText(state, tx(state.locale, "Recomendaciones", "Recommendations"), {
+      fontStyle: "bold",
+      color: COLORS.navy,
+      gapAfter: 2,
+    });
+    addBulletList(state, recommendations);
+  }
+
+  const alerts = Array.isArray(payload.alertas) ? payload.alertas : [];
+  if (alerts.length) {
+    addWrappedText(state, tx(state.locale, "Alertas y cuidados", "Alerts and precautions"), {
+      fontStyle: "bold",
+      color: COLORS.amber,
+      gapAfter: 2,
+    });
+    addBulletList(state, alerts);
+  }
+
+  const disclaimers = Array.isArray(payload.disclaimers) ? payload.disclaimers : [];
+  if (disclaimers.length) {
+    addWrappedText(state, tx(state.locale, "Disclaimers", "Disclaimers"), {
+      fontStyle: "bold",
+      color: COLORS.violet,
+      gapAfter: 2,
+    });
+    addBulletList(state, disclaimers);
+  }
+}
+
+function addAction(state: PdfState, action: RagCoachChatActionResult, index: number): void {
+  addSectionTitle(
+    state,
+    `${index + 1}. ${actionLabel(action.type, state.locale)} · ${safeText(action.title)}`,
+    action.ok ? COLORS.green : COLORS.amber,
+  );
+  addLabelValue(state, tx(state.locale, "Estado", "Status"), action.ok ? "OK" : tx(state.locale, "Revisar", "Review"));
+  addWrappedText(state, action.message, { gapAfter: 4 });
+
+  if (action.ragSummary) {
+    addLabelValue(state, tx(state.locale, "Resumen RAG", "RAG summary"), action.ragSummary);
+  }
+
+  const payload = asRecord(action.payload);
+  if (payload && action.type === "routine_generated") addRoutinePayload(state, payload);
+  if (payload && action.type === "diet_generated") addDietPayload(state, payload);
+  if (payload && action.type === "evolution_analyzed") addEvolutionPayload(state, payload);
+
+  if (action.qualityAudit) {
+    addWrappedText(
+      state,
+      `${tx(state.locale, "QA de calidad", "Quality QA")}: ${action.qualityAudit.score}% · ${action.qualityAudit.statusLabel}`,
+      { fontStyle: "bold", color: COLORS.green, gapAfter: 1 },
+    );
+    addWrappedText(state, action.qualityAudit.summary, { fontSize: 8.7, gapAfter: 2 });
+    addBulletList(
+      state,
+      action.qualityAudit.checks.map((check) => `${check.status.toUpperCase()} · ${check.label}: ${check.detail}`),
+    );
+  }
+
+  if (action.safetyNotes?.length) {
+    addWrappedText(state, tx(state.locale, "Seguridad aplicada", "Applied safety"), {
+      fontStyle: "bold",
+      color: COLORS.amber,
+      gapAfter: 2,
+    });
+    addBulletList(state, action.safetyNotes);
+  }
+
+  if (action.warnings?.length) {
+    addWrappedText(state, tx(state.locale, "Observaciones", "Notes"), {
+      fontStyle: "bold",
+      color: COLORS.navy,
+      gapAfter: 2,
+    });
+    addBulletList(state, action.warnings);
+  }
+
+  addSources(state, action.sources);
+}
+
+function addFooter(state: PdfState): void {
+  const totalPages = state.doc.getNumberOfPages();
+  for (let page = 1; page <= totalPages; page += 1) {
+    state.doc.setPage(page);
+    state.doc.setDrawColor(...COLORS.border);
+    state.doc.line(PAGE_MARGIN, 282, PAGE_WIDTH - PAGE_MARGIN, 282);
+    state.doc.setFont("helvetica", "normal");
+    state.doc.setFontSize(7.5);
+    state.doc.setTextColor(100, 116, 139);
+    state.doc.text(safeText(state.brandName), PAGE_MARGIN, 288);
+    state.doc.text(
+      `${tx(state.locale, "Página", "Page")} ${page} ${tx(state.locale, "de", "of")} ${totalPages}`,
+      PAGE_WIDTH - PAGE_MARGIN,
+      288,
+      { align: "right" },
+    );
+  }
+}
+
+function addLegalSection(state: PdfState, values: Array<string | null | undefined>): void {
+  const legal = values.map((value) => safeText(value, "")).filter(Boolean);
+  if (!legal.length) return;
+  addSectionTitle(state, tx(state.locale, "Información institucional", "Institutional information"));
+  for (const value of legal) addWrappedText(state, value, { fontSize: 8.3, lineHeight: 4.6 });
+}
+
+export async function descargarRagCoachPdf({
+  message,
+  subject,
+  generatedBy,
+  locale = "es",
+}: DescargarRagCoachPdfParams): Promise<void> {
+  if (typeof window === "undefined") {
+    throw new Error(tx(locale, "La exportación PDF solo está disponible en el navegador.", "PDF export is only available in the browser."));
+  }
+
+  const branding = await getResolvedGimnasioBranding();
+  const logoData = await loadImageAsDataUrl(branding.logoUrl || "/gm_logo.svg", 500, 500);
+  const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4", compress: true });
+  const state: PdfState = {
+    doc,
+    y: 0,
+    locale,
+    brandName: branding.nombre,
+    brandSubtitle: branding.subtitulo,
+    logoData,
+  };
+
+  doc.setProperties({
+    title: tx(locale, "Informe RAG Coach", "RAG Coach report"),
+    subject: safeText(subject.name),
+    author: safeText(branding.nombre),
+    creator: "Gym Master",
+    keywords: "Gym Master, RAG Coach, IA, rutina, dieta, evolución",
+  });
+
+  doc.setFillColor(...COLORS.navy);
+  doc.rect(0, 0, PAGE_WIDTH, 44, "F");
+
+  if (logoData) doc.addImage(logoData, "PNG", PAGE_MARGIN, 7, 25, 25);
+
+  const titleX = logoData ? 44 : PAGE_MARGIN;
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(16.5);
+  doc.setTextColor(255, 255, 255);
+  doc.text(safeText(branding.nombre), titleX, 14);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(8.5);
+  doc.text(doc.splitTextToSize(safeText(branding.subtitulo), 145), titleX, 21);
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10.5);
+  doc.text(tx(locale, "Informe del RAG Coach", "RAG Coach report"), titleX, 35);
+
+  state.y = 53;
+  addLabelValue(state, tx(locale, "Socio", "Member"), subject.name);
+  if (subject.dni) addLabelValue(state, tx(locale, "DNI", "ID"), subject.dni);
+  if (subject.email) addLabelValue(state, tx(locale, "Email", "Email"), subject.email);
+  addLabelValue(state, tx(locale, "Fecha de emisión", "Issue date"), formatDateTime(message.createdAt, locale));
+  if (generatedBy) addLabelValue(state, tx(locale, "Emitido por", "Issued by"), generatedBy);
+  addLabelValue(state, tx(locale, "Intención", "Intent"), intentLabel(message.intent, locale));
+  addLabelValue(state, tx(locale, "Confianza contextual", "Context confidence"), confidenceLabel(message.contextConfidence, locale));
+
+  if (message.requestMessage) {
+    addSectionTitle(state, tx(locale, "Consulta", "Request"));
+    addWrappedText(state, message.requestMessage, { fontStyle: "italic", color: COLORS.navy, gapAfter: 4 });
+  }
+
+  addSectionTitle(state, tx(locale, "Respuesta del Coach IA", "AI Coach response"), COLORS.cyan);
+  addWrappedText(state, message.content, { color: COLORS.navy, fontSize: 9.8, lineHeight: 5.5, gapAfter: 4 });
+
+  if (message.contextSummary) {
+    addSectionTitle(state, tx(locale, "Contexto aplicado", "Applied context"), COLORS.green);
+    addWrappedText(state, message.contextSummary);
+  }
+
+  if (message.contextSnapshot) addContextSnapshot(state, message.contextSnapshot);
+
+  if (message.actions?.length) {
+    addSectionTitle(state, tx(locale, "Resultados y acciones", "Results and actions"), COLORS.green);
+    message.actions.forEach((action, index) => addAction(state, action, index));
+  }
+
+  if (message.safetySummary) {
+    addSectionTitle(state, tx(locale, "Resumen de seguridad", "Safety summary"), COLORS.amber);
+    addWrappedText(state, message.safetySummary);
+  }
+
+  if (message.qaSummary) {
+    addSectionTitle(state, tx(locale, "QA IA / RAG", "AI / RAG QA"), COLORS.green);
+    addWrappedText(state, message.qaSummary);
+  }
+
+  if (message.coachNotes?.length) {
+    addSectionTitle(state, tx(locale, "Notas del Coach", "Coach notes"));
+    addBulletList(state, message.coachNotes);
+  }
+
+  if (message.contextHints?.length) {
+    addSectionTitle(state, tx(locale, "Pistas del contexto", "Context hints"));
+    addBulletList(state, message.contextHints);
+  }
+
+  if (message.memoryHighlights?.length) {
+    addSectionTitle(state, tx(locale, "Memoria recordada", "Remembered context"), COLORS.violet);
+    addBulletList(state, message.memoryHighlights);
+  }
+
+  if (message.memoryTrace?.length) {
+    addSectionTitle(state, tx(locale, "Trazabilidad contextual", "Context trace"), COLORS.violet);
+    addBulletList(state, message.memoryTrace);
+  }
+
+  if (message.missingParams?.length) {
+    addSectionTitle(state, tx(locale, "Datos pendientes", "Missing data"), COLORS.amber);
+    addBulletList(state, message.missingParams);
+  }
+
+  if (message.nextBestStep) {
+    addSectionTitle(state, tx(locale, "Próximo paso", "Next step"), COLORS.violet);
+    addWrappedText(state, message.nextBestStep, { fontStyle: "bold", color: COLORS.navy });
+  }
+
+  if (message.suggestedReplies?.length) {
+    addSectionTitle(state, tx(locale, "Sugerencias para continuar", "Suggestions to continue"));
+    addBulletList(state, message.suggestedReplies);
+  }
+
+  addSectionTitle(state, tx(locale, "Aviso responsable", "Responsible notice"), COLORS.amber);
+  addWrappedText(
+    state,
+    tx(
+      locale,
+      "Este informe organiza contenido generado por el RAG Coach de Gym Master. No reemplaza evaluación médica, nutricional ni profesional. Ante lesiones, síntomas, condiciones clínicas o dudas relevantes, consultá al profesional responsable.",
+      "This report organizes content generated by the Gym Master RAG Coach. It does not replace medical, nutritional, or professional evaluation. For injuries, symptoms, clinical conditions, or relevant concerns, consult the responsible professional.",
+    ),
+    { fontSize: 8.5, lineHeight: 4.7 },
+  );
+
+  addLegalSection(state, [branding.textoLegalReportes, branding.piePagina]);
+  addFooter(state);
+
+  const subjectFileName = safeText(subject.name, tx(locale, "socio", "member"));
+  doc.save(buildTimestampedDownloadFileName(`${tx(locale, "informe-rag-coach", "rag-coach-report")}-${subjectFileName}`, "pdf"));
+}


### PR DESCRIPTION
# feat: add professional PDF output to RAG Coach

## Resumen

Esta Pull Request incorpora exportación profesional a PDF para las respuestas útiles generadas por el RAG Coach unificado de Gym Master en la rama `feature/rag-coach-pdf-output-v1`.

Cada respuesta exitosa del Coach puede descargarse como un informe A4 independiente del dashboard. El documento reúne branding del gimnasio, datos del socio, consulta original, respuesta generada, contexto, acciones, fuentes RAG, QA, seguridad, memoria conversacional, próximos pasos y disclaimer responsable.

La implementación conserva el idioma activo ES/EN, mantiene un snapshot inmutable del socio utilizado al generar cada respuesta y no agrega endpoints públicos ni cambios de base de datos.

## Motivación

Gym Master ya disponía de exportaciones separadas para rutinas, dietas y evolución física, pero el Coach IA unificado no permitía conservar o compartir una respuesta completa como documento formal.

El objetivo de esta feature es convertir cada interacción útil en un entregable profesional que pueda:

- archivarse;
- imprimirse;
- compartirse con el socio;
- utilizarse como respaldo del seguimiento;
- mantener la trazabilidad del contexto usado por el RAG Coach;
- respetar la identidad visual y el idioma operativo del gimnasio.

## Alcance consolidado

- **5 archivos** modificados o agregados.
- **1102 inserciones** y **0 eliminaciones**.
- Generación PDF completamente en el navegador.
- Botón de descarga en respuestas exitosas del asistente.
- Branding configurable del gimnasio con logo y fallback.
- Snapshot del socio asociado a cada respuesta.
- Contenido ES/EN según el locale activo.
- Rutinas, dietas y evolución física interpretadas desde los payloads del Coach.
- Fuentes RAG, similitud, QA, seguridad y memoria contextual.
- Paginación automática y pie `Página X de Y` / `Page X of Y`.
- Nuevo gate `npm run test:rag-coach-pdf`.
- Sin cambios de API, base de datos, migraciones, RLS o RPC.

## Cambios principales

### 1. Descarga desde cada respuesta útil

`src/app/dashboard/coach/page.tsx` incorpora la acción:

```text
Descargar informe PDF / Download PDF report
```

El botón aparece exclusivamente cuando:

- el mensaje pertenece al asistente;
- existe una consulta original asociada;
- la respuesta fue generada correctamente.

No aparece en:

- saludo inicial;
- mensajes del usuario;
- respuestas de error;
- generaciones fallidas.

Durante la exportación, el botón muestra estado de carga y evita descargas simultáneas.

### 2. Snapshot inmutable del socio y de la consulta

Cada respuesta generada almacena:

```text
createdAt
requestMessage
socioSnapshot.name
socioSnapshot.dni
socioSnapshot.email
```

Este snapshot se crea en el momento de enviar la consulta. Si un administrador cambia posteriormente el selector de socio, el PDF anterior conserva el destinatario original.

La medida evita mezclar:

- respuesta de un socio;
- datos visibles de otro socio seleccionado después;
- contexto actual de sesión con contexto histórico del mensaje.

### 3. Utilidad central `ragCoachPdf.ts`

Se agrega `src/utils/ragCoachPdf.ts`, basada en `jsPDF`, con generación A4 vertical y diseño independiente del DOM.

La utilidad:

- resuelve branding mediante `getResolvedGimnasioBranding`;
- obtiene logo configurado o fallback `/gm_logo.svg`;
- normaliza imágenes externas mediante el proxy interno;
- configura propiedades del documento;
- genera encabezado institucional;
- administra márgenes, saltos y continuidad entre páginas;
- crea nombre de archivo seguro y fechado;
- guarda el PDF directamente en el navegador.

No se utiliza `doc.html()` ni captura del dashboard. El modo oscuro, sidebar y componentes visuales de la pantalla no forman parte del documento.

### 4. Contenido del informe

El PDF incluye, cuando está disponible:

- nombre, DNI y correo del socio;
- fecha de emisión y usuario emisor;
- intención detectada;
- confianza contextual;
- consulta original;
- respuesta del Coach IA;
- contexto aplicado;
- objetivo, nivel y snapshot operativo del socio;
- acciones y resultados generados;
- rutina por días y ejercicios;
- series, repeticiones, descanso y grupo muscular;
- dieta, vigencia, bloques de comidas y recomendaciones;
- evolución física, métricas, alertas y recomendaciones;
- fuentes RAG y porcentaje de similitud;
- resumen de seguridad;
- QA IA/RAG;
- notas del Coach;
- pistas contextuales;
- memoria recordada y trazabilidad;
- datos pendientes;
- próximo paso;
- sugerencias para continuar;
- aviso responsable;
- textos legales y pie institucional.

### 5. Gobernanza ES/EN

El documento utiliza el locale activo del dashboard:

- `es`: títulos, etiquetas, fechas, días, comidas, objetivos, niveles y disclaimer en español;
- `en`: equivalentes del sistema en inglés.

Se reutilizan traductores de datos propios del sistema:

```text
translateCoreDayLabel
translateCoreFoodItem
translateCoreMealTitle
translateCoreLevel
translateCoreObjective
translateCoreMuscleGroup
```

Los datos cargados por el gimnasio o el socio no se traducen automáticamente. La exportación respeta la gobernanza existente: se traducen etiquetas y valores propios del sistema, no el contenido comercial o clínico introducido por el cliente.

### 6. Paginación y layout

La utilidad define:

```text
A4 vertical
margen: 14 mm
límite de contenido: 278 mm
pie: 282-288 mm
```

Los textos largos se procesan mediante `splitTextToSize`. Antes de insertar una sección se verifica espacio disponible; cuando no alcanza, se crea una nueva página con encabezado de continuación.

El pie se agrega al finalizar sobre todas las páginas:

```text
Nombre del gimnasio                         Página X de Y
```

### 7. Branding e imágenes

El encabezado utiliza:

- nombre del gimnasio;
- subtítulo institucional;
- logo configurado;
- fallback `/gm_logo.svg`.

Cuando el logo es externo, la URL se normaliza y se procesa mediante `/api/image-proxy`. Si no puede cargarse, el informe continúa sin interrumpir la exportación.

### 8. Seguridad y privacidad

- La acción vive dentro de `/dashboard/coach`, que requiere sesión autenticada.
- No se agrega un endpoint público de exportación.
- No se envían datos a un servicio PDF externo.
- El documento se genera localmente en el navegador.
- No se incluyen tokens, permisos, IDs internos ni trazas de autenticación.
- No se vuelca JSON técnico crudo.
- No se captura el DOM del dashboard.
- El socio utilizado queda fijado por snapshot en cada mensaje.

### 9. Manejo de errores

La descarga:

- utiliza un estado `exportingPdfMessageId`;
- bloquea acciones paralelas;
- muestra toast de éxito;
- muestra un error genérico cuando la generación falla;
- libera el estado en `finally`.

## Archivos del cambio

```text
docs/rag/rag-coach-pdf-output-v1.md
package.json
scripts/verify-rag-coach-pdf-output.mjs
src/app/dashboard/coach/page.tsx
src/utils/ragCoachPdf.ts
```

## Validación automática

Se agrega:

```bash
npm run test:rag-coach-pdf
```

El gate verifica:

- existencia del script en `package.json`;
- integración del botón en el Coach;
- snapshot de consulta y socio;
- generación browser-side con `jsPDF`;
- branding y nombre de archivo;
- rutinas, dietas y evolución;
- fuentes, QA, seguridad y pie paginado;
- gobernanza ES/EN;
- wrapping y saltos de página;
- ausencia de captura DOM y JSON crudo;
- ausencia de cambios requeridos en API, DB, migraciones, RLS y RPC.

Gate acumulativo ejecutado:

```bash
rm -rf .next

npm run build &&
npm run test:pwa-cache &&
npm run test:pwa-install-update &&
npm run test:auth-rbac &&
npm run test:http-runtime-security &&
npm run test:rag-coach-pdf &&
npm run test:business-backup-export &&
npm run test:repo-security
```

## QA manual aprobada

Se validó correctamente:

- respuesta general;
- rutina completa;
- dieta;
- análisis de evolución física;
- exportación en español;
- exportación en inglés;
- ingreso como administrador;
- ingreso como socio;
- cambio del selector después de generar una respuesta;
- conservación del socio original en el PDF;
- textos extensos y varias páginas;
- márgenes y saltos;
- pie `Página X de Y`;
- logo configurado y fallback;
- ausencia del botón en saludo, usuario y errores.

## Base de datos y contratos

Esta Pull Request **no modifica**:

- `src/app/api/rag/coach/chat/route.ts`;
- `src/services/server/ragCoachUnifiedChatService.ts`;
- contratos de la API del Coach;
- tablas;
- migraciones;
- políticas RLS;
- funciones RPC;
- persistencia del historial conversacional;
- datos existentes.

## Riesgos residuales

| Riesgo | Mitigación / seguimiento |
|---|---|
| PDF generado en cliente | Mantener el bundle y la utilidad bajo gate; evaluar generación server-side solo si se requieren firmas o archivado central. |
| Respuestas extremadamente extensas | El paginado está cubierto; puede definirse un máximo editorial si el uso real produce documentos excesivos. |
| Limitaciones tipográficas de jsPDF | Se normalizan caracteres y emojis; incorporar fuentes embebidas solo si se requiere una cobertura Unicode mayor. |
| Payloads futuros del Coach | El exportador usa lectura defensiva; actualizar el gate si se agregan nuevos tipos de acciones. |
| Logo externo no disponible | La exportación continúa sin logo o utiliza fallback local. |
| Datos generados por IA | Se incluye disclaimer y debe mantenerse la revisión profesional para decisiones médicas o nutricionales. |

## Rollback

No existen cambios persistentes. El rollback consiste en revertir el commit o merge de esta PR.

Para rollback parcial deben retirarse conjuntamente:

- integración de `page.tsx`;
- `src/utils/ragCoachPdf.ts`;
- script `test:rag-coach-pdf`;
- documentación de la feature.

## Checklist

- [x] Botón disponible solo en respuestas útiles.
- [x] Generación A4 profesional desde el navegador.
- [x] Branding y logo del gimnasio.
- [x] Snapshot del socio y consulta original.
- [x] Rutinas, dietas y evolución interpretadas.
- [x] Fuentes RAG, QA y seguridad incluidas.
- [x] Memoria, próximos pasos y sugerencias incluidas.
- [x] Gobernanza ES/EN.
- [x] Paginación `Página X de Y`.
- [x] Sin captura del DOM ni JSON crudo.
- [x] Sin endpoint público de exportación.
- [x] Sin cambios de API, DB, migraciones, RLS o RPC.
- [x] Build y gates acumulativos aprobados.
- [x] QA manual como administrador y socio aprobada.
